### PR TITLE
Make gavinmatt shared codeowner of apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @contentful/team-integrations
+apps @contentful/team-integrations @gavinmatt


### PR DESCRIPTION
## Purpose

@gavinmatt should be flagged for review for any PRs touching the apps folder

## Approach

* Add @gavinmatt to codeowners. Multiple codeowners are "or" so this statement means either @gavinmatt _or_ @contentful/team-integrations is marked as codeowner

## Dependencies and/or References

* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
