### PR TITLE
feat(cloudinary2): save backend parameters

### DIFF
--- a/apps/cloudinary2/.env.example
+++ b/apps/cloudinary2/.env.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_BASE_URL=https://cloudinary-backend-dev.ngrok.io/dev/api

--- a/apps/cloudinary2/.gitignore
+++ b/apps/cloudinary2/.gitignore
@@ -1,3 +1,6 @@
+!.env*
+*.local
+
 # dependencies
 /node_modules
 

--- a/apps/cloudinary2/src/components/FieldWrapper.tsx
+++ b/apps/cloudinary2/src/components/FieldWrapper.tsx
@@ -1,0 +1,22 @@
+import { Flex, FormControl } from '@contentful/f36-components';
+import { PropsWithChildren, ReactNode, useId } from 'react';
+
+interface Props {
+  name: string;
+  description: ReactNode;
+  counter?: boolean;
+}
+
+export function FieldWrapper({ name, description, counter = false, children }: PropsWithChildren<Props>) {
+  return (
+    <FormControl id={useId()}>
+      <FormControl.Label>{name}</FormControl.Label>
+      {children}
+
+      <Flex justifyContent="space-between">
+        <FormControl.HelpText>{description}</FormControl.HelpText>
+        {counter && <FormControl.Counter />}
+      </Flex>
+    </FormControl>
+  );
+}

--- a/apps/cloudinary2/src/components/SelectField.tsx
+++ b/apps/cloudinary2/src/components/SelectField.tsx
@@ -1,0 +1,29 @@
+import { Option, Select } from '@contentful/f36-components';
+import { ReactNode, useId } from 'react';
+import { FieldWrapper } from './FieldWrapper';
+
+interface Props {
+  name: string;
+  description: ReactNode;
+
+  value: string;
+  onChange: (value: string) => void;
+
+  isRequired: boolean;
+  options: string[];
+  testId: string;
+}
+
+export function SelectField({ name, description, value, onChange, isRequired, options, testId }: Props) {
+  return (
+    <FieldWrapper name={name} description={description}>
+      <Select name={useId()} isRequired={isRequired} onChange={(e) => onChange(e.target.value)} value={value} testId={testId}>
+        {options.map((currValue: string) => (
+          <Option value={currValue} key={currValue}>
+            {currValue}
+          </Option>
+        ))}
+      </Select>
+    </FieldWrapper>
+  );
+}

--- a/apps/cloudinary2/src/components/TextField.tsx
+++ b/apps/cloudinary2/src/components/TextField.tsx
@@ -1,0 +1,35 @@
+import { TextInput, TextInputProps } from '@contentful/f36-components';
+import { ReactNode, useId } from 'react';
+import { FieldWrapper } from './FieldWrapper';
+
+interface Props {
+  name: string;
+  description: ReactNode;
+
+  value: string;
+  onChange: (value: string) => void;
+
+  isRequired?: boolean;
+  type: 'text' | 'number';
+
+  inputProps?: Pick<TextInputProps, 'max' | 'min'>;
+  testId: string;
+}
+
+export function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId }: Props) {
+  return (
+    <FieldWrapper name={name} description={description} counter>
+      <TextInput
+        name={useId()}
+        width={type === 'text' ? 'large' : 'medium'}
+        type={type}
+        maxLength={255}
+        isRequired={isRequired}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        testId={testId}
+        {...inputProps}
+      />
+    </FieldWrapper>
+  );
+}

