### PR TITLE
chore: [INTEG-812] Add dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 15
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@contentful/app-sdk'


### PR DESCRIPTION
## Purpose

Adds a dependabot.yml file that mirrors the configuration we had in the apps repo.

## Approach

I kept the following configurations options under `ignore`: 
- Ignoring major semver updates
- Ignoring `@contentful/app-sdk` updates. It is configured this way in the apps repo, but I am open to changing it if we want.
