### PR TITLE
chore: update semantic config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
## Purpose

The purpose of this PR is to 
1. test that the Contentful semantic-pull-requests app works by ensuring we require the PR title to have semantic formatting and 
2. test that the custom configuration of the app enforces title check only, and that we are only going to refer to the PR title and not commits for the semantic info. This PR does not enforce any functionality of correct versioning, just enforces semantic commits. 

With this PR in particular as testing ground:

You will notice the title is formatted appropriately per semver standards. 
But when I changed it or did not have the correct formatting the PR check failed: 

![Screenshot 2023-11-06 at 12 46 25 PM](https://github.com/contentful/marketplace-partner-apps/assets/58186851/f6d4435d-8bb6-44b6-a28b-b47cf59f09a6)
![Screenshot 2023-11-06 at 12 46 09 PM](https://github.com/contentful/marketplace-partner-apps/assets/58186851/91cdf070-7862-45ae-aed2-3a2124edb6a3)


Follow-up work to:

In order to ensure this compatible with the release-please functionality and conventional commits I would like to make sure of the following: 

1. Make sure that our merge/squash process is compatible with release-please for this repo - the PR title is referenced appropriately for this title. 
3. Ensure that the configuration for semantic commit messages is aligned to properly increment versioning with release-please. Release-please uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for this. 
4. Ensure the same PR check occurs when merging to the prod branch (this should be the case with just this PR). 
5. Answer the question of if we want there to exist a semantic commit message as a fallback?



