### PR TITLE
Fix/cloudinary localization bug

### DIFF
--- a/apps/cloudinary2/package-lock.json
+++ b/apps/cloudinary2/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cloudinary2",
+  "name": "@contentful/cloudinary-assets",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cloudinary2",
+      "name": "@contentful/cloudinary-assets",
       "version": "2.0.0",
       "dependencies": {
         "@contentful/app-sdk": "4.22.1",

--- a/apps/cloudinary2/src/locations/Field/index.tsx
+++ b/apps/cloudinary2/src/locations/Field/index.tsx
@@ -18,7 +18,7 @@ const Field = () => {
   const sdk = useSDK<FieldAppSDK<AppInstallationParameters>>();
   useAutoResizer({ absoluteElements: true });
 
-  const [assets = [], setAssets] = useFieldValue<CloudinaryAsset[]>();
+  const [assets = [], setAssets] = useFieldValue<CloudinaryAsset[]>(sdk.field.id, sdk.field.locale)
 
   const [editingEnabled, setEditingEnabled] = useState(!sdk.field.getIsDisabled());
   useEffect(() => {


### PR DESCRIPTION
## Purpose

We received customer reports that inserting images was broken for localized entries. When inserting an image for one locale it was also overriding the "default" locale.

Bug seems to related to an erroneous logic in the `useFieldValue` hook here https://github.com/contentful/ui-extensions-sdk/blob/fa8a06f9d6ded33fcef2b8cad87fce7b2cb2c3e2/lib/field.ts#L87 which assumes that the _default_ locale (`sdk.locales.default`) should be used when a locale is not specified, which contravenes the behavior of `field.setValue()` which uses the _current_ field locale (ie. `sdk.field.locale`) if one is not explicitly provided.

## Approach

* Just pass the correct locale value explicitly

## Testing steps

Reproduced bug locally then verified the fix manually (no tests in this part of the app):

<img width="575" alt="image" src="https://github.com/contentful/marketplace-partner-apps/assets/235836/e633c6bf-28b9-48fa-aeb6-e3a3404fa503">


## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
