### PR TITLE
fix: disable batch creation of CEs (#3)

### DIFF
--- a/apps/surfer/src/components/SurferContainer.tsx
+++ b/apps/surfer/src/components/SurferContainer.tsx
@@ -19,7 +19,7 @@ export const SurferContainer = forwardRef<
     height?: string;
   }
 >(({ isLoading, flex, height, isExpanded, toggleExpanded }, ref) => (
-  <Flex flexDirection="column" justifyContent="space-between" fullHeight gap={tokens.spacingS} style={{ overflow: 'hidden' }}>
+  <Flex flexDirection="column" justifyContent="space-between" fullHeight gap={tokens.spacingS} style={{ overflowX: 'hidden' }}>
     {toggleExpanded && !isLoading && (
       <Button
         isFullWidth

--- a/apps/surfer/src/locations/Sidebar.tsx
+++ b/apps/surfer/src/locations/Sidebar.tsx
@@ -32,6 +32,7 @@ const Sidebar = () => {
     setHtml(contentHtml);
     configureView({
       configurationToggleOverride: true,
+      disableBatchContentEditorCreation: true,
     });
   };
 

--- a/apps/surfer/src/types.ts
+++ b/apps/surfer/src/types.ts
@@ -6,7 +6,12 @@ export interface SurferContext {
   setHtml: (html: string | null) => void;
   requestView: (requestedView: SurferView) => void;
   refreshDraft: () => void;
-  configureView: (config: { disableDraftConfiguration?: boolean; configurationOnCancelOverride?: boolean; configurationToggleOverride?: boolean }) => void;
+  configureView: (config: {
+    disableDraftConfiguration?: boolean;
+    configurationOnCancelOverride?: boolean;
+    configurationToggleOverride?: boolean;
+    disableBatchContentEditorCreation?: boolean;
+  }) => void;
 }
 
 export enum SurferRpcCommands {


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
Disable an option for batch creating Surfer's Content Editors inside Contentful's app.

Our Surfer app is used on a specific content, tied to a single Content Editor. The batching feature doesn't make much sense in this context, while being problematic to display correctly in the sidebar's limited space. Creating a single CE is still available through the Contentful app and customers can find the batching feature in Surfer.

Bonus: fix the `Collapse` button being cut in some cases.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
We're configuring the view to disable the `Create multiple` button.

<img width="301" alt="image" src="https://github.com/contentful/marketplace-partner-apps/assets/28512248/8b8ff119-97d2-4c87-9c4d-40f5528b7cb4">

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

In Dev mode:

1. Create new content with Surfer enabled
2. The only option to create a new CE should be `Create for 1 CE credit`

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->
None

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->
None, it's a bug we found since the first PR.

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
Nope
