### PR TITLE
[] Deploys all apps on merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "build-apps": "lerna run build --concurrency=1 --stream --since main",
     "test-apps": "lerna run test --concurrency=1 --stream --since main",
     "install-apps": "lerna run install-ci --concurrency=1 --stream --since main",
-    "deploy:staging": "lerna run deploy:staging --concurrency=3 --since main",
-    "deploy": "lerna run deploy --concurrency=3 --since main",
+    "deploy:staging": "lerna run deploy:staging --concurrency=3",
+    "deploy": "lerna run deploy --concurrency=3",
     "prepare": "husky install"
   },
   "lint-staged": {


### PR DESCRIPTION
## Purpose
Reverting the --since option for the deploy commands because deploying to staging and prod can't find a diff on master branch since once the PR is merged, the --since option can't find any diffs during the deploy stage

## Testing steps
Check deploy and staging step in CircleCI
