### PR TITLE
[] Update root package to just build all apps on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "scripts": {
     "test-apps": "lerna run test --concurrency=1 --stream --since main",
     "build-apps": "lerna run build --concurrency=1 --stream --since main",
-    "build-apps:deploy": "lerna run build --concurrency=1 --stream --since $(git merge-base origin/main HEAD^1)",
+    "build-apps:deploy": "lerna run build --concurrency=1 --stream",
     "install-apps": "lerna run install-ci --concurrency=1 --stream --since main",
-    "install-apps:deploy": "lerna run install-ci --concurrency=1 --stream --since $(git merge-base origin/main HEAD^1)",
-    "deploy:staging": "lerna run deploy:staging --concurrency=3 --since $(git merge-base origin/main HEAD^1)",
-    "deploy:production": "lerna run deploy --concurrency=3  --since $(git merge-base origin/main HEAD^1)",
+    "install-apps:deploy": "lerna run install-ci --concurrency=1 --stream",
+    "deploy:staging": "lerna run deploy:staging --concurrency=3",
+    "deploy:production": "lerna run deploy --concurrency=3",
     "prepare": "husky install"
   },
   "lint-staged": {


### PR DESCRIPTION
## Purpose
Avoids future bugs and will help testing in all deployed apps so far (Cloudinary, Bynder, along with Shopify)

## Approach
Build should only impact Shopify but deploys affect all apps