--- a/apps/cloudinary2/src/constants.ts
+++ b/apps/cloudinary2/src/constants.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from './types';
+import { AppInstallationParameters, BackendParameters } from './types';
 
 export const DEFAULT_APP_INSTALLATION_PARAMETERS: AppInstallationParameters = {
   cloudName: '',
@@ -8,4 +8,8 @@ export const DEFAULT_APP_INSTALLATION_PARAMETERS: AppInstallationParameters = {
   quality: 'auto',
   format: 'auto',
 };
+export const DEFAULT_BACKEND_PARAMETERS: BackendParameters = {
+  apiSecret: '',
+};
 export const VALID_IMAGE_FORMATS = ['svg', 'jpg', 'png', 'gif', 'jpeg', 'tiff', 'ico', 'webp', 'pdf', 'bmp', 'psd', 'eps', 'jxr', 'wdp'];
+export const BACKEND_BASE_URL = import.meta.env.VITE_BACKEND_BASE_URL;

--- a/apps/cloudinary2/src/locations/ConfigScreen/BackendConfiguration.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/BackendConfiguration.tsx
@@ -1,0 +1,36 @@
+import { Form } from '@contentful/f36-components';
+import { useCallback } from 'react';
+import { TextField } from '../../components/TextField';
+import { BackendParameters } from '../../types';
+
+interface Props {
+  parameters: BackendParameters;
+  onParametersChange: (parameters: BackendParameters) => void;
+}
+
+export function BackendConfiguration({ parameters, onParametersChange }: Props) {
+  const onParameterChange = useCallback(
+    <Key extends keyof BackendParameters>(key: Key, value: BackendParameters[Key]) => {
+      const newParameters = {
+        ...parameters,
+        [key]: value,
+      };
+      onParametersChange(newParameters);
+    },
+    [parameters, onParametersChange],
+  );
+
+  return (
+    <Form>
+      <TextField
+        testId="config-apiSecret"
+        name="API secret (write-only)"
+        description=""
+        value={parameters.apiSecret}
+        onChange={(value) => onParameterChange('apiSecret', value)}
+        isRequired
+        type="text"
+      />
+    </Form>
+  );
+}

--- a/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.spec.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { noop } from 'lodash';
 import { describe, expect, it, vi } from 'vitest';
-import { Configuration } from './Configuration';
+import { InstallParamsConfiguration } from './InstallParamsConfiguration';
 import { AppInstallationParameters } from '../../types';
 import userEvent from '@testing-library/user-event';
 
@@ -16,7 +16,7 @@ const installationParameters: AppInstallationParameters = {
 
 describe('Configuration', () => {
   it('renders fields correctly', () => {
-    const { getByTestId } = render(<Configuration parameters={installationParameters} onParametersChange={noop} />);
+    const { getByTestId } = render(<InstallParamsConfiguration parameters={installationParameters} onParametersChange={noop} />);
 
     expect((getByTestId('config-cloudName') as HTMLInputElement).value).toBe('cloud');
     expect((getByTestId('config-apiKey') as HTMLInputElement).value).toBe('key');
@@ -28,7 +28,7 @@ describe('Configuration', () => {
 
   it('max files number is parsed correctly', async () => {
     const onParametersChange = vi.fn();
-    const { getByTestId } = render(<Configuration parameters={installationParameters} onParametersChange={onParametersChange} />);
+    const { getByTestId } = render(<InstallParamsConfiguration parameters={installationParameters} onParametersChange={onParametersChange} />);
 
     const input = getByTestId('config-maxFiles') as HTMLInputElement;
     await userEvent.type(input, '5'); // appending a 5
@@ -41,7 +41,7 @@ describe('Configuration', () => {
 
   it('max files default to 10', async () => {
     const onParametersChange = vi.fn();
-    const { getByTestId } = render(<Configuration parameters={installationParameters} onParametersChange={onParametersChange} />);
+    const { getByTestId } = render(<InstallParamsConfiguration parameters={installationParameters} onParametersChange={onParametersChange} />);
 
     const input = getByTestId('config-maxFiles') as HTMLInputElement;
     await userEvent.clear(input);
@@ -54,7 +54,7 @@ describe('Configuration', () => {
 
   it('cloud name can be changed', async () => {
     const onParametersChange = vi.fn();
-    const { getByTestId } = render(<Configuration parameters={installationParameters} onParametersChange={onParametersChange} />);
+    const { getByTestId } = render(<InstallParamsConfiguration parameters={installationParameters} onParametersChange={onParametersChange} />);
 
     const input = getByTestId('config-cloudName') as HTMLInputElement;
     await userEvent.type(input, 'y');
@@ -67,7 +67,7 @@ describe('Configuration', () => {
 
   it('quality can be changed', async () => {
     const onParametersChange = vi.fn();
-    const { getByTestId } = render(<Configuration parameters={installationParameters} onParametersChange={onParametersChange} />);
+    const { getByTestId } = render(<InstallParamsConfiguration parameters={installationParameters} onParametersChange={onParametersChange} />);
 
     const input = getByTestId('config-quality') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'auto:eco' } });

--- a/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
@@ -1,7 +1,9 @@
-import { Form, FormControl, Select, Option, TextLink, Flex, TextInput, TextInputProps } from '@contentful/f36-components';
-import { PropsWithChildren, ReactNode, useCallback, useId } from 'react';
-import { AppInstallationParameters } from '../../types';
+import { Form, TextLink } from '@contentful/f36-components';
+import { useCallback } from 'react';
+import { SelectField } from '../../components/SelectField';
+import { TextField } from '../../components/TextField';
 import { DEFAULT_APP_INSTALLATION_PARAMETERS } from '../../constants';
+import { AppInstallationParameters } from '../../types';
 
 const MAX_FILES_UPPER_LIMIT = 1000;
 
@@ -10,7 +12,7 @@ interface Props {
   onParametersChange: (parameters: AppInstallationParameters) => void;
 }
 
-export function Configuration({ parameters, onParametersChange }: Props) {
+export function InstallParamsConfiguration({ parameters, onParametersChange }: Props) {
   const onParameterChange = useCallback(
     <Key extends keyof AppInstallationParameters>(key: Key, value: AppInstallationParameters[Key]) => {
       const newParameters = {
@@ -118,83 +120,5 @@ export function Configuration({ parameters, onParametersChange }: Props) {
         onChange={(value) => onParameterChange('format', value)}
       />
     </Form>
-  );
-}
-
-interface TextFieldProps {
-  name: string;
-  description: ReactNode;
-
-  value: string;
-  onChange: (value: string) => void;
-
-  isRequired?: boolean;
-  type: 'text' | 'number';
-
-  inputProps?: Pick<TextInputProps, 'max' | 'min'>;
-  testId: string;
-}
-
-function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId }: TextFieldProps) {
-  return (
-    <FieldWrapper name={name} description={description} counter>
-      <TextInput
-        name={useId()}
-        width={type === 'text' ? 'large' : 'medium'}
-        type={type}
-        maxLength={255}
-        isRequired={isRequired}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        testId={testId}
-        {...inputProps}
-      />
-    </FieldWrapper>
-  );
-}
-
-interface SelectFieldProps {
-  name: string;
-  description: ReactNode;
-
-  value: string;
-  onChange: (value: string) => void;
-
-  isRequired: boolean;
-  options: string[];
-  testId: string;
-}
-
-function SelectField({ name, description, value, onChange, isRequired, options, testId }: SelectFieldProps) {
-  return (
-    <FieldWrapper name={name} description={description}>
-      <Select name={useId()} isRequired={isRequired} onChange={(e) => onChange(e.target.value)} value={value} testId={testId}>
-        {options.map((currValue: string) => (
-          <Option value={currValue} key={currValue}>
-            {currValue}
-          </Option>
-        ))}
-      </Select>
-    </FieldWrapper>
-  );
-}
-
-interface FieldWrapperProps {
-  name: string;
-  description: ReactNode;
-  counter?: boolean;
-}
-
-function FieldWrapper({ name, description, counter = false, children }: PropsWithChildren<FieldWrapperProps>) {
-  return (
-    <FormControl id={useId()}>
-      <FormControl.Label>{name}</FormControl.Label>
-      {children}
-
-      <Flex justifyContent="space-between">
-        <FormControl.HelpText>{description}</FormControl.HelpText>
-        {counter && <FormControl.Counter />}
-      </Flex>
-    </FormControl>
   );
 }

--- a/apps/cloudinary2/src/locations/ConfigScreen/helpers.ts
+++ b/apps/cloudinary2/src/locations/ConfigScreen/helpers.ts
@@ -1,0 +1,35 @@
+import { KnownAppSDK } from '@contentful/app-sdk';
+import { BACKEND_BASE_URL } from '../../constants';
+import { BackendParameters } from '../../types';
+
+export async function updateBackendParameters(parameters: BackendParameters, sdk: KnownAppSDK): Promise<void> {
+  const request = {
+    method: 'PUT' as const,
+    url: new URL(`${BACKEND_BASE_URL}/parameters`),
+    body: JSON.stringify(parameters),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const { additionalHeaders: signedHeaders } = await sdk.cma.appSignedRequest.create(
+    { appDefinitionId: sdk.ids.app! },
+    {
+      method: request.method,
+      path: request.url.pathname,
+      body: request.body,
+      headers: request.headers,
+    },
+  );
+
+  const response = await fetch(request.url, {
+    method: request.method,
+    body: request.body,
+    headers: {
+      ...request.headers,
+      ...signedHeaders,
+    },
+  });
+
+  await response.json();
+}

--- a/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
@@ -73,7 +73,9 @@ const ConfigScreen = () => {
 
   useEffect(() => {
     return sdk.app.onConfigurationCompleted(() => {
-      updateBackendParameters(backendParameters, sdk);
+      if (backendParameters.apiSecret.length > 0) {
+        updateBackendParameters(backendParameters, sdk);
+      }
     });
   }, [backendParameters, sdk]);
 

--- a/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
@@ -2,16 +2,16 @@ import { ConfigAppSDK } from '@contentful/app-sdk';
 import { GlobalStyles, Heading, Paragraph } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { ContentTypeProps, CreateAppSignedRequestProps } from 'contentful-management';
+import { ContentTypeProps } from 'contentful-management';
 import { css } from 'emotion';
 import { useCallback, useEffect, useState } from 'react';
 import logo from '../../assets/logo.svg';
-import { BACKEND_BASE_URL, DEFAULT_APP_INSTALLATION_PARAMETERS, DEFAULT_BACKEND_PARAMETERS } from '../../constants';
+import { DEFAULT_APP_INSTALLATION_PARAMETERS, DEFAULT_BACKEND_PARAMETERS } from '../../constants';
 import { AppInstallationParameters, BackendParameters } from '../../types';
-import { FieldSelector } from './FieldSelector';
-import { SelectedFields, editorInterfacesToSelectedFields, selectedFieldsToTargetState } from './fields';
-import { InstallParamsConfiguration } from './InstallParamsConfiguration';
 import { BackendConfiguration } from './BackendConfiguration';
+import { FieldSelector } from './FieldSelector';
+import { InstallParamsConfiguration } from './InstallParamsConfiguration';
+import { SelectedFields, editorInterfacesToSelectedFields, selectedFieldsToTargetState } from './fields';
 import { updateBackendParameters } from './helpers';
 
 const styles = {

--- a/apps/cloudinary2/src/types.ts
+++ b/apps/cloudinary2/src/types.ts
@@ -7,6 +7,10 @@ export interface AppInstallationParameters {
   format: string;
 }
 
+export interface BackendParameters {
+  apiSecret: string;
+}
+
 /**
  * Auto-generated, might not be accurate
  */

--- a/apps/cloudinary2/src/vite-env.d.ts
+++ b/apps/cloudinary2/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Changes

* Adds a new field "API Secret"
* Sends a request including the secret after save
* Components were extracted to the `components` folder

Notes

* Backend parameters are write-only, so the field is always empty after loading the config screen
* Explanations about what this does will be added in the future
* Backend will be created separately

Screenshot
![image](https://github.com/contentful/marketplace-partner-apps/assets/4947671/f2bce39d-65a8-484d-815e-65952e7937d5)
