### PR TITLE
fix: menu item display for non-image assets [INTEG-1415]

### DIFF
--- a/apps/cloudinary2/src/locations/Field/Thumbnail.tsx
+++ b/apps/cloudinary2/src/locations/Field/Thumbnail.tsx
@@ -97,14 +97,22 @@ export function Thumbnail({ asset, isDisabled, onDelete }: Props) {
             <dl className={styles.fileInformation.dl}>
               <dt>Location:</dt>
               <dd>{asset.public_id.split('/').slice(0, -1).join('/') || 'Home'}</dd>
-              <dt>Format:</dt>
-              <dd>{asset.format}</dd>
+              {asset.format && (
+                <>
+                  <dt>Format:</dt>
+                  <dd>{asset.format}</dd>
+                </>
+              )}
               <dt>Size:</dt>
               <dd>{fileSize(asset.bytes).human('jedec')}</dd>
-              <dt>Dimensions:</dt>
-              <dd>
-                {asset.width} x {asset.height} px
-              </dd>
+              {asset.width && asset.height && (
+                <>
+                  <dt>Dimensions:</dt>
+                  <dd>
+                    {asset.width} x {asset.height} px
+                  </dd>
+                </>
+              )}
               <dt>Created on:</dt>
               <dd>
                 <DateTime date={asset.created_at} format="day" />


### PR DESCRIPTION
## Purpose

With the refreshed Cloudinary app, users can see additional file information in a menu for selected assets. Non-image assets don’t have format or dimensions data, so currently the menu information doesn’t look right for these assets.

## Approach

Only show the format and dimensions data when it exists. See screenshots below.

Before:
![Screenshot 2023-10-09 at 9 40 37 AM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/1066b38a-81e8-4d69-8bd0-f0388dfbb714)

After:
![Screenshot 2023-10-09 at 9 40 12 AM](https://github.com/contentful/marketplace-partner-apps/assets/62958907/c625f309-79a0-47cb-abb4-9eb4fda77373)

## Testing steps

Select a non-image asset in Cloudinary. The file information in the menu should only show location, size, and created date. Any image or video asset should also display the format and dimensions.

## Breaking Changes

## Dependencies and/or References

## Deployment
