### PR TITLE
ci: add GH action to ensure PR titles are convetnional commits

### DIFF
--- a/.github/workflows/lint-pull-requests.yml
+++ b/.github/workflows/lint-pull-requests.yml
@@ -1,0 +1,21 @@
+name: "Lint Pull Requests"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In order for your app to be deployed successfully (with the exception of the tes
 
 When you are ready to submit your app to the [marketplace apps repo](https://github.com/contentful/marketplace-partner-apps), clone the repo locally, create a new branch with a descriptive name for the app/changes you are introducing, and create a pull-request against the `main` branch. An ecosystems integrations will review your PR soon and let you know if any changes or clarifications are needed. To ensure the fastest approval time on your PR, make sure you:
 
+- PR titles must confirm to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard. (A Github Action will emit a failing status check if your PR title does not match)
 - Fill out the pull-request template as much as possible. Screenshots, images, and videos are often helpful for providing context and are encouraged.
 - Comment your changes, either in GitHub or the code itself to provide reviewers more context than they might get otherwise.
 - Ensure your changes are wholly contained within your app's folder, and do not make alterations to other folders or the root level. If you have need for root-level changes, please create an issue instead.


### PR DESCRIPTION
## Purpose

To in the future support better changelogs and more accurate version increments, our PR titles should be in conventional commit style: https://www.conventionalcommits.org/en/v1.0.0/#summary

Since we use PR titles for squash and merge, verifying the titles of our PRs is extra important.

## Approach

* Use semantic-pull-request Github action https://github.com/marketplace/actions/semantic-pull-request

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
