### PR TITLE
[INTEG-1152] Fix: Bynder horizontal scroll

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -82,7 +82,7 @@ function makeThumbnail(resource) {
 function prepareBynderHTML() {
   return `
     <div class="dialog-container">
-      <div id="bynder-compactview" />
+      <div id="bynder-compactview" style="overflow-x:auto;" />
     </div>      
   `;
 }


### PR DESCRIPTION
## Purpose

When there are a lot of filters in the filter bar for the Bynder UCV, the whole dialog was scrolling horizontally and you couldn't see all of the features in the search bar above the filters. 

## Approach

Added `overflow-x:auto` to the container div.

Before:
![Screenshot 2023-09-01 at 1 00 28 PM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/b431ef54-3531-46e6-8824-6313d1f13e56)

After:
![Screenshot 2023-09-01 at 1 00 17 PM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/594e0e47-c54a-4e2b-bcc0-15e2e84f5a2e)

## Testing steps

Note that I could not add additional filters via our Bynder testing environment, so I added additional filters by creating new button elements in Dev Tools in order to replicate the issue. I also tested that adding the CSS property did not impact the Bynder UCV when there aren't too many filters in the top bar.
