### PR TITLE
feat: new default selected asset displays asset name [INTEG-1405]

### DIFF
--- a/apps/bynder/package-lock.json
+++ b/apps/bynder/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/bynder-assets",
       "version": "1.11.16",
       "dependencies": {
-        "@contentful/dam-app-base": "^2.0.35",
+        "@contentful/dam-app-base": "^2.1.0",
         "react": "16.14.0",
         "react-dom": "16.14.0"
       },
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@contentful/dam-app-base": {
-      "version": "2.0.62",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.0.62.tgz",
-      "integrity": "sha512-X56DvE1vl9eI2V0szIwJ8dOZ6bDJA9SVy5heIc2dBpS9fZHCGSHFgcWIag5aQxNrxDXheaHYvC2+PLq4cRVqBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.1.0.tgz",
+      "integrity": "sha512-bSeLRfT4M3o4P8P+RECu6hYyrAfZuZRD74xBhhFdONirmDoxb0xvjmfEL2Ej6SpTF88GXRuGzKj0+Ed/Zp6Sdg==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -19754,9 +19754,9 @@
       }
     },
     "@contentful/dam-app-base": {
-      "version": "2.0.62",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.0.62.tgz",
-      "integrity": "sha512-X56DvE1vl9eI2V0szIwJ8dOZ6bDJA9SVy5heIc2dBpS9fZHCGSHFgcWIag5aQxNrxDXheaHYvC2+PLq4cRVqBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.1.0.tgz",
+      "integrity": "sha512-bSeLRfT4M3o4P8P+RECu6hYyrAfZuZRD74xBhhFdONirmDoxb0xvjmfEL2Ej6SpTF88GXRuGzKj0+Ed/Zp6Sdg==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "5.0.1"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "^2.0.35",
+    "@contentful/dam-app-base": "^2.1.0",
     "react": "16.14.0",
     "react-dom": "16.14.0"
   },

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -74,7 +74,7 @@ const validAssetTypes = ['image', 'audio', 'document', 'video'];
 function makeThumbnail(resource) {
   const thumbnail = (resource.thumbnails && resource.thumbnails.webimage) || resource.src;
   const url = typeof thumbnail === 'string' ? thumbnail : undefined;
-  const alt = [resource.id, ...(resource.tags || [])].join(', ');
+  const alt = [resource.name || resource.id, ...(resource.tags || [])].join(', ');
 
   return [url, alt];
 }


### PR DESCRIPTION
## Purpose

[This PR](https://github.com/contentful/apps/pull/5020) updated the `dam-app-base` with a new default for when there is no url/thumbnail image for an asset. This current PR bumps the `dam-app-base` in the Bynder app to utilize this change. It also changes the value of the alt text for the thumbnail to display the asset name instead of the asset id. Many of our other DAM apps return the asset name or a more readable Id from the `makeThumbnail` function.

## Approach

The asset name is a friendlier thing for users to see when there is no thumbnail image to display. 

Before:
![Screenshot 2023-10-03 at 1 11 35 PM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/f18bf4ba-9914-4d63-9022-296e82b121f9)

After:
![Screenshot 2023-10-03 at 1 12 15 PM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/bf2b0d50-0287-4a2d-911c-601aa9d12858)

## Testing steps

Select an asset from Bynder that doesn't have a thumbnail image to see the new default asset in the entry. 

## Breaking Changes

None, this is purely a visual change.

## Dependencies and/or References

## Deployment
