### PR TITLE
fix(Cloudinary): store API Secret after installation

### DIFF
--- a/apps/cloudinary2/.env.example
+++ b/apps/cloudinary2/.env.example
@@ -1,1 +1,1 @@
-VITE_BACKEND_BASE_URL=https://cloudinary-backend-dev.ngrok.io/dev/api
+VITE_CLOUDINARY_BACKEND_BASE_URL=https://cloudinary-backend-dev.ngrok.io/dev/api

--- a/apps/cloudinary2/src/constants.ts
+++ b/apps/cloudinary2/src/constants.ts
@@ -13,4 +13,4 @@ export const DEFAULT_BACKEND_PARAMETERS: BackendParameters = {
   apiSecret: '',
 };
 export const VALID_IMAGE_FORMATS = ['svg', 'jpg', 'png', 'gif', 'jpeg', 'tiff', 'ico', 'webp', 'pdf', 'bmp', 'psd', 'eps', 'jxr', 'wdp'];
-export const BACKEND_BASE_URL = import.meta.env.VITE_BACKEND_BASE_URL;
+export const BACKEND_BASE_URL = import.meta.env.VITE_CLOUDINARY_BACKEND_BASE_URL;

--- a/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/index.tsx
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useState } from 'react';
 import logo from '../../assets/logo.svg';
 import { DEFAULT_APP_INSTALLATION_PARAMETERS, DEFAULT_BACKEND_PARAMETERS } from '../../constants';
 import { AppInstallationParameters, BackendParameters } from '../../types';
-import { BackendConfiguration } from './BackendConfiguration';
 import { FieldSelector } from './FieldSelector';
 import { InstallParamsConfiguration } from './InstallParamsConfiguration';
 import { SelectedFields, editorInterfacesToSelectedFields, selectedFieldsToTargetState } from './fields';
@@ -64,25 +63,43 @@ const ConfigScreen = () => {
   const [contentTypes, setContentTypes] = useState<ContentTypeProps[]>([]);
   const [selectedFields, setSelectedFields] = useState<SelectedFields>({});
 
-  const onConfigure = useCallback(async () => {
-    let installationUuid = parameters.installationUuid;
-    if (backendParameters.apiSecret.length > 0) {
-      installationUuid = window.crypto.randomUUID();
-      await updateBackendParameters(installationUuid, backendParameters, sdk);
-      setBackendParameters({ apiSecret: '' });
-    }
+  const onConfigure = useCallback(() => ({
+    parameters: {
+      ...parameters,
+      installationUuid: parameters.installationUuid || window.crypto.randomUUID(),
+    },
+    targetState: selectedFieldsToTargetState(contentTypes, selectedFields),
+  }), [backendParameters, parameters, contentTypes, selectedFields, sdk]);
 
-    return {
-      parameters: {
-        ...parameters,
-        installationUuid,
-      },
-      targetState: selectedFieldsToTargetState(contentTypes, selectedFields),
-    };
-  }, [backendParameters, parameters, contentTypes, selectedFields, sdk]);
+  const onConfigurationCompleted = useCallback(
+    async (error: any) => {
+      const genericErrorMessage =
+        'Unable to store configuration. Please try again.';
+
+      if (error) {
+        sdk.notifier.error(genericErrorMessage);
+        return;
+      }
+
+      const parameters = await sdk.app.getParameters<AppInstallationParameters>();
+      const installationUuid = parameters?.installationUuid;
+
+      try {
+        if (backendParameters.apiSecret.length > 0 && installationUuid) {
+          await updateBackendParameters(installationUuid, backendParameters, sdk);
+          setBackendParameters({ apiSecret: '' });
+        }
+      } catch (e) {
+        console.error(e);
+        sdk.notifier.error(genericErrorMessage);
+      }
+    },
+    [setBackendParameters, sdk.app.getParameters, backendParameters]
+  );
 
   useEffect(() => {
-    return sdk.app.onConfigure(() => onConfigure());
+    sdk.app.onConfigure(() => onConfigure());
+    sdk.app.onConfigurationCompleted((error) => onConfigurationCompleted(error));
   }, [sdk, onConfigure]);
 
   useEffect(() => {

--- a/apps/cloudinary2/src/vite-env.d.ts
+++ b/apps/cloudinary2/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_BACKEND_BASE_URL: string;
+  readonly VITE_CLOUDINARY_BACKEND_BASE_URL: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Purpose

When installing for the first time we need to wait for the installation to finish in order to utilize signed requests.

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
