### PR TITLE
ci: remove unneeded vault access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,24 +2,6 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.0.2
-  vault: contentful/vault@1
-
-commands:
-  publish:
-    steps:
-      - vault/get-secrets:
-          template-preset: 'semantic-release-ecosystem'
-      - run:
-          name: Setup NPM
-          command: |
-            echo $'@contentful:registry=https://registry.npmjs.org/
-            //registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
-      - run: export GH_TOKEN=${GITHUB_TOKEN}
-      - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
-      - run: git config --global user.name "${GIT_AUTHOR_NAME}"
-      - run:
-          name: Publish packages
-          command: npm run publish-packages
 
 jobs:
   apps-checks:
@@ -87,8 +69,6 @@ workflows:
   apps-ci-pipeline:
     jobs:
       - apps-checks:
-          context:
-            - vault
           filters:
             branches:
               ignore:
@@ -96,7 +76,6 @@ workflows:
                 - production
       - deploy-staging:
           context:
-            - vault
             - marketplace-partner-apps-staging
           filters:
             branches:
@@ -104,7 +83,6 @@ workflows:
                 - main
       - deploy-prod:
           context:
-            - vault
             - marketplace-partner-apps-production
           filters:
             branches:


### PR DESCRIPTION
## Purpose

Partners are seeing build fails because of authorization issues with CircleCI checks. EG https://app.circleci.com/pipelines/github/contentful/marketplace-partner-apps/706/workflows/cbd48495-086f-4e4f-a384-87f3d31bcae2

<img width="1217" alt="image" src="https://github.com/contentful/marketplace-partner-apps/assets/235836/9f502d66-e73c-4960-90d7-2dc8d9c4d2eb">


## Approach

Hard to know exactly what's causing this but I suspect it's the vault requirement that's hitting an auth problem. We actually don't even need access to the CI vault for any of our tests, so I want to try removing it. (If we do end up needing this access in CI I'll find out the hard way).

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
