### PR TITLE
fix: adjust Bynder dialog width [INTEG-1305]

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -82,7 +82,7 @@ function makeThumbnail(resource) {
 function prepareBynderHTML() {
   return `
     <div class="dialog-container">
-      <div id="bynder-compactview" style="overflow-x:auto;" />
+      <div id="bynder-compactview" style="overflow-x:auto; width:100%;" />
     </div>      
   `;
 }


### PR DESCRIPTION
## Purpose

Reported bug in the Bynder app where when you use the search and only a few assets are displaying (so there are fewer columns), the content in the dialog shrinks in width.

## Approach

Adjusted CSS for the `bynder-compactview` div to make `width: 100%`. See before and after below:

Before:
![Screenshot 2023-09-19 at 7 55 11 AM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/152de51a-4a5e-4a9b-97c9-f8f17133f70d)

After:
![Screenshot 2023-09-19 at 7 55 19 AM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/f72b9e53-7668-475f-bad9-aa131c854c35)

## Testing steps

1. Go to a space where the Bynder app is installed
2. Go to an entry and navigate to a field that's using the Bynder app
3. Click on "Select a file on Bynder" button
4. In the dialog, enter something in the search field that limits results to only a few assets
5. Confirm that the width of the content in the dialog doesn't change when there are only a few items displayed

## Breaking Changes

None

## Dependencies and/or References

## Deployment

