### PR TITLE
fix: flexfields to render rich text fields

### DIFF
--- a/apps/flexfields/package-lock.json
+++ b/apps/flexfields/package-lock.json
@@ -9,14 +9,13 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-sdk": "4.14.1",
-        "@contentful/default-field-editors": "^1.5.8",
-        "@contentful/f36-components": "4.52.3",
-        "@contentful/f36-multiselect": "^4.20.12",
+        "@contentful/app-sdk": "4.23.1",
+        "@contentful/default-field-editors": "^1.5.24",
+        "@contentful/f36-components": "4.54.3",
+        "@contentful/f36-multiselect": "^4.21.0",
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
         "@contentful/react-apps-toolkit": "1.2.16",
-        "@udecode/plate-common": "^24.3.6",
         "contentful-management": "10.46.4",
         "emotion": "10.0.27",
         "react": "17.0.2",
@@ -34,6 +33,10 @@
         "@types/react-dom": "18.0.3",
         "cross-env": "7.0.3",
         "typescript": "4.9.5"
+      },
+      "peerDependencies": {
+        "@udecode/plate-common": "23.6.0",
+        "slate-react": "0.95.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1935,9 +1938,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.2.tgz",
-      "integrity": "sha512-suItGf7PhtfgQMCd8ofYzycdsAHDBB8BkNrmyxeLvptW7yNT6zGT6ZzwhAfmB94TUyAAStrHjaDGC4/foenF2A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.1.tgz",
+      "integrity": "sha512-L5UInv8Ffd6BPw0P3EF7JLYAMeEbclY7+6Q11REt8vhih8RuLreKtPy/xk8wPxs4EQgYqzI7cdgpiYwWlbS/ow==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1952,9 +1955,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.0.tgz",
-      "integrity": "sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.2.tgz",
+      "integrity": "sha512-tjoi4MCWDNxgIpoLZ7+tezdS9OEB6pkiDKhfKx9ReJ/XBcs2G2RXIu+/FxXBlWsPTsz6C9q/r4gjzrsxpcnqCQ==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -1995,9 +1998,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.4.tgz",
-      "integrity": "sha512-YoTrvjv9e8EbPs58opjZKyJ3ewFrVSUzQ/4WXlULQLSDDr1nGPJ67mMXFNNVYwdFhybzhrzrtqgHmtpJwIF+8g==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
+      "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2099,10 +2102,10 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.14.1.tgz",
-      "integrity": "sha512-ugAbeOg75+nT6/xTkSgwRpMbVwZmipgUh5Yx0gzidYaJNdxC3Kk6piUrGqIoAx4RFW/sbu6M5+vi1Lyw4krMJw==",
-      "peerDependencies": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
+      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
+      "dependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
@@ -2118,9 +2121,9 @@
       }
     },
     "node_modules/@contentful/default-field-editors": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.12.tgz",
-      "integrity": "sha512-QRSAT+Z1MkfkujUhMB/JGdsvCg7Dlhwojtf3s62Mz6xE4YoH5zlL1jt858GGgp9SwpsAJMqV2RQ8MRSMNJCRlQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.24.tgz",
+      "integrity": "sha512-lckpAkC02amkpc65hD2iopo2P1rDDSDj5Jkn8JDhGwIZZ7tdwV3/oBzwUn2k/6j8/OYAIRCWm6e22OqdmmCKJw==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/field-editor-boolean": "^1.4.2",
@@ -2129,14 +2132,14 @@
         "@contentful/field-editor-dropdown": "^1.4.2",
         "@contentful/field-editor-json": "^3.3.6",
         "@contentful/field-editor-list": "^1.4.2",
-        "@contentful/field-editor-location": "^1.3.5",
-        "@contentful/field-editor-markdown": "^1.5.2",
+        "@contentful/field-editor-location": "^1.3.6",
+        "@contentful/field-editor-markdown": "^1.5.3",
         "@contentful/field-editor-multiple-line": "^1.3.4",
         "@contentful/field-editor-number": "^1.3.4",
         "@contentful/field-editor-radio": "^1.4.2",
         "@contentful/field-editor-rating": "^1.4.2",
-        "@contentful/field-editor-reference": "^5.17.0",
-        "@contentful/field-editor-rich-text": "^3.12.7",
+        "@contentful/field-editor-reference": "^5.20.0",
+        "@contentful/field-editor-rich-text": "^3.16.1",
         "@contentful/field-editor-shared": "^1.4.2",
         "@contentful/field-editor-single-line": "^1.3.4",
         "@contentful/field-editor-slug": "^1.4.2",
@@ -2150,111 +2153,10 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-markdown": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.5.2.tgz",
-      "integrity": "sha512-AQrkrtn72dnxAyAxOjE/pKRV7DE9ouihjD3lbARPFsr2sxrVUdzCczi9yENyLi+WMTZYaNlH1cFPtYmeu+0xFA==",
-      "dependencies": {
-        "@contentful/f36-components": "^4.0.27",
-        "@contentful/f36-icons": "^4.1.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.4.2",
-        "@types/codemirror": "0.0.109",
-        "codemirror": "^5.65.11",
-        "constate": "^3.2.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "react-markdown": "^8.0.7",
-        "rehype-raw": "^6.1.1",
-        "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^3.0.1"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-reference": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.17.0.tgz",
-      "integrity": "sha512-UJLUfXKorXCNUzeSx8sWsej7q4UFcun5YnbrVqYBub1NoHvGZyWAtFyyG91dJVFs5qj72Wx6+TUThLW6nCy1qw==",
-      "dependencies": {
-        "@contentful/f36-components": "^4.0.27",
-        "@contentful/f36-icons": "^4.1.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.4.2",
-        "@contentful/mimetype": "^1.4.0",
-        "@dnd-kit/core": "^6.0.8",
-        "@dnd-kit/modifiers": "^6.0.1",
-        "@dnd-kit/sortable": "^7.0.2",
-        "@tanstack/react-query": "^4.3.9",
-        "@types/deep-equal": "^1.0.1",
-        "constate": "3.2.0",
-        "contentful-management": "^10.14.0",
-        "deep-equal": "2.2.2",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "moment": "^2.20.0",
-        "p-queue": "^4.0.0",
-        "react-intersection-observer": "9.4.0",
-        "type-fest": "2.17.0"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-reference/node_modules/@dnd-kit/sortable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
-      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.0",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.0.7",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
-      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
-      "dependencies": {
-        "@tanstack/query-core": "4.36.1",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text": {
-      "version": "3.12.7",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.12.7.tgz",
-      "integrity": "sha512-lNxPOMrXWDyGQuam6FDBABOf6MhL/vlM+HE4/z7qFSCOQNzLou3b2XMtJyIkF/2PwkTd/7QsyFllI9EP98CE1w==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.1.tgz",
+      "integrity": "sha512-YFicYD1yDzE5q+8g7dvtX9ZgHUtrv4+qA5pEO74YDngfd/131QNNBjeGi0fMlJunwZJjHopFwICtnXvB29UAWw==",
       "dependencies": {
         "@contentful/app-sdk": "^4.21.1",
         "@contentful/contentful-slatejs-adapter": "^15.16.5",
@@ -2262,7 +2164,7 @@
         "@contentful/f36-icons": "^4.1.1",
         "@contentful/f36-tokens": "^4.0.0",
         "@contentful/f36-utils": "^4.19.0",
-        "@contentful/field-editor-reference": "^5.17.0",
+        "@contentful/field-editor-reference": "^5.20.0",
         "@contentful/field-editor-shared": "^1.4.2",
         "@contentful/rich-text-plain-text-renderer": "^16.0.4",
         "@contentful/rich-text-types": "16.3.0",
@@ -2347,48 +2249,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-23.7.0.tgz",
@@ -2434,101 +2294,6 @@
         "@udecode/slate": "22.0.2",
         "@udecode/slate-react": "22.0.2",
         "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-core": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
-      "integrity": "sha512-5nw86q3Om2TLtwo0rmMSzE5phbuoQoE9GlXxBL/oo7BYQwLWFSwqMqSxAO1doysqQ+Z8Yw5ctRtOq3kz587A0w==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "@udecode/zustood": "^1.1.3",
-        "clsx": "^1.2.1",
-        "jotai": "1.7.2",
-        "lodash": "^4.17.21",
-        "nanoid": "^3.3.6",
-        "react-hotkeys-hook": "^4.4.1",
-        "use-deep-compare": "^1.1.0",
-        "zustand": "^3.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-core/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-core/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
         "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
@@ -2595,48 +2360,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-23.7.0.tgz",
@@ -2690,48 +2413,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node": {
@@ -2789,48 +2470,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-23.7.0.tgz",
@@ -2884,48 +2523,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx": {
@@ -2989,48 +2586,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-heading": {
@@ -3153,48 +2708,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-23.7.0.tgz",
@@ -3249,48 +2762,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-resizable": {
@@ -3363,48 +2834,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block/node_modules/@udecode/plate-common/node_modules/@udecode/slate": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-      "dependencies": {
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block/node_modules/@udecode/plate-common/node_modules/@udecode/slate-react": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block/node_modules/@udecode/plate-common/node_modules/@udecode/slate-utils": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-      "dependencies": {
-        "@udecode/slate": "22.0.2",
-        "@udecode/utils": "19.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/slate-history": {
       "version": "0.66.0",
       "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.66.0.tgz",
@@ -3442,21 +2871,6 @@
       "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
       "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ=="
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-slug": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.4.2.tgz",
@@ -3477,48 +2891,16 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@types/codemirror": {
-      "version": "0.0.109",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
-      "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
-      "dependencies": {
-        "@types/tern": "*"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@udecode/utils": {
-      "version": "19.7.1",
-      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-19.7.1.tgz",
-      "integrity": "sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ=="
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/constate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/constate/-/constate-3.2.0.tgz",
-      "integrity": "sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/type-fest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
-      "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.52.3.tgz",
-      "integrity": "sha512-z7CDPZPb/mNjQQdmddopF3wSBDDOGwaKx1Xnjkn6AXp3YWpIoSHN29e+41PX5uibIvmm87SXpf+7A8tJc5IjNQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.54.3.tgz",
+      "integrity": "sha512-iIRqxfnh45Gd2F+V6k7e4RljIgxlRjgd/xNOhRoxlJYLBV+Mx1JIYeHGnb2eUalUW3WMwF9PwISj9eEaqNK8AA==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-collapse": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3527,15 +2909,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.52.3.tgz",
-      "integrity": "sha512-j9TzdAUhOT1h1pU3dt4ZX+peBITvaj6MNd8gVCCVTEPlWPwFmfCCtOLXkVF+j0R29L0yrdCE2cgcp4VLMaGxrQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.54.3.tgz",
+      "integrity": "sha512-TC6csZ/deWryhGx8JcX0AfdA4aweExl/3jWB30qOEhRUut495WX9lTQ9vByQxewODZtunExbX+aS3e9Nc/K+qA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3544,18 +2926,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.52.3.tgz",
-      "integrity": "sha512-WdxpNwBY3T7RXL2qctPMF/r88ab3SCbdHWJGI68OXAvn/cJi3Wgvx32d7fQBYyQpprdqj9se6D2b6kgPDc1XhA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.54.3.tgz",
+      "integrity": "sha512-TI1NICydG7c7hIxBsAwXPhFs5DQA1dsc5RD0VbC36kh4I39T48C4oAhWxDBFgG5eofg+MnuagrPLrKSVPh49TA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@contentful/f36-utils": "^4.23.2",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -3566,11 +2948,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.52.3.tgz",
-      "integrity": "sha512-8Qp2Rgg3u/oEWFAbFJnWgMR24SJyteavrFvGX6YEBakiz3XAgNfVDe1KVo9hvpmNZsTWtyyL33NkmgKKLwZksg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.54.3.tgz",
+      "integrity": "sha512-xMoN2Ne1Fv+0GcoZFYNFslzY1DXp5434uwwWt2YQL9WgDtVPwGzv7jEcCTgEt0ON/wfS7XL36e7dthjLPY03sw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
@@ -3581,12 +2963,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.52.3.tgz",
-      "integrity": "sha512-kU4qPKanAZ5RoaZhvIMyuMnYyXfhsddIULGzm8455W28SOvkV+MqnfjW2vpD0V7aR77JS2HjSiA/4QS9sKtcjQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.54.3.tgz",
+      "integrity": "sha512-ZCivD9ken9uh8ROPTuOUVo3IInVAcVj3O2UmVIdYZ9Jq0hF7mIYivKjswbVlQzWHd5FELonBwVYFzl38+idK5A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-spinner": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-spinner": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.24.1",
         "emotion": "^10.0.17"
@@ -3597,22 +2979,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.52.3.tgz",
-      "integrity": "sha512-RYnX70UOd4mQfQwzdtnD27th0UNKKelfY3wPk9ZO3ZxRY9NapWKmSJyXXisjWTIZmGKIyEK9ZoCRHngevnCR9w==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.54.3.tgz",
+      "integrity": "sha512-e07DMsB+En9PLyRZrsL9IvuYRT1gfID6eehIpjpokmloigpd85hirbFmB1LUvTqKo+9ubCdxEcKAHLUW8Y9FzQ==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.52.3",
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-asset": "^4.54.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -3622,11 +3004,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.52.3.tgz",
-      "integrity": "sha512-RO+hpGYhmYTIzqFZuapx3+yncRRCFfp7hyEty6fYwUe/+H5+M3oh2JI0JJjt/InAaw0PRVVeLF8dN8E8BLLbaA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.54.3.tgz",
+      "integrity": "sha512-YNzHbPRNDjPSqEyh7X+7ZlT6ZxDY+6qzuBYf99ynCysi8N+HShAFrItFhseXXTPecTpaenV3PStljo+BiUPU4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -3636,81 +3018,71 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.52.3.tgz",
-      "integrity": "sha512-lrnYS2qphl8u4oHFLInDVFf3n0F9HgGh2ZkfWqCwBsgu8Ssn++LgV/F5EFhwrPQ7cd4DjI2/DnDX5hWrkJ7o/A==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.54.3.tgz",
+      "integrity": "sha512-O77NGz+M55/FeoFdGGNAAB3JfJFI9NDlyplqBqoyq8yQHBqo8SPNdwkcWDpBN6StXuWNJfpL4t5CNRr5D9wswg==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.52.3",
-        "@contentful/f36-asset": "^4.52.3",
-        "@contentful/f36-autocomplete": "^4.52.3",
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-card": "^4.52.3",
-        "@contentful/f36-collapse": "^4.52.3",
-        "@contentful/f36-copybutton": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-datepicker": "^4.52.3",
-        "@contentful/f36-datetime": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-empty-state": "^4.52.3",
-        "@contentful/f36-entity-list": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-accordion": "^4.54.3",
+        "@contentful/f36-asset": "^4.54.3",
+        "@contentful/f36-autocomplete": "^4.54.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-card": "^4.54.3",
+        "@contentful/f36-collapse": "^4.54.3",
+        "@contentful/f36-copybutton": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-datepicker": "^4.54.3",
+        "@contentful/f36-datetime": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-empty-state": "^4.54.3",
+        "@contentful/f36-entity-list": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.52.3",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-modal": "^4.52.3",
+        "@contentful/f36-list": "^4.54.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-modal": "^4.54.3",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.52.3",
-        "@contentful/f36-notification": "^4.52.3",
-        "@contentful/f36-pagination": "^4.52.3",
-        "@contentful/f36-pill": "^4.52.3",
-        "@contentful/f36-popover": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
-        "@contentful/f36-spinner": "^4.52.3",
-        "@contentful/f36-table": "^4.52.3",
-        "@contentful/f36-tabs": "^4.52.3",
-        "@contentful/f36-text-link": "^4.52.3",
+        "@contentful/f36-note": "^4.54.3",
+        "@contentful/f36-notification": "^4.54.3",
+        "@contentful/f36-pagination": "^4.54.3",
+        "@contentful/f36-pill": "^4.54.3",
+        "@contentful/f36-popover": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
+        "@contentful/f36-spinner": "^4.54.3",
+        "@contentful/f36-table": "^4.54.3",
+        "@contentful/f36-tabs": "^4.54.3",
+        "@contentful/f36-text-link": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
-        "@contentful/f36-typography": "^4.52.3",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-tooltip": "^4.54.3",
+        "@contentful/f36-typography": "^4.54.3",
+        "@contentful/f36-utils": "^4.23.2"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dependencies": {
-        "@types/react": "^16"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.52.3.tgz",
-      "integrity": "sha512-rWYBIO3VnLZNle9gHP4dSFo0FGels4g/NPwn9jRsVzA692nKubHtV/sAO+zA2n23jJ9rVRfvQR5xd7ZDJv4taQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.54.3.tgz",
+      "integrity": "sha512-lRxn+Z8AhgEXzoLAJ1Tp5FYmkMmh4yKbjhDHQo2wwzrWHLor2H2pl/1K1t6vGAT5rL1TC+Z/8SYlFdYGDnimgQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3719,9 +3091,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.52.3.tgz",
-      "integrity": "sha512-amiKICOzlUkyO8Ef6BVqnUBw25RA8PqL7mEWRtBV3DUEVNMebKSFrMlyS1eEDt7E4kUBoBKZ8vEf4Lyper9wbQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.54.3.tgz",
+      "integrity": "sha512-Gp9j+8OJ5i9zV5c3lpK2p6X4nIg4BnDDfGss2h9ZdCHEgVA/GKsdbGTCWfnxuIsH6eSjVnFZWJvfBmIxGMmp7w==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.2",
         "@emotion/core": "^10.1.1",
@@ -3735,17 +3107,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.52.3.tgz",
-      "integrity": "sha512-YVUvVSz1rr61e2HwCje2jgbnpS5aFgN5bf5moO1BA4iMVQQwbAXD1JmOW+Vl+9emCpElAXmgTJL0AIibT22h1Q==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.54.3.tgz",
+      "integrity": "sha512-9UZklFHt5NUyGfFiGKLYkkCh3ttxyRRL+si6x2xLsV0YRfKhswnyS12+8vCdmMjr4GHFusUoZsxEYceeiEXf0Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -3757,11 +3129,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.52.3.tgz",
-      "integrity": "sha512-Asac5DEqxr58cc4UVrfaefnxZ7mDo6J2KX3mVjTZfbb6LOtF72GD/VM/WkLCofBWjzOVWVeYB1Nyv0rdzXxDZQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.54.3.tgz",
+      "integrity": "sha512-TCxcBYfirntwM87WFVOZ2dpUTbS6xxFaipZt6YM+3UBPLTcJdiOz42QissQnzku2FA5oz6zXLRMOR8V/6FnUpg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -3772,11 +3144,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.52.3.tgz",
-      "integrity": "sha512-K4AbEimGG49B7zX2aauS4PN5My0OMp1vGMFami2tTKrAlUr1gvjDd49/MnXuFszyqaG/XHP3bNgKoLRo0Bspdg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.54.3.tgz",
+      "integrity": "sha512-5pqUNFg9/K1mLGlwfGd850ZAfaIfI4B7fIfL5cHLoP9lfKqDB7jI/ecBc3BzTmY1c+2dGhpzjXe3d+h+h91ecA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.24.1",
@@ -3788,12 +3160,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.52.3.tgz",
-      "integrity": "sha512-wVtmnQ3R5tmaiMvl9our8iNzyZDxvG5R2J7CXwmwNzTwUc4qdJkSV8LIdGJK2vPS5YXFz6hL0C7foeuSbRuoCQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.54.3.tgz",
+      "integrity": "sha512-4tT0jzT7ORB0m29DsncfPPWnvFn5UZBVOW6q3A+2/kqE1j/hy0E1Dkaf/lc0D2KDzAlJxDMNLWwjKjOLMI9PhQ==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3802,20 +3174,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.52.3.tgz",
-      "integrity": "sha512-LTHeY0HnRs8cP7vT+y6agnS17pTm8fE+QplhZf+z4k/xypsAR0Jm+Ae94yMlVXYR9aJurJfG2Dqo8WKTRjWi0g==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.54.3.tgz",
+      "integrity": "sha512-4o4w5Z5O4R2YIUfVwdaOjvvhTyidbiGjvrk47283hkJ/Qdorv4gPRwevjJVt5CiBbc4dpxgU9XkLaRJKm5EdWQ==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3824,14 +3196,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.52.3.tgz",
-      "integrity": "sha512-2BTE/rsRw+xDdfK8d8XCcBmPOukrI7agUKHbp73x/gt2fWukXZn7satHWsBmz6Ek1169Q5GyfAUm+84asIhSHg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.54.3.tgz",
+      "integrity": "sha512-V8AjaougJew9VWW7jHfYiS5XnsPYqIpoVGVTj4CtVMPWaWL9nb32zCP/pPAg3UAdzB2vZ1NUByMlS2coasuz5A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3840,11 +3212,11 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.52.3.tgz",
-      "integrity": "sha512-kobypjFcH5FvhkJ3sPgiZUR9qSUEBtQk/c79FnWlefIBqEdWGYYmduMjQ4eSOMEhnJo8ZUqs7f/NB/6akrvHag==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.54.3.tgz",
+      "integrity": "sha512-HRuLCzZ49qzEsOfuIp95AcEZdlcFuiWx2a6/Q0bRpVe6x8zioiTMpzHr5A+V1LA4RXefyQIbbtulN0rpJMMLRA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -3869,11 +3241,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.52.3.tgz",
-      "integrity": "sha512-B2J/GYXP3WvHGPqS9rLdwd+rDLuMC2XfP5t7XfhlTUCNKtaO56vnyxlih1sI6KnnhGiuoYugrMzGlFb2cC+NIA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.54.3.tgz",
+      "integrity": "sha512-pjmS57OcZC1mie1ItKHNLpKpzlS9zlvx8TVPTcZlrt7P5Zs8n1zDuL/qsBnL6/2ahQ+z8AodOWu4YiiJ/dn6hw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -3883,15 +3255,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.52.3.tgz",
-      "integrity": "sha512-LJzq3Ah4g5Uib9Hnt3AWjnmosQNdxdLIdCLeXTHaICEdHNaffLVrKSRY08k6B2q7RjzUFExogtdvEkVKwanBmw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.54.3.tgz",
+      "integrity": "sha512-UYwiyLjeBG5jirjYh7j0K7U1qvZNhIbjp07KuMM+ktc5q+xeCO9sssDDl4jazpKgCtVyCa1H5G3J1supLrghpg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       },
@@ -3901,15 +3273,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.52.3.tgz",
-      "integrity": "sha512-b147S+B8H9lD8FVS5zInxhHdzkYi440wjYBFQeNOHO2QrMF4+bYCwloRY21WGAZ/wakqWiqsAxxPuyb0j9oxnw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.54.3.tgz",
+      "integrity": "sha512-dw9/DrzTDdg+Q3O1nrbrNIpyDMtDk8g2QgxUqU0aiEQ11v21Qa4ZQFNO18bcz5AR/PaB1NfSJekT/4rxFGOt3Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -3920,9 +3292,9 @@
       }
     },
     "node_modules/@contentful/f36-multiselect": {
-      "version": "4.20.13",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.20.13.tgz",
-      "integrity": "sha512-vBvJbz+yyeQ8PgOUc5Y9+VPbl5oT3VCpb2luXh1YsvtcArXwUmTPWyNBAWN15TB4oj2XRnaTwJUUDMDZ2UGcSw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.21.0.tgz",
+      "integrity": "sha512-72VCl5K8MwImfUCNlfXqwcgcr19q/ZAkvrroykQxwH+hrLYv0Oo/EaOSwPJ1Qo/uPJ521aEAkZqSGgUE/vpm0g==",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@contentful/f36-button": "^4.52.2",
@@ -3962,16 +3334,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.52.3.tgz",
-      "integrity": "sha512-nbXsq2PCGFsUYhoARbqQWUn65MNXboealtoNUmuEUvi5SEpTd8TQDZh2U0L3dSYRkNWUQdjx7y/im6GowKCmYQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.54.3.tgz",
+      "integrity": "sha512-mvKzjeglqLFBKaJQk7TilglBbo9llbnneJ4zYp2HeCQUVauPzTLNGlkMJafbdlBhXvsREUpbaF1WbIf3js7JnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3980,16 +3352,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.52.3.tgz",
-      "integrity": "sha512-aa2weMcI2l49UJta+kc6gRYAx/EC06/51Vk27ykkevrwtHeZjq7PEN3lhzfYS1qdBo5Lnkt1MLb/MBkdwG4mSg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.54.3.tgz",
+      "integrity": "sha512-6/+IT4SjZbGxewW1gpaFQ/FlSMdDdL2lPWFLGHuH2WTIhtZGxksXbiR2avfMgYQ0w3l9FNpA/5wgVXlKVdlSpg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.52.3",
+        "@contentful/f36-text-link": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -4000,16 +3372,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.52.3.tgz",
-      "integrity": "sha512-FuxBv9UiNekwi5ryJdEKg2S7eti+KF++2dISLUacPJyqmgPT2tGudqLc3t8QBclmLlPWEHtayg4BTZ8MmKexrQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.54.3.tgz",
+      "integrity": "sha512-fY2X2O2H2Z7wtfhyMtHqFtuyKRKqSXBiM8+4NrEuD9u++EoV+T903HgKwMvDRuoMifep+BVsmtkQdH6M39nmPA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -4018,16 +3390,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.52.3.tgz",
-      "integrity": "sha512-eHzs6renbheOT8YqwIt+jb3dm+58pcRFmF1WY123/OadLlvngfQcJQOtJKBTQ8hB2+Iupzoj1QT678U3GKZ8Gg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.54.3.tgz",
+      "integrity": "sha512-8yIE5581ZCcJz+BzajDZpKni4eTV720wkuQo80y3XBLkh/JTugZZMjNqzhYjsSj2M+0F7HYVou60gdO6t3B++Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -4036,11 +3408,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.52.3.tgz",
-      "integrity": "sha512-hCc+Ax1fkWQ8F2PrEt/x2KLHIUa+VoeuPRUQyTQjiUMpzdZOQa9qja7IPoKO8MklNjlnquLJAAto8NPe6Cuqgg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.54.3.tgz",
+      "integrity": "sha512-tXTbqMo8GMVy/iQAzhRQ21DuUoWyR4LKbrW/2c6bwMe+9MfQYYuuDdofoLD673qLadT/7AYENmUk9KiMhev6yA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.23.2",
         "@popperjs/core": "^2.11.5",
@@ -4053,12 +3425,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.52.3.tgz",
-      "integrity": "sha512-nJspEE6CTPduiAoCdVR2jDA8b0Om8LMIp32UjcPwxEczHvHfTpoNLDa1g39pSSFtMlk/en4jtRqHTUKn2yMIsw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.54.3.tgz",
+      "integrity": "sha512-JetaqBsiyPNcMxRIm4OO0w/6tSxAUvUlXrzZFhBbV8SgHq2oP8RniJtraC5nlIMxKVRjHQd+QQtQsi9sI5DAUw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-table": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-table": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -4068,11 +3440,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.52.3.tgz",
-      "integrity": "sha512-zLJ0YVIFqPN7wCFr3CFkfb2b/q6pAKqdSOa2yGm8BEQ+Rz7ERkSmj9x394Q3BhFPXQ3pjIppQ5uPiTbmUnXXTA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.54.3.tgz",
+      "integrity": "sha512-Oj6hPrNFigjq7/91fvqhNgcu3ldLO0eeS3y1dBXNVlZ28LYt2kfgD/YJW3cFeFoQbEjhIghl2wRnn8dvLlQnbQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -4082,14 +3454,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.52.3.tgz",
-      "integrity": "sha512-BhwZq03uBsloDmq6931n9vRA8tztsHgBVEkDiUq5aHCrHp6tXbsxwHHveDXRQO5G7uhllF6aW8CLLbTNBbdk7Q==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.54.3.tgz",
+      "integrity": "sha512-J4zBqgAAuMxZB9YyVvttpNQcRMpVU1/nC8QSQpak96//QkEF4iQJyuF2K9lYb+ISYVDT1/CyNQv/BgQI1zKWxQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -4098,11 +3470,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.52.3.tgz",
-      "integrity": "sha512-aKUNkEQY+f1xE4hz5DOCDpwHcC72YAPd2QxOiCxl0u0uFgUvV7aqmLjEthL4h9Q4sWO/pQpVOPjhvcJJxTIgMQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.54.3.tgz",
+      "integrity": "sha512-bkrQ+0UjO15BYzhLuOEHyiAHrUwEzTW9tWYH/EOr3MtnkkP12Dx6+NREu2gi0GwPsbKt2zFsTdaAdnarva7kGQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -4113,11 +3485,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.52.3.tgz",
-      "integrity": "sha512-2hz0RzvNXw9u+jmKVFYHEwEuwZgO/Ac8fHMYzVJ3t3HsPV1gIr/ediXeFEJUZiO3VsAIzqp3j0XjV9SK4IItGg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.54.3.tgz",
+      "integrity": "sha512-tN1oMgcWC+zaE0fdQucFPqk3We/TAgKPp9r1Ff3r1bufMc6n0NEnGEqefcdSejwU1uPKFaX8zZ6MdWDWUV9WfA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -4132,11 +3504,11 @@
       "integrity": "sha512-sM2AM/8Qn4K0mm2H14nDJMIYoAUv7+tHGUyGqnXEyOVD/5O9lzLTkELEA9R0UgtPPcTywCYC6aZCCggy/Ezd/g=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.52.3.tgz",
-      "integrity": "sha512-0xOq5FF7Uv+VcI2+yGs4iBz6Ti3iOLO68EFsnBP3PVvKL3Qc0e8IQBp/oBC8z4e/rqn0w8qDxRJ9abOSRK6n9g==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.54.3.tgz",
+      "integrity": "sha512-I839wA5RGd6jBzUEmV/S79Y+2MpUlDf6bEwJqafXUALvlK4OGmBAFdAbbLSbQYuLurvo6jPkYEZvLGPUJuZHfg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.23.2",
         "@popperjs/core": "^2.11.5",
@@ -4150,11 +3522,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.52.3.tgz",
-      "integrity": "sha512-ojbwmJ4W1Sb6hvquZ0YeZDj1r2/r7YgRHx0+th7QjHWpBGTGfXlHr7P0SF2c5VoeDpOcma3RaT+i3BYoix03Qg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.54.3.tgz",
+      "integrity": "sha512-50PG2sDKwki8y2LqnfEqC6QhQSOxTHcAILbv1yO+BV7I+oMVvhEPXUTBWPXtaxqapi1J01rFqEU1NSjoMpRqfg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       },
@@ -4209,30 +3581,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-boolean/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-boolean/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-checkbox": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-checkbox/-/field-editor-checkbox-1.4.2.tgz",
@@ -4245,30 +3593,6 @@
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-checkbox/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-checkbox/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -4287,30 +3611,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-date/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-date/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-dropdown": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-dropdown/-/field-editor-dropdown-1.4.2.tgz",
@@ -4324,30 +3624,6 @@
         "nanoid": "^3.1.3"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-dropdown/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-dropdown/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -4371,41 +3647,20 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-json/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-json/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-json/node_modules/@uiw/react-codemirror": {
-      "version": "4.21.19",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.19.tgz",
-      "integrity": "sha512-KCm+izhkeRCz9uuPY4WtlMAwEE6HsGR/iHGFDABj2OFq9DfnpAIFyVx2Z87NxMHvHi7zttn6JerxwNLJdV12og==",
+      "version": "4.21.21",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.21.tgz",
+      "integrity": "sha512-PaxBMarufMWoR0qc5zuvBSt76rJ9POm9qoOaJbqRmnNL2viaF+d+Paf2blPSlm1JSnqn7hlRjio+40nZJ9TKzw==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.21.19",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.21",
         "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       },
       "peerDependencies": {
         "@babel/runtime": ">=7.11.0",
@@ -4446,34 +3701,10 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-list/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-list/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-location": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.5.tgz",
-      "integrity": "sha512-P5YfJX0qmCZRvrvsPqCt3kUlSMyYBVChoJzOJEzzOwGcRg1xtjy7pFmgVy1OkBX771hEuRyc71BIrg4gWHcrAg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.6.tgz",
+      "integrity": "sha512-bQ0IUSpC5X4KMzDOVG6VK3/JOn/hM8yoVlpU7Rqnv2jllCkx1dbDYQ98VV3DzC7jkSs631DVP353eiKne3eqWA==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
@@ -4485,30 +3716,6 @@
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-location/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-location/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -4530,6 +3737,38 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@contentful/field-editor-markdown": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.5.3.tgz",
+      "integrity": "sha512-MdSrkoH+0iKD1KgCv5p8ViE186z0TleFF+F/hx2QJmBf3xxdMxPok01OmbyttTLQtBBz2XMsTF35NQT8OrclBA==",
+      "dependencies": {
+        "@contentful/f36-components": "^4.0.27",
+        "@contentful/f36-icons": "^4.1.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.4.2",
+        "@types/codemirror": "0.0.109",
+        "codemirror": "^5.65.11",
+        "constate": "^3.2.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "react-markdown": "^8.0.7",
+        "rehype-raw": "^6.1.1",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": "^4.17.1",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-markdown/node_modules/@types/codemirror": {
+      "version": "0.0.109",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
+      "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@contentful/field-editor-multiple-line": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-multiple-line/-/field-editor-multiple-line-1.3.4.tgz",
@@ -4545,30 +3784,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-multiple-line/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-multiple-line/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-number": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-number/-/field-editor-number-1.3.4.tgz",
@@ -4580,30 +3795,6 @@
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-number/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-number/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -4624,30 +3815,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-radio/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-radio/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-rating": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-rating/-/field-editor-rating-1.4.2.tgz",
@@ -4663,16 +3830,95 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-rating/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
+    "node_modules/@contentful/field-editor-reference": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.20.0.tgz",
+      "integrity": "sha512-LMTBniTIEV63sdz9zdmQOSl70awe0scUQwKWuWQN/nnB2qeMRc2ypZdo3j+NkKGHut//WssSYoKxg8tSQYLpUg==",
       "dependencies": {
-        "contentful-management": ">=7.30.0"
+        "@contentful/f36-components": "^4.0.27",
+        "@contentful/f36-icons": "^4.1.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.4.2",
+        "@contentful/mimetype": "^1.4.0",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@tanstack/react-query": "^4.3.9",
+        "@types/deep-equal": "^1.0.1",
+        "constate": "3.2.0",
+        "contentful-management": "^10.14.0",
+        "deep-equal": "2.2.2",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "moment": "^2.20.0",
+        "p-queue": "^4.0.0",
+        "react-intersection-observer": "9.4.0",
+        "type-fest": "2.17.0"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": "^4.17.1",
+        "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-rating/node_modules/@contentful/field-editor-shared": {
+    "node_modules/@contentful/field-editor-reference/node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
+      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
+      "dependencies": {
+        "@tanstack/query-core": "4.36.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/constate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/constate/-/constate-3.2.0.tgz",
+      "integrity": "sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/type-fest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
+      "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
       "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
@@ -4702,30 +3948,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-single-line/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-single-line/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-tags": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-tags/-/field-editor-tags-1.4.2.tgz",
@@ -4742,30 +3964,6 @@
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-tags/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-tags/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -4797,30 +3995,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-url/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-url/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@contentful/field-editor-validation-errors": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-validation-errors/-/field-editor-validation-errors-1.3.4.tgz",
@@ -4833,30 +4007,6 @@
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-validation-errors/node_modules/@contentful/app-sdk": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-      "peer": true,
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-validation-errors/node_modules/@contentful/field-editor-shared": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-      "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.17.1",
         "react": ">=16.8.0"
       }
     },
@@ -5171,9 +4321,9 @@
       }
     },
     "node_modules/@dnd-kit/accessibility": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
-      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -5182,12 +4332,12 @@
       }
     },
     "node_modules/@dnd-kit/core": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
-      "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
       "dependencies": {
-        "@dnd-kit/accessibility": "^3.0.0",
-        "@dnd-kit/utilities": "^3.2.1",
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
@@ -5209,9 +4359,9 @@
       }
     },
     "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.1.tgz",
-      "integrity": "sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -5262,17 +4412,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/serialize": {
       "version": "0.11.16",
@@ -7279,9 +6429,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
-      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -7352,9 +6502,9 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.6.tgz",
-      "integrity": "sha512-47rJE80oqPmFdVDCD7IheXBrVdwuBgsYwoczFvKmwfo2Mzsnt+V9OONsYauFmICb6lQPpCuXYJWejBNs4pDJRg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+      "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -7461,9 +6611,9 @@
       "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.13.tgz",
-      "integrity": "sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -7474,9 +6624,9 @@
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "node_modules/@types/ms": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
-      "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
       "version": "16.18.58",
@@ -7547,9 +6697,9 @@
       }
     },
     "node_modules/@types/react-modal": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.1.tgz",
-      "integrity": "sha512-HsH2E3luJ2hdVOAovq93x/r+CmWqbhwT8hXW05KMp3zzbSEZsBn4egnMGU/VLwScwlCRPTyZgIEPqLycaz5EOw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -7635,9 +6785,9 @@
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "node_modules/@types/unist": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
-      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -7879,38 +7029,36 @@
       }
     },
     "node_modules/@udecode/plate-common": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-24.4.0.tgz",
-      "integrity": "sha512-5HaQQNs/4sCZBUGcJDhVTrU5OBBENLLy3bjdixfFOGydlL/5F0m7XYZoVV/zeltVSwO6GWelhHtYnk/xXn12Pw==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
+      "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
+      "peer": true,
       "dependencies": {
-        "@udecode/plate-core": "24.4.0",
-        "@udecode/plate-utils": "24.4.0",
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0"
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/plate-utils": "23.6.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-core": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-24.4.0.tgz",
-      "integrity": "sha512-xg/ZzqpnNQmtXQBM02KMBLHczy2LpGQ2HLEjZVXWsHU1YLyiUCyVW/DCi/woPY1dSuSy60ZnVGPKnxs4Ao7zCQ==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
+      "integrity": "sha512-5nw86q3Om2TLtwo0rmMSzE5phbuoQoE9GlXxBL/oo7BYQwLWFSwqMqSxAO1doysqQ+Z8Yw5ctRtOq3kz587A0w==",
       "dependencies": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/utils": "19.7.1",
         "@udecode/zustood": "^1.1.3",
         "clsx": "^1.2.1",
-        "is-hotkey": "^0.2.0",
         "jotai": "1.7.2",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.6",
@@ -7923,39 +7071,36 @@
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-utils": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-24.4.0.tgz",
-      "integrity": "sha512-mVMv1YHv8lZLUds/UF0XvF7jX73QWT1ngNGl7O/pgSdz/BfOCbxEXo3RZHRcG/uwx4ltsO0LOFhXtcYLK71qiQ==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
+      "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "24.4.0",
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0",
-        "clsx": "^1.2.1",
-        "lodash": "^4.17.21"
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/slate": {
-      "version": "24.3.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-24.3.6.tgz",
-      "integrity": "sha512-NfIR4Qkndoba/Ncw+nZ4fNPcd/F+mAHtoOqunRtZR5HdOJN1uBGnSK39duvZST/iB78nPueAVG5hrZ3awGcb4w==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
+      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
       "dependencies": {
-        "@udecode/utils": "24.3.0"
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "slate": ">=0.94.0",
@@ -7963,28 +7108,28 @@
       }
     },
     "node_modules/@udecode/slate-react": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-24.4.0.tgz",
-      "integrity": "sha512-qQ+k6j5a5n0NIVGhgCpK8AbAFN+dxYtQLvbQEIoqr4vWtq9zR9PvJTuPurD8UWATt+ngJ7B1gC6bvSwMh8Uikg==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
+      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
       "dependencies": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/utils": "24.3.0"
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/slate-utils": {
-      "version": "24.3.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-24.3.6.tgz",
-      "integrity": "sha512-bYyj0UYn6pWF1jqraWNQFxhLnUsPcbgrv6MDDKu6I8RlUkrc/ykGaRSoQLwJdRaRmLc4xivUrOnJXLyMfadqLQ==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
+      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
       "dependencies": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/utils": "24.3.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
@@ -7993,9 +7138,9 @@
       }
     },
     "node_modules/@udecode/utils": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-24.3.0.tgz",
-      "integrity": "sha512-/Y2lh/Ih1wx4zN35Ky2Z1G1/5f7cSAS7F6dkhrcbJUnDF0srTidoEIRabK+og/yIK/MCEFfOsQGetoV7Ert5hg=="
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-19.7.1.tgz",
+      "integrity": "sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ=="
     },
     "node_modules/@udecode/zustood": {
       "version": "1.1.3",
@@ -8052,9 +7197,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.19",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.19.tgz",
-      "integrity": "sha512-FwnzjNSc1mbzlcOlGmZgK2JMFcmPSHDeDUoql4ioyffF6ytiUD6LB9exOlQlAppzAZkKBYHqBwBjd0gdJYpH/w==",
+      "version": "4.21.21",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.21.tgz",
+      "integrity": "sha512-+0i9dPrRSa8Mf0CvyrMvnAhajnqwsP3IMRRlaHDRgsSGL8igc4z7MhvUPn+7cWFAAqWzQRhMdMSWzo6/TEa3EA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -8063,6 +7208,9 @@
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       },
       "peerDependencies": {
         "@codemirror/autocomplete": ">=6.0.0",
@@ -9650,9 +8798,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.15",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
-      "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -9805,6 +8953,14 @@
       "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/constate": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/constate/-/constate-3.3.2.tgz",
+      "integrity": "sha512-ZnEWiwU6QUTil41D5EGpA7pbqAPGvnR9kBjko8DzVIxpC60mdNKrP568tT5WLJPAxAOtJqJw60+h79ot/Uz1+Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/content-disposition": {
@@ -12794,9 +11950,9 @@
       }
     },
     "node_modules/hast-util-sanitize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.0.tgz",
-      "integrity": "sha512-L0g/qhOA82zG2hA3O29hnlv4mLU7YVVT1if5JZSr2tKO1ywkQbuMDcN05btgX0HtpqDXQniAM0ar0K+Lv4MDBQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.1.tgz",
+      "integrity": "sha512-IGrgWLuip4O2nq5CugXy4GI2V8kx4sFVy5Hd4vF7AR2gxS0N9s7nEAVUyeMtZKZvzrxVsHt73XdTsno1tClIkQ==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.2.0",
@@ -12808,17 +11964,17 @@
       }
     },
     "node_modules/hast-util-sanitize/node_modules/@types/hast": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
-      "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/hast-util-sanitize/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
     "node_modules/hast-util-sanitize/node_modules/unist-util-position": {
       "version": "5.0.0",
@@ -19211,9 +18367,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
-      "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -19379,9 +18535,9 @@
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.2.tgz",
-      "integrity": "sha512-uUOS+RhYVgyJEWcuAJgelVwhcJ2chsMk7HZCpu+wtjSlFAGSFsHU0r4lMTt47HQ1RdQfI5MmFRt43yHTP9lfmQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19418,9 +18574,9 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.2.tgz",
-      "integrity": "sha512-sK5M5PNZaLiszmACUKUpVu1eX3eFDVV+WLdWQ3BxTPbEC9jhuawmlgpbSXX5dIIQQwJpZ4wwP5+vsMVOwa1IRw==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.9.1.tgz",
+      "integrity": "sha512-W0SPApKIsYq+XCtfGeMYDoU0KbsG3wfkYtlw8l+vZp6KoBXGOlhzBUp4tNx1XiwiOZwhfdGOlj7NGSCKGSlg5Q==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
@@ -19496,15 +18652,24 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
       "version": "2.9.5",
@@ -19895,9 +19060,9 @@
       }
     },
     "node_modules/rehype-sanitize/node_modules/@types/hast": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
-      "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -20341,12 +19506,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -20635,9 +19800,9 @@
       }
     },
     "node_modules/slate-history": {
-      "version": "0.93.0",
-      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.93.0.tgz",
-      "integrity": "sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
+      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
       "peer": true,
       "dependencies": {
         "is-plain-object": "^5.0.0"
@@ -20658,9 +19823,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.99.0.tgz",
-      "integrity": "sha512-E+mU87L5epS/Cj9Z35aRkTEMrBXdX8URbFh8B2zTq2DDQKn+MT6/ag41g1InMdRoQ/kipGsbtcrM8dEicY8o/Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.95.0.tgz",
+      "integrity": "sha512-nOk6SMcHfrahzUV60qtKBSgPuZxgH2p+vKC2IcmjWAq8ScBEdLL4UB/dZBE2tZjsrxyloWQklGh3RQO5u+SbUg==",
       "peer": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
@@ -21048,9 +20213,9 @@
       "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/style-to-object": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
-      "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
       "dependencies": {
         "inline-style-parser": "0.1.1"
       }
@@ -24438,9 +23603,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@codemirror/autocomplete": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.2.tgz",
-      "integrity": "sha512-suItGf7PhtfgQMCd8ofYzycdsAHDBB8BkNrmyxeLvptW7yNT6zGT6ZzwhAfmB94TUyAAStrHjaDGC4/foenF2A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.1.tgz",
+      "integrity": "sha512-L5UInv8Ffd6BPw0P3EF7JLYAMeEbclY7+6Q11REt8vhih8RuLreKtPy/xk8wPxs4EQgYqzI7cdgpiYwWlbS/ow==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -24449,9 +23614,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.0.tgz",
-      "integrity": "sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.2.tgz",
+      "integrity": "sha512-tjoi4MCWDNxgIpoLZ7+tezdS9OEB6pkiDKhfKx9ReJ/XBcs2G2RXIu+/FxXBlWsPTsz6C9q/r4gjzrsxpcnqCQ==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -24492,9 +23657,9 @@
       }
     },
     "@codemirror/search": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.4.tgz",
-      "integrity": "sha512-YoTrvjv9e8EbPs58opjZKyJ3ewFrVSUzQ/4WXlULQLSDDr1nGPJ67mMXFNNVYwdFhybzhrzrtqgHmtpJwIF+8g==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
+      "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -24582,10 +23747,12 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.14.1.tgz",
-      "integrity": "sha512-ugAbeOg75+nT6/xTkSgwRpMbVwZmipgUh5Yx0gzidYaJNdxC3Kk6piUrGqIoAx4RFW/sbu6M5+vi1Lyw4krMJw==",
-      "requires": {}
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
+      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
+      "requires": {
+        "contentful-management": ">=7.30.0"
+      }
     },
     "@contentful/contentful-slatejs-adapter": {
       "version": "15.16.8",
@@ -24596,9 +23763,9 @@
       }
     },
     "@contentful/default-field-editors": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.12.tgz",
-      "integrity": "sha512-QRSAT+Z1MkfkujUhMB/JGdsvCg7Dlhwojtf3s62Mz6xE4YoH5zlL1jt858GGgp9SwpsAJMqV2RQ8MRSMNJCRlQ==",
+      "version": "1.5.24",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.24.tgz",
+      "integrity": "sha512-lckpAkC02amkpc65hD2iopo2P1rDDSDj5Jkn8JDhGwIZZ7tdwV3/oBzwUn2k/6j8/OYAIRCWm6e22OqdmmCKJw==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/field-editor-boolean": "^1.4.2",
@@ -24607,14 +23774,14 @@
         "@contentful/field-editor-dropdown": "^1.4.2",
         "@contentful/field-editor-json": "^3.3.6",
         "@contentful/field-editor-list": "^1.4.2",
-        "@contentful/field-editor-location": "^1.3.5",
-        "@contentful/field-editor-markdown": "^1.5.2",
+        "@contentful/field-editor-location": "^1.3.6",
+        "@contentful/field-editor-markdown": "^1.5.3",
         "@contentful/field-editor-multiple-line": "^1.3.4",
         "@contentful/field-editor-number": "^1.3.4",
         "@contentful/field-editor-radio": "^1.4.2",
         "@contentful/field-editor-rating": "^1.4.2",
-        "@contentful/field-editor-reference": "^5.17.0",
-        "@contentful/field-editor-rich-text": "^3.12.7",
+        "@contentful/field-editor-reference": "^5.20.0",
+        "@contentful/field-editor-rich-text": "^3.16.1",
         "@contentful/field-editor-shared": "^1.4.2",
         "@contentful/field-editor-single-line": "^1.3.4",
         "@contentful/field-editor-slug": "^1.4.2",
@@ -24625,84 +23792,10 @@
         "emotion": "^10.0.27"
       },
       "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-markdown": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.5.2.tgz",
-          "integrity": "sha512-AQrkrtn72dnxAyAxOjE/pKRV7DE9ouihjD3lbARPFsr2sxrVUdzCczi9yENyLi+WMTZYaNlH1cFPtYmeu+0xFA==",
-          "requires": {
-            "@contentful/f36-components": "^4.0.27",
-            "@contentful/f36-icons": "^4.1.0",
-            "@contentful/f36-tokens": "^4.0.0",
-            "@contentful/field-editor-shared": "^1.4.2",
-            "@types/codemirror": "0.0.109",
-            "codemirror": "^5.65.11",
-            "constate": "^3.2.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15",
-            "react-markdown": "^8.0.7",
-            "rehype-raw": "^6.1.1",
-            "rehype-sanitize": "^6.0.0",
-            "remark-gfm": "^3.0.1"
-          }
-        },
-        "@contentful/field-editor-reference": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.17.0.tgz",
-          "integrity": "sha512-UJLUfXKorXCNUzeSx8sWsej7q4UFcun5YnbrVqYBub1NoHvGZyWAtFyyG91dJVFs5qj72Wx6+TUThLW6nCy1qw==",
-          "requires": {
-            "@contentful/f36-components": "^4.0.27",
-            "@contentful/f36-icons": "^4.1.0",
-            "@contentful/f36-tokens": "^4.0.0",
-            "@contentful/field-editor-shared": "^1.4.2",
-            "@contentful/mimetype": "^1.4.0",
-            "@dnd-kit/core": "^6.0.8",
-            "@dnd-kit/modifiers": "^6.0.1",
-            "@dnd-kit/sortable": "^7.0.2",
-            "@tanstack/react-query": "^4.3.9",
-            "@types/deep-equal": "^1.0.1",
-            "constate": "3.2.0",
-            "contentful-management": "^10.14.0",
-            "deep-equal": "2.2.2",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15",
-            "moment": "^2.20.0",
-            "p-queue": "^4.0.0",
-            "react-intersection-observer": "9.4.0",
-            "type-fest": "2.17.0"
-          },
-          "dependencies": {
-            "@dnd-kit/sortable": {
-              "version": "7.0.2",
-              "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
-              "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
-              "requires": {
-                "@dnd-kit/utilities": "^3.2.0",
-                "tslib": "^2.0.0"
-              }
-            },
-            "@tanstack/react-query": {
-              "version": "4.36.1",
-              "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
-              "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
-              "requires": {
-                "@tanstack/query-core": "4.36.1",
-                "use-sync-external-store": "^1.2.0"
-              }
-            }
-          }
-        },
         "@contentful/field-editor-rich-text": {
-          "version": "3.12.7",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.12.7.tgz",
-          "integrity": "sha512-lNxPOMrXWDyGQuam6FDBABOf6MhL/vlM+HE4/z7qFSCOQNzLou3b2XMtJyIkF/2PwkTd/7QsyFllI9EP98CE1w==",
+          "version": "3.16.1",
+          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.1.tgz",
+          "integrity": "sha512-YFicYD1yDzE5q+8g7dvtX9ZgHUtrv4+qA5pEO74YDngfd/131QNNBjeGi0fMlJunwZJjHopFwICtnXvB29UAWw==",
           "requires": {
             "@contentful/app-sdk": "^4.21.1",
             "@contentful/contentful-slatejs-adapter": "^15.16.5",
@@ -24710,7 +23803,7 @@
             "@contentful/f36-icons": "^4.1.1",
             "@contentful/f36-tokens": "^4.0.0",
             "@contentful/f36-utils": "^4.19.0",
-            "@contentful/field-editor-reference": "^5.17.0",
+            "@contentful/field-editor-reference": "^5.20.0",
             "@contentful/field-editor-shared": "^1.4.2",
             "@contentful/rich-text-plain-text-renderer": "^16.0.4",
             "@contentful/rich-text-types": "16.3.0",
@@ -24769,33 +23862,6 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
                   }
                 }
@@ -24834,71 +23900,7 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
-                  }
-                }
-              }
-            },
-            "@udecode/plate-core": {
-              "version": "23.6.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
-              "integrity": "sha512-5nw86q3Om2TLtwo0rmMSzE5phbuoQoE9GlXxBL/oo7BYQwLWFSwqMqSxAO1doysqQ+Z8Yw5ctRtOq3kz587A0w==",
-              "requires": {
-                "@udecode/slate": "22.0.2",
-                "@udecode/slate-react": "22.0.2",
-                "@udecode/utils": "19.7.1",
-                "@udecode/zustood": "^1.1.3",
-                "clsx": "^1.2.1",
-                "jotai": "1.7.2",
-                "lodash": "^4.17.21",
-                "nanoid": "^3.3.6",
-                "react-hotkeys-hook": "^4.4.1",
-                "use-deep-compare": "^1.1.0",
-                "zustand": "^3.7.2"
-              },
-              "dependencies": {
-                "@udecode/slate": {
-                  "version": "22.0.2",
-                  "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                  "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                  "requires": {
-                    "@udecode/utils": "19.7.1"
-                  }
-                },
-                "@udecode/slate-react": {
-                  "version": "22.0.2",
-                  "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                  "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                  "requires": {
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/utils": "19.7.1"
                   }
                 }
               }
@@ -24936,33 +23938,6 @@
                         "@udecode/slate-react": "22.0.2",
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
                       }
                     }
                   }
@@ -25002,33 +23977,6 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
                   }
                 }
@@ -25067,33 +24015,6 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
                   }
                 }
@@ -25131,33 +24052,6 @@
                         "@udecode/slate-react": "22.0.2",
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
                       }
                     }
                   }
@@ -25203,33 +24097,6 @@
                         "@udecode/slate-react": "22.0.2",
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
                       }
                     }
                   }
@@ -25305,33 +24172,6 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
                   }
                 }
@@ -25370,33 +24210,6 @@
                         "@udecode/slate-react": "22.0.2",
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
                       }
                     }
                   }
@@ -25444,33 +24257,6 @@
                         "@udecode/slate-utils": "22.0.2",
                         "@udecode/utils": "19.7.1"
                       }
-                    },
-                    "@udecode/slate": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
-                      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
-                      "requires": {
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-react": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
-                      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    },
-                    "@udecode/slate-utils": {
-                      "version": "22.0.2",
-                      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
-                      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
-                      "requires": {
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/utils": "19.7.1",
-                        "lodash": "^4.17.21"
-                      }
                     }
                   }
                 }
@@ -25509,17 +24295,6 @@
             }
           }
         },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        },
         "@contentful/field-editor-slug": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.4.2.tgz",
@@ -25535,212 +24310,166 @@
             "speakingurl": "^13.0.0",
             "use-debounce": "^7.0.0"
           }
-        },
-        "@types/codemirror": {
-          "version": "0.0.109",
-          "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
-          "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
-          "requires": {
-            "@types/tern": "*"
-          }
-        },
-        "@udecode/utils": {
-          "version": "19.7.1",
-          "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-19.7.1.tgz",
-          "integrity": "sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ=="
-        },
-        "constate": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/constate/-/constate-3.2.0.tgz",
-          "integrity": "sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==",
-          "requires": {}
-        },
-        "type-fest": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
-          "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA=="
         }
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.52.3.tgz",
-      "integrity": "sha512-z7CDPZPb/mNjQQdmddopF3wSBDDOGwaKx1Xnjkn6AXp3YWpIoSHN29e+41PX5uibIvmm87SXpf+7A8tJc5IjNQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.54.3.tgz",
+      "integrity": "sha512-iIRqxfnh45Gd2F+V6k7e4RljIgxlRjgd/xNOhRoxlJYLBV+Mx1JIYeHGnb2eUalUW3WMwF9PwISj9eEaqNK8AA==",
       "requires": {
-        "@contentful/f36-collapse": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-collapse": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.52.3.tgz",
-      "integrity": "sha512-j9TzdAUhOT1h1pU3dt4ZX+peBITvaj6MNd8gVCCVTEPlWPwFmfCCtOLXkVF+j0R29L0yrdCE2cgcp4VLMaGxrQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.54.3.tgz",
+      "integrity": "sha512-TC6csZ/deWryhGx8JcX0AfdA4aweExl/3jWB30qOEhRUut495WX9lTQ9vByQxewODZtunExbX+aS3e9Nc/K+qA==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.52.3.tgz",
-      "integrity": "sha512-WdxpNwBY3T7RXL2qctPMF/r88ab3SCbdHWJGI68OXAvn/cJi3Wgvx32d7fQBYyQpprdqj9se6D2b6kgPDc1XhA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.54.3.tgz",
+      "integrity": "sha512-TI1NICydG7c7hIxBsAwXPhFs5DQA1dsc5RD0VbC36kh4I39T48C4oAhWxDBFgG5eofg+MnuagrPLrKSVPh49TA==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@contentful/f36-utils": "^4.23.2",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.52.3.tgz",
-      "integrity": "sha512-8Qp2Rgg3u/oEWFAbFJnWgMR24SJyteavrFvGX6YEBakiz3XAgNfVDe1KVo9hvpmNZsTWtyyL33NkmgKKLwZksg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.54.3.tgz",
+      "integrity": "sha512-xMoN2Ne1Fv+0GcoZFYNFslzY1DXp5434uwwWt2YQL9WgDtVPwGzv7jEcCTgEt0ON/wfS7XL36e7dthjLPY03sw==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.52.3.tgz",
-      "integrity": "sha512-kU4qPKanAZ5RoaZhvIMyuMnYyXfhsddIULGzm8455W28SOvkV+MqnfjW2vpD0V7aR77JS2HjSiA/4QS9sKtcjQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.54.3.tgz",
+      "integrity": "sha512-ZCivD9ken9uh8ROPTuOUVo3IInVAcVj3O2UmVIdYZ9Jq0hF7mIYivKjswbVlQzWHd5FELonBwVYFzl38+idK5A==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-spinner": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-spinner": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.24.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.52.3.tgz",
-      "integrity": "sha512-RYnX70UOd4mQfQwzdtnD27th0UNKKelfY3wPk9ZO3ZxRY9NapWKmSJyXXisjWTIZmGKIyEK9ZoCRHngevnCR9w==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.54.3.tgz",
+      "integrity": "sha512-e07DMsB+En9PLyRZrsL9IvuYRT1gfID6eehIpjpokmloigpd85hirbFmB1LUvTqKo+9ubCdxEcKAHLUW8Y9FzQ==",
       "requires": {
-        "@contentful/f36-asset": "^4.52.3",
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-asset": "^4.54.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.52.3.tgz",
-      "integrity": "sha512-RO+hpGYhmYTIzqFZuapx3+yncRRCFfp7hyEty6fYwUe/+H5+M3oh2JI0JJjt/InAaw0PRVVeLF8dN8E8BLLbaA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.54.3.tgz",
+      "integrity": "sha512-YNzHbPRNDjPSqEyh7X+7ZlT6ZxDY+6qzuBYf99ynCysi8N+HShAFrItFhseXXTPecTpaenV3PStljo+BiUPU4w==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.52.3.tgz",
-      "integrity": "sha512-lrnYS2qphl8u4oHFLInDVFf3n0F9HgGh2ZkfWqCwBsgu8Ssn++LgV/F5EFhwrPQ7cd4DjI2/DnDX5hWrkJ7o/A==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.54.3.tgz",
+      "integrity": "sha512-O77NGz+M55/FeoFdGGNAAB3JfJFI9NDlyplqBqoyq8yQHBqo8SPNdwkcWDpBN6StXuWNJfpL4t5CNRr5D9wswg==",
       "requires": {
-        "@contentful/f36-accordion": "^4.52.3",
-        "@contentful/f36-asset": "^4.52.3",
-        "@contentful/f36-autocomplete": "^4.52.3",
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-card": "^4.52.3",
-        "@contentful/f36-collapse": "^4.52.3",
-        "@contentful/f36-copybutton": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-datepicker": "^4.52.3",
-        "@contentful/f36-datetime": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-empty-state": "^4.52.3",
-        "@contentful/f36-entity-list": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-accordion": "^4.54.3",
+        "@contentful/f36-asset": "^4.54.3",
+        "@contentful/f36-autocomplete": "^4.54.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-card": "^4.54.3",
+        "@contentful/f36-collapse": "^4.54.3",
+        "@contentful/f36-copybutton": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-datepicker": "^4.54.3",
+        "@contentful/f36-datetime": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-empty-state": "^4.54.3",
+        "@contentful/f36-entity-list": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.52.3",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-modal": "^4.52.3",
+        "@contentful/f36-list": "^4.54.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-modal": "^4.54.3",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.52.3",
-        "@contentful/f36-notification": "^4.52.3",
-        "@contentful/f36-pagination": "^4.52.3",
-        "@contentful/f36-pill": "^4.52.3",
-        "@contentful/f36-popover": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
-        "@contentful/f36-spinner": "^4.52.3",
-        "@contentful/f36-table": "^4.52.3",
-        "@contentful/f36-tabs": "^4.52.3",
-        "@contentful/f36-text-link": "^4.52.3",
+        "@contentful/f36-note": "^4.54.3",
+        "@contentful/f36-notification": "^4.54.3",
+        "@contentful/f36-pagination": "^4.54.3",
+        "@contentful/f36-pill": "^4.54.3",
+        "@contentful/f36-popover": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
+        "@contentful/f36-spinner": "^4.54.3",
+        "@contentful/f36-table": "^4.54.3",
+        "@contentful/f36-tabs": "^4.54.3",
+        "@contentful/f36-text-link": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
-        "@contentful/f36-typography": "^4.52.3",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "16.14.22",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-          "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@types/react-dom": {
-          "version": "16.9.14",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-          "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-          "requires": {
-            "@types/react": "^16"
-          }
-        }
+        "@contentful/f36-tooltip": "^4.54.3",
+        "@contentful/f36-typography": "^4.54.3",
+        "@contentful/f36-utils": "^4.23.2"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.52.3.tgz",
-      "integrity": "sha512-rWYBIO3VnLZNle9gHP4dSFo0FGels4g/NPwn9jRsVzA692nKubHtV/sAO+zA2n23jJ9rVRfvQR5xd7ZDJv4taQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.54.3.tgz",
+      "integrity": "sha512-lRxn+Z8AhgEXzoLAJ1Tp5FYmkMmh4yKbjhDHQo2wwzrWHLor2H2pl/1K1t6vGAT5rL1TC+Z/8SYlFdYGDnimgQ==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.52.3.tgz",
-      "integrity": "sha512-amiKICOzlUkyO8Ef6BVqnUBw25RA8PqL7mEWRtBV3DUEVNMebKSFrMlyS1eEDt7E4kUBoBKZ8vEf4Lyper9wbQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.54.3.tgz",
+      "integrity": "sha512-Gp9j+8OJ5i9zV5c3lpK2p6X4nIg4BnDDfGss2h9ZdCHEgVA/GKsdbGTCWfnxuIsH6eSjVnFZWJvfBmIxGMmp7w==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.2",
         "@emotion/core": "^10.1.1",
@@ -25750,17 +24479,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.52.3.tgz",
-      "integrity": "sha512-YVUvVSz1rr61e2HwCje2jgbnpS5aFgN5bf5moO1BA4iMVQQwbAXD1JmOW+Vl+9emCpElAXmgTJL0AIibT22h1Q==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.54.3.tgz",
+      "integrity": "sha512-9UZklFHt5NUyGfFiGKLYkkCh3ttxyRRL+si6x2xLsV0YRfKhswnyS12+8vCdmMjr4GHFusUoZsxEYceeiEXf0Q==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -25768,22 +24497,22 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.52.3.tgz",
-      "integrity": "sha512-Asac5DEqxr58cc4UVrfaefnxZ7mDo6J2KX3mVjTZfbb6LOtF72GD/VM/WkLCofBWjzOVWVeYB1Nyv0rdzXxDZQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.54.3.tgz",
+      "integrity": "sha512-TCxcBYfirntwM87WFVOZ2dpUTbS6xxFaipZt6YM+3UBPLTcJdiOz42QissQnzku2FA5oz6zXLRMOR8V/6FnUpg==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.52.3.tgz",
-      "integrity": "sha512-K4AbEimGG49B7zX2aauS4PN5My0OMp1vGMFami2tTKrAlUr1gvjDd49/MnXuFszyqaG/XHP3bNgKoLRo0Bspdg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.54.3.tgz",
+      "integrity": "sha512-5pqUNFg9/K1mLGlwfGd850ZAfaIfI4B7fIfL5cHLoP9lfKqDB7jI/ecBc3BzTmY1c+2dGhpzjXe3d+h+h91ecA==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.24.1",
@@ -25791,51 +24520,51 @@
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.52.3.tgz",
-      "integrity": "sha512-wVtmnQ3R5tmaiMvl9our8iNzyZDxvG5R2J7CXwmwNzTwUc4qdJkSV8LIdGJK2vPS5YXFz6hL0C7foeuSbRuoCQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.54.3.tgz",
+      "integrity": "sha512-4tT0jzT7ORB0m29DsncfPPWnvFn5UZBVOW6q3A+2/kqE1j/hy0E1Dkaf/lc0D2KDzAlJxDMNLWwjKjOLMI9PhQ==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.52.3.tgz",
-      "integrity": "sha512-LTHeY0HnRs8cP7vT+y6agnS17pTm8fE+QplhZf+z4k/xypsAR0Jm+Ae94yMlVXYR9aJurJfG2Dqo8WKTRjWi0g==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.54.3.tgz",
+      "integrity": "sha512-4o4w5Z5O4R2YIUfVwdaOjvvhTyidbiGjvrk47283hkJ/Qdorv4gPRwevjJVt5CiBbc4dpxgU9XkLaRJKm5EdWQ==",
       "requires": {
-        "@contentful/f36-badge": "^4.52.3",
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-badge": "^4.54.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.52.3",
-        "@contentful/f36-skeleton": "^4.52.3",
+        "@contentful/f36-menu": "^4.54.3",
+        "@contentful/f36-skeleton": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.52.3.tgz",
-      "integrity": "sha512-2BTE/rsRw+xDdfK8d8XCcBmPOukrI7agUKHbp73x/gt2fWukXZn7satHWsBmz6Ek1169Q5GyfAUm+84asIhSHg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.54.3.tgz",
+      "integrity": "sha512-V8AjaougJew9VWW7jHfYiS5XnsPYqIpoVGVTj4CtVMPWaWL9nb32zCP/pPAg3UAdzB2vZ1NUByMlS2coasuz5A==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.52.3.tgz",
-      "integrity": "sha512-kobypjFcH5FvhkJ3sPgiZUR9qSUEBtQk/c79FnWlefIBqEdWGYYmduMjQ4eSOMEhnJo8ZUqs7f/NB/6akrvHag==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.54.3.tgz",
+      "integrity": "sha512-HRuLCzZ49qzEsOfuIp95AcEZdlcFuiWx2a6/Q0bRpVe6x8zioiTMpzHr5A+V1LA4RXefyQIbbtulN0rpJMMLRA==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
@@ -25852,48 +24581,48 @@
       }
     },
     "@contentful/f36-list": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.52.3.tgz",
-      "integrity": "sha512-B2J/GYXP3WvHGPqS9rLdwd+rDLuMC2XfP5t7XfhlTUCNKtaO56vnyxlih1sI6KnnhGiuoYugrMzGlFb2cC+NIA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.54.3.tgz",
+      "integrity": "sha512-pjmS57OcZC1mie1ItKHNLpKpzlS9zlvx8TVPTcZlrt7P5Zs8n1zDuL/qsBnL6/2ahQ+z8AodOWu4YiiJ/dn6hw==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.52.3.tgz",
-      "integrity": "sha512-LJzq3Ah4g5Uib9Hnt3AWjnmosQNdxdLIdCLeXTHaICEdHNaffLVrKSRY08k6B2q7RjzUFExogtdvEkVKwanBmw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.54.3.tgz",
+      "integrity": "sha512-UYwiyLjeBG5jirjYh7j0K7U1qvZNhIbjp07KuMM+ktc5q+xeCO9sssDDl4jazpKgCtVyCa1H5G3J1supLrghpg==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.52.3",
+        "@contentful/f36-popover": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.52.3.tgz",
-      "integrity": "sha512-b147S+B8H9lD8FVS5zInxhHdzkYi440wjYBFQeNOHO2QrMF4+bYCwloRY21WGAZ/wakqWiqsAxxPuyb0j9oxnw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.54.3.tgz",
+      "integrity": "sha512-dw9/DrzTDdg+Q3O1nrbrNIpyDMtDk8g2QgxUqU0aiEQ11v21Qa4ZQFNO18bcz5AR/PaB1NfSJekT/4rxFGOt3Q==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
     "@contentful/f36-multiselect": {
-      "version": "4.20.13",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.20.13.tgz",
-      "integrity": "sha512-vBvJbz+yyeQ8PgOUc5Y9+VPbl5oT3VCpb2luXh1YsvtcArXwUmTPWyNBAWN15TB4oj2XRnaTwJUUDMDZ2UGcSw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.21.0.tgz",
+      "integrity": "sha512-72VCl5K8MwImfUCNlfXqwcgcr19q/ZAkvrroykQxwH+hrLYv0Oo/EaOSwPJ1Qo/uPJ521aEAkZqSGgUE/vpm0g==",
       "requires": {
         "@babel/runtime": "^7.21.0",
         "@contentful/f36-button": "^4.52.2",
@@ -25925,69 +24654,69 @@
       }
     },
     "@contentful/f36-note": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.52.3.tgz",
-      "integrity": "sha512-nbXsq2PCGFsUYhoARbqQWUn65MNXboealtoNUmuEUvi5SEpTd8TQDZh2U0L3dSYRkNWUQdjx7y/im6GowKCmYQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.54.3.tgz",
+      "integrity": "sha512-mvKzjeglqLFBKaJQk7TilglBbo9llbnneJ4zYp2HeCQUVauPzTLNGlkMJafbdlBhXvsREUpbaF1WbIf3js7JnQ==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-icon": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-icon": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.52.3.tgz",
-      "integrity": "sha512-aa2weMcI2l49UJta+kc6gRYAx/EC06/51Vk27ykkevrwtHeZjq7PEN3lhzfYS1qdBo5Lnkt1MLb/MBkdwG4mSg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.54.3.tgz",
+      "integrity": "sha512-6/+IT4SjZbGxewW1gpaFQ/FlSMdDdL2lPWFLGHuH2WTIhtZGxksXbiR2avfMgYQ0w3l9FNpA/5wgVXlKVdlSpg==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.52.3",
+        "@contentful/f36-text-link": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.52.3.tgz",
-      "integrity": "sha512-FuxBv9UiNekwi5ryJdEKg2S7eti+KF++2dISLUacPJyqmgPT2tGudqLc3t8QBclmLlPWEHtayg4BTZ8MmKexrQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.54.3.tgz",
+      "integrity": "sha512-fY2X2O2H2Z7wtfhyMtHqFtuyKRKqSXBiM8+4NrEuD9u++EoV+T903HgKwMvDRuoMifep+BVsmtkQdH6M39nmPA==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-forms": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-forms": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.52.3.tgz",
-      "integrity": "sha512-eHzs6renbheOT8YqwIt+jb3dm+58pcRFmF1WY123/OadLlvngfQcJQOtJKBTQ8hB2+Iupzoj1QT678U3GKZ8Gg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.54.3.tgz",
+      "integrity": "sha512-8yIE5581ZCcJz+BzajDZpKni4eTV720wkuQo80y3XBLkh/JTugZZMjNqzhYjsSj2M+0F7HYVou60gdO6t3B++Q==",
       "requires": {
-        "@contentful/f36-button": "^4.52.3",
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-drag-handle": "^4.52.3",
+        "@contentful/f36-button": "^4.54.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-drag-handle": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.52.3",
+        "@contentful/f36-tooltip": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.52.3.tgz",
-      "integrity": "sha512-hCc+Ax1fkWQ8F2PrEt/x2KLHIUa+VoeuPRUQyTQjiUMpzdZOQa9qja7IPoKO8MklNjlnquLJAAto8NPe6Cuqgg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.54.3.tgz",
+      "integrity": "sha512-tXTbqMo8GMVy/iQAzhRQ21DuUoWyR4LKbrW/2c6bwMe+9MfQYYuuDdofoLD673qLadT/7AYENmUk9KiMhev6yA==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.23.2",
         "@popperjs/core": "^2.11.5",
@@ -25996,55 +24725,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.52.3.tgz",
-      "integrity": "sha512-nJspEE6CTPduiAoCdVR2jDA8b0Om8LMIp32UjcPwxEczHvHfTpoNLDa1g39pSSFtMlk/en4jtRqHTUKn2yMIsw==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.54.3.tgz",
+      "integrity": "sha512-JetaqBsiyPNcMxRIm4OO0w/6tSxAUvUlXrzZFhBbV8SgHq2oP8RniJtraC5nlIMxKVRjHQd+QQtQsi9sI5DAUw==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
-        "@contentful/f36-table": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
+        "@contentful/f36-table": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.52.3.tgz",
-      "integrity": "sha512-zLJ0YVIFqPN7wCFr3CFkfb2b/q6pAKqdSOa2yGm8BEQ+Rz7ERkSmj9x394Q3BhFPXQ3pjIppQ5uPiTbmUnXXTA==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.54.3.tgz",
+      "integrity": "sha512-Oj6hPrNFigjq7/91fvqhNgcu3ldLO0eeS3y1dBXNVlZ28LYt2kfgD/YJW3cFeFoQbEjhIghl2wRnn8dvLlQnbQ==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.52.3.tgz",
-      "integrity": "sha512-BhwZq03uBsloDmq6931n9vRA8tztsHgBVEkDiUq5aHCrHp6tXbsxwHHveDXRQO5G7uhllF6aW8CLLbTNBbdk7Q==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.54.3.tgz",
+      "integrity": "sha512-J4zBqgAAuMxZB9YyVvttpNQcRMpVU1/nC8QSQpak96//QkEF4iQJyuF2K9lYb+ISYVDT1/CyNQv/BgQI1zKWxQ==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.52.3",
+        "@contentful/f36-typography": "^4.54.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.52.3.tgz",
-      "integrity": "sha512-aKUNkEQY+f1xE4hz5DOCDpwHcC72YAPd2QxOiCxl0u0uFgUvV7aqmLjEthL4h9Q4sWO/pQpVOPjhvcJJxTIgMQ==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.54.3.tgz",
+      "integrity": "sha512-bkrQ+0UjO15BYzhLuOEHyiAHrUwEzTW9tWYH/EOr3MtnkkP12Dx6+NREu2gi0GwPsbKt2zFsTdaAdnarva7kGQ==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.52.3.tgz",
-      "integrity": "sha512-2hz0RzvNXw9u+jmKVFYHEwEuwZgO/Ac8fHMYzVJ3t3HsPV1gIr/ediXeFEJUZiO3VsAIzqp3j0XjV9SK4IItGg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.54.3.tgz",
+      "integrity": "sha512-tN1oMgcWC+zaE0fdQucFPqk3We/TAgKPp9r1Ff3r1bufMc6n0NEnGEqefcdSejwU1uPKFaX8zZ6MdWDWUV9WfA==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
@@ -26055,11 +24784,11 @@
       "integrity": "sha512-sM2AM/8Qn4K0mm2H14nDJMIYoAUv7+tHGUyGqnXEyOVD/5O9lzLTkELEA9R0UgtPPcTywCYC6aZCCggy/Ezd/g=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.52.3.tgz",
-      "integrity": "sha512-0xOq5FF7Uv+VcI2+yGs4iBz6Ti3iOLO68EFsnBP3PVvKL3Qc0e8IQBp/oBC8z4e/rqn0w8qDxRJ9abOSRK6n9g==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.54.3.tgz",
+      "integrity": "sha512-I839wA5RGd6jBzUEmV/S79Y+2MpUlDf6bEwJqafXUALvlK4OGmBAFdAbbLSbQYuLurvo6jPkYEZvLGPUJuZHfg==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-utils": "^4.23.2",
         "@popperjs/core": "^2.11.5",
@@ -26069,11 +24798,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.52.3.tgz",
-      "integrity": "sha512-ojbwmJ4W1Sb6hvquZ0YeZDj1r2/r7YgRHx0+th7QjHWpBGTGfXlHr7P0SF2c5VoeDpOcma3RaT+i3BYoix03Qg==",
+      "version": "4.54.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.54.3.tgz",
+      "integrity": "sha512-50PG2sDKwki8y2LqnfEqC6QhQSOxTHcAILbv1yO+BV7I+oMVvhEPXUTBWPXtaxqapi1J01rFqEU1NSjoMpRqfg==",
       "requires": {
-        "@contentful/f36-core": "^4.52.3",
+        "@contentful/f36-core": "^4.54.3",
         "@contentful/f36-tokens": "^4.0.2",
         "emotion": "^10.0.17"
       }
@@ -26111,28 +24840,6 @@
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "nanoid": "^3.1.3"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-checkbox": {
@@ -26145,28 +24852,6 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-date": {
@@ -26179,28 +24864,6 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "moment": "^2.20.0"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-dropdown": {
@@ -26214,28 +24877,6 @@
         "emotion": "^10.0.0",
         "lodash": "^4.17.15",
         "nanoid": "^3.1.3"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-json": {
@@ -26255,36 +24896,16 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        },
         "@uiw/react-codemirror": {
-          "version": "4.21.19",
-          "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.19.tgz",
-          "integrity": "sha512-KCm+izhkeRCz9uuPY4WtlMAwEE6HsGR/iHGFDABj2OFq9DfnpAIFyVx2Z87NxMHvHi7zttn6JerxwNLJdV12og==",
+          "version": "4.21.21",
+          "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.21.tgz",
+          "integrity": "sha512-PaxBMarufMWoR0qc5zuvBSt76rJ9POm9qoOaJbqRmnNL2viaF+d+Paf2blPSlm1JSnqn7hlRjio+40nZJ9TKzw==",
           "requires": {
             "@babel/runtime": "^7.18.6",
             "@codemirror/commands": "^6.1.0",
             "@codemirror/state": "^6.1.1",
             "@codemirror/theme-one-dark": "^6.0.0",
-            "@uiw/codemirror-extensions-basic-setup": "4.21.19",
+            "@uiw/codemirror-extensions-basic-setup": "4.21.21",
             "codemirror": "^6.0.0"
           }
         },
@@ -26314,34 +24935,12 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-location": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.5.tgz",
-      "integrity": "sha512-P5YfJX0qmCZRvrvsPqCt3kUlSMyYBVChoJzOJEzzOwGcRg1xtjy7pFmgVy1OkBX771hEuRyc71BIrg4gWHcrAg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.6.tgz",
+      "integrity": "sha512-bQ0IUSpC5X4KMzDOVG6VK3/JOn/hM8yoVlpU7Rqnv2jllCkx1dbDYQ98VV3DzC7jkSs631DVP353eiKne3eqWA==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
@@ -26353,26 +24952,6 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        },
         "google-map-react": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.2.0.tgz",
@@ -26382,6 +24961,36 @@
             "@mapbox/point-geometry": "^0.1.0",
             "eventemitter3": "^4.0.4",
             "prop-types": "^15.7.2"
+          }
+        }
+      }
+    },
+    "@contentful/field-editor-markdown": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.5.3.tgz",
+      "integrity": "sha512-MdSrkoH+0iKD1KgCv5p8ViE186z0TleFF+F/hx2QJmBf3xxdMxPok01OmbyttTLQtBBz2XMsTF35NQT8OrclBA==",
+      "requires": {
+        "@contentful/f36-components": "^4.0.27",
+        "@contentful/f36-icons": "^4.1.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.4.2",
+        "@types/codemirror": "0.0.109",
+        "codemirror": "^5.65.11",
+        "constate": "^3.2.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "react-markdown": "^8.0.7",
+        "rehype-raw": "^6.1.1",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^3.0.1"
+      },
+      "dependencies": {
+        "@types/codemirror": {
+          "version": "0.0.109",
+          "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
+          "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
+          "requires": {
+            "@types/tern": "*"
           }
         }
       }
@@ -26396,28 +25005,6 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-number": {
@@ -26429,28 +25016,6 @@
         "@contentful/f36-tokens": "^4.0.0",
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-radio": {
@@ -26465,28 +25030,6 @@
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "nanoid": "^3.1.3"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-rating": {
@@ -26499,28 +25042,74 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
+      }
+    },
+    "@contentful/field-editor-reference": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.20.0.tgz",
+      "integrity": "sha512-LMTBniTIEV63sdz9zdmQOSl70awe0scUQwKWuWQN/nnB2qeMRc2ypZdo3j+NkKGHut//WssSYoKxg8tSQYLpUg==",
+      "requires": {
+        "@contentful/f36-components": "^4.0.27",
+        "@contentful/f36-icons": "^4.1.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.4.2",
+        "@contentful/mimetype": "^1.4.0",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@tanstack/react-query": "^4.3.9",
+        "@types/deep-equal": "^1.0.1",
+        "constate": "3.2.0",
+        "contentful-management": "^10.14.0",
+        "deep-equal": "2.2.2",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "moment": "^2.20.0",
+        "p-queue": "^4.0.0",
+        "react-intersection-observer": "9.4.0",
+        "type-fest": "2.17.0"
       },
       "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
+        "@dnd-kit/sortable": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+          "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
           "requires": {
-            "contentful-management": ">=7.30.0"
+            "@dnd-kit/utilities": "^3.2.0",
+            "tslib": "^2.0.0"
           }
         },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
+        "@tanstack/react-query": {
+          "version": "4.36.1",
+          "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
+          "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
           "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
+            "@tanstack/query-core": "4.36.1",
+            "use-sync-external-store": "^1.2.0"
           }
+        },
+        "constate": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/constate/-/constate-3.2.0.tgz",
+          "integrity": "sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==",
+          "requires": {}
+        },
+        "type-fest": {
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
+          "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA=="
         }
+      }
+    },
+    "@contentful/field-editor-shared": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
+      "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
+      "requires": {
+        "@contentful/f36-note": "^4.2.8",
+        "@contentful/f36-tokens": "^4.0.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-single-line": {
@@ -26533,28 +25122,6 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-tags": {
@@ -26573,26 +25140,6 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        },
         "@dnd-kit/sortable": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
@@ -26614,28 +25161,6 @@
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/field-editor-validation-errors": {
@@ -26648,28 +25173,6 @@
         "@contentful/f36-tokens": "^4.0.0",
         "@contentful/field-editor-shared": "^1.4.2",
         "emotion": "^10.0.17"
-      },
-      "dependencies": {
-        "@contentful/app-sdk": {
-          "version": "4.23.1",
-          "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
-          "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
-          "peer": true,
-          "requires": {
-            "contentful-management": ">=7.30.0"
-          }
-        },
-        "@contentful/field-editor-shared": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.4.2.tgz",
-          "integrity": "sha512-N0R7dPdR+CoVyxhG6CahcpJTjuZasytQPl0yRlOtOd9SvWEvBqc4/s/r27Dip/s6RNa8YBNlAfZvayxpdClQOw==",
-          "requires": {
-            "@contentful/f36-note": "^4.2.8",
-            "@contentful/f36-tokens": "^4.0.0",
-            "emotion": "^10.0.17",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@contentful/mimetype": {
@@ -26828,20 +25331,20 @@
       "requires": {}
     },
     "@dnd-kit/accessibility": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
-      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
       "requires": {
         "tslib": "^2.0.0"
       }
     },
     "@dnd-kit/core": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
-      "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
       "requires": {
-        "@dnd-kit/accessibility": "^3.0.0",
-        "@dnd-kit/utilities": "^3.2.1",
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       }
     },
@@ -26855,9 +25358,9 @@
       }
     },
     "@dnd-kit/utilities": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.1.tgz",
-      "integrity": "sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -26902,17 +25405,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/serialize": {
       "version": "0.11.16",
@@ -28402,9 +26905,9 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
-      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "requires": {
         "@types/ms": "*"
       }
@@ -28475,9 +26978,9 @@
       }
     },
     "@types/hast": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.6.tgz",
-      "integrity": "sha512-47rJE80oqPmFdVDCD7IheXBrVdwuBgsYwoczFvKmwfo2Mzsnt+V9OONsYauFmICb6lQPpCuXYJWejBNs4pDJRg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.8.tgz",
+      "integrity": "sha512-aMIqAlFd2wTIDZuvLbhUT+TGvMxrNC8ECUIVtH6xxy0sQLs3iu6NO8Kp/VT5je7i5ufnebXzdV1dNDMnvaH6IQ==",
       "requires": {
         "@types/unist": "^2"
       }
@@ -28577,9 +27080,9 @@
       "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "@types/mdast": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.13.tgz",
-      "integrity": "sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
       "requires": {
         "@types/unist": "^2"
       }
@@ -28590,9 +27093,9 @@
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "@types/ms": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
-      "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "@types/node": {
       "version": "16.18.58",
@@ -28663,9 +27166,9 @@
       }
     },
     "@types/react-modal": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.1.tgz",
-      "integrity": "sha512-HsH2E3luJ2hdVOAovq93x/r+CmWqbhwT8hXW05KMp3zzbSEZsBn4egnMGU/VLwScwlCRPTyZgIEPqLycaz5EOw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "requires": {
         "@types/react": "*"
       }
@@ -28751,9 +27254,9 @@
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "@types/unist": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
-      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "@types/ws": {
       "version": "8.5.4",
@@ -28892,30 +27395,29 @@
       }
     },
     "@udecode/plate-common": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-24.4.0.tgz",
-      "integrity": "sha512-5HaQQNs/4sCZBUGcJDhVTrU5OBBENLLy3bjdixfFOGydlL/5F0m7XYZoVV/zeltVSwO6GWelhHtYnk/xXn12Pw==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
+      "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
+      "peer": true,
       "requires": {
-        "@udecode/plate-core": "24.4.0",
-        "@udecode/plate-utils": "24.4.0",
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0"
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/plate-utils": "23.6.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       }
     },
     "@udecode/plate-core": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-24.4.0.tgz",
-      "integrity": "sha512-xg/ZzqpnNQmtXQBM02KMBLHczy2LpGQ2HLEjZVXWsHU1YLyiUCyVW/DCi/woPY1dSuSy60ZnVGPKnxs4Ao7zCQ==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
+      "integrity": "sha512-5nw86q3Om2TLtwo0rmMSzE5phbuoQoE9GlXxBL/oo7BYQwLWFSwqMqSxAO1doysqQ+Z8Yw5ctRtOq3kz587A0w==",
       "requires": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/utils": "19.7.1",
         "@udecode/zustood": "^1.1.3",
         "clsx": "^1.2.1",
-        "is-hotkey": "^0.2.0",
         "jotai": "1.7.2",
         "lodash": "^4.17.21",
         "nanoid": "^3.3.6",
@@ -28925,51 +27427,50 @@
       }
     },
     "@udecode/plate-utils": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-24.4.0.tgz",
-      "integrity": "sha512-mVMv1YHv8lZLUds/UF0XvF7jX73QWT1ngNGl7O/pgSdz/BfOCbxEXo3RZHRcG/uwx4ltsO0LOFhXtcYLK71qiQ==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
+      "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
+      "peer": true,
       "requires": {
         "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "24.4.0",
-        "@udecode/slate": "24.3.6",
-        "@udecode/slate-react": "24.4.0",
-        "@udecode/slate-utils": "24.3.6",
-        "@udecode/utils": "24.3.0",
-        "clsx": "^1.2.1",
-        "lodash": "^4.17.21"
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       }
     },
     "@udecode/slate": {
-      "version": "24.3.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-24.3.6.tgz",
-      "integrity": "sha512-NfIR4Qkndoba/Ncw+nZ4fNPcd/F+mAHtoOqunRtZR5HdOJN1uBGnSK39duvZST/iB78nPueAVG5hrZ3awGcb4w==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
+      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
       "requires": {
-        "@udecode/utils": "24.3.0"
+        "@udecode/utils": "19.7.1"
       }
     },
     "@udecode/slate-react": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-24.4.0.tgz",
-      "integrity": "sha512-qQ+k6j5a5n0NIVGhgCpK8AbAFN+dxYtQLvbQEIoqr4vWtq9zR9PvJTuPurD8UWATt+ngJ7B1gC6bvSwMh8Uikg==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
+      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
       "requires": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/utils": "24.3.0"
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1"
       }
     },
     "@udecode/slate-utils": {
-      "version": "24.3.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-24.3.6.tgz",
-      "integrity": "sha512-bYyj0UYn6pWF1jqraWNQFxhLnUsPcbgrv6MDDKu6I8RlUkrc/ykGaRSoQLwJdRaRmLc4xivUrOnJXLyMfadqLQ==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
+      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
       "requires": {
-        "@udecode/slate": "24.3.6",
-        "@udecode/utils": "24.3.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1",
         "lodash": "^4.17.21"
       }
     },
     "@udecode/utils": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-24.3.0.tgz",
-      "integrity": "sha512-/Y2lh/Ih1wx4zN35Ky2Z1G1/5f7cSAS7F6dkhrcbJUnDF0srTidoEIRabK+og/yIK/MCEFfOsQGetoV7Ert5hg=="
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-19.7.1.tgz",
+      "integrity": "sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ=="
     },
     "@udecode/zustood": {
       "version": "1.1.3",
@@ -28998,9 +27499,9 @@
       }
     },
     "@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.19",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.19.tgz",
-      "integrity": "sha512-FwnzjNSc1mbzlcOlGmZgK2JMFcmPSHDeDUoql4ioyffF6ytiUD6LB9exOlQlAppzAZkKBYHqBwBjd0gdJYpH/w==",
+      "version": "4.21.21",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.21.tgz",
+      "integrity": "sha512-+0i9dPrRSa8Mf0CvyrMvnAhajnqwsP3IMRRlaHDRgsSGL8igc4z7MhvUPn+7cWFAAqWzQRhMdMSWzo6/TEa3EA==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -30209,9 +28710,9 @@
       }
     },
     "codemirror": {
-      "version": "5.65.15",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
-      "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -30342,6 +28843,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
       "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA=="
+    },
+    "constate": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/constate/-/constate-3.3.2.tgz",
+      "integrity": "sha512-ZnEWiwU6QUTil41D5EGpA7pbqAPGvnR9kBjko8DzVIxpC60mdNKrP568tT5WLJPAxAOtJqJw60+h79ot/Uz1+Q==",
+      "requires": {}
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -32512,9 +31019,9 @@
       }
     },
     "hast-util-sanitize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.0.tgz",
-      "integrity": "sha512-L0g/qhOA82zG2hA3O29hnlv4mLU7YVVT1if5JZSr2tKO1ywkQbuMDcN05btgX0HtpqDXQniAM0ar0K+Lv4MDBQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.1.tgz",
+      "integrity": "sha512-IGrgWLuip4O2nq5CugXy4GI2V8kx4sFVy5Hd4vF7AR2gxS0N9s7nEAVUyeMtZKZvzrxVsHt73XdTsno1tClIkQ==",
       "requires": {
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.2.0",
@@ -32522,17 +31029,17 @@
       },
       "dependencies": {
         "@types/hast": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
-          "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+          "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
           "requires": {
             "@types/unist": "*"
           }
         },
         "@types/unist": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
         },
         "unist-util-position": {
           "version": "5.0.0",
@@ -37001,9 +35508,9 @@
       }
     },
     "property-information": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
-      "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -37118,9 +35625,9 @@
       }
     },
     "react-animate-height": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.2.tgz",
-      "integrity": "sha512-uUOS+RhYVgyJEWcuAJgelVwhcJ2chsMk7HZCpu+wtjSlFAGSFsHU0r4lMTt47HQ1RdQfI5MmFRt43yHTP9lfmQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "requires": {}
     },
     "react-app-polyfill": {
@@ -37145,9 +35652,9 @@
       }
     },
     "react-day-picker": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.2.tgz",
-      "integrity": "sha512-sK5M5PNZaLiszmACUKUpVu1eX3eFDVV+WLdWQ3BxTPbEC9jhuawmlgpbSXX5dIIQQwJpZ4wwP5+vsMVOwa1IRw==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.9.1.tgz",
+      "integrity": "sha512-W0SPApKIsYq+XCtfGeMYDoU0KbsG3wfkYtlw8l+vZp6KoBXGOlhzBUp4tNx1XiwiOZwhfdGOlj7NGSCKGSlg5Q==",
       "requires": {}
     },
     "react-dev-utils": {
@@ -37201,6 +35708,17 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-error-overlay": {
@@ -37209,9 +35727,9 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
       "version": "2.9.5",
@@ -37507,9 +36025,9 @@
       },
       "dependencies": {
         "@types/hast": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
-          "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+          "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
           "requires": {
             "@types/unist": "*"
           }
@@ -37800,12 +36318,12 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "peer": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -38047,9 +36565,9 @@
       }
     },
     "slate-history": {
-      "version": "0.93.0",
-      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.93.0.tgz",
-      "integrity": "sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
+      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
       "peer": true,
       "requires": {
         "is-plain-object": "^5.0.0"
@@ -38064,9 +36582,9 @@
       }
     },
     "slate-react": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.99.0.tgz",
-      "integrity": "sha512-E+mU87L5epS/Cj9Z35aRkTEMrBXdX8URbFh8B2zTq2DDQKn+MT6/ag41g1InMdRoQ/kipGsbtcrM8dEicY8o/Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.95.0.tgz",
+      "integrity": "sha512-nOk6SMcHfrahzUV60qtKBSgPuZxgH2p+vKC2IcmjWAq8ScBEdLL4UB/dZBE2tZjsrxyloWQklGh3RQO5u+SbUg==",
       "peer": true,
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
@@ -38365,9 +36883,9 @@
       "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "style-to-object": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.2.tgz",
-      "integrity": "sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
       "requires": {
         "inline-style-parser": "0.1.1"
       }

--- a/apps/flexfields/package-lock.json
+++ b/apps/flexfields/package-lock.json
@@ -10,13 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "4.23.1",
-        "@contentful/default-field-editors": "^1.5.24",
+        "@contentful/default-field-editors": "^1.5.25",
         "@contentful/f36-components": "4.54.3",
         "@contentful/f36-multiselect": "^4.21.0",
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
         "@contentful/react-apps-toolkit": "1.2.16",
-        "@udecode/plate-common": "23.6.0",
         "contentful-management": "10.46.4",
         "emotion": "10.0.27",
         "react": "17.0.2",
@@ -34,9 +33,6 @@
         "@types/react-dom": "18.0.3",
         "cross-env": "7.0.3",
         "typescript": "4.9.5"
-      },
-      "peerDependencies": {
-        "@udecode/plate-common": "23.6.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2121,9 +2117,9 @@
       }
     },
     "node_modules/@contentful/default-field-editors": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.24.tgz",
-      "integrity": "sha512-lckpAkC02amkpc65hD2iopo2P1rDDSDj5Jkn8JDhGwIZZ7tdwV3/oBzwUn2k/6j8/OYAIRCWm6e22OqdmmCKJw==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.25.tgz",
+      "integrity": "sha512-8rNXV7dh72ErW9XbF48PzW0mdaEtCbuVR3ILxfyRV1Nzt33oRWBHOTgv9NXme0p0dA5AEHMS+/MVcwg0rUN6yA==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/field-editor-boolean": "^1.4.2",
@@ -2139,7 +2135,7 @@
         "@contentful/field-editor-radio": "^1.4.2",
         "@contentful/field-editor-rating": "^1.4.2",
         "@contentful/field-editor-reference": "^5.20.0",
-        "@contentful/field-editor-rich-text": "^3.16.1",
+        "@contentful/field-editor-rich-text": "^3.16.2",
         "@contentful/field-editor-shared": "^1.4.2",
         "@contentful/field-editor-single-line": "^1.3.4",
         "@contentful/field-editor-slug": "^1.4.2",
@@ -2154,9 +2150,9 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.1.tgz",
-      "integrity": "sha512-YFicYD1yDzE5q+8g7dvtX9ZgHUtrv4+qA5pEO74YDngfd/131QNNBjeGi0fMlJunwZJjHopFwICtnXvB29UAWw==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.2.tgz",
+      "integrity": "sha512-6TsgaZQRz3CB+1NbJEtRR4UGpfORxv6621NsyjNjsOxV/3zg4e6JrHtTeARQ6raM+dNvlV+6yfH0aL0GPrPrmA==",
       "dependencies": {
         "@contentful/app-sdk": "^4.21.1",
         "@contentful/contentful-slatejs-adapter": "^15.16.5",
@@ -2171,6 +2167,7 @@
         "@popperjs/core": "^2.11.5",
         "@udecode/plate-basic-marks": "23.7.0",
         "@udecode/plate-break": "23.7.0",
+        "@udecode/plate-common": "23.7.0",
         "@udecode/plate-core": "23.6.0",
         "@udecode/plate-list": "23.7.0",
         "@udecode/plate-paragraph": "23.7.0",
@@ -2209,46 +2206,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-23.7.0.tgz",
@@ -2264,7 +2221,7 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break/node_modules/@udecode/plate-common": {
+    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-common": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
       "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
@@ -2284,7 +2241,7 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
+    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
       "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
@@ -2320,92 +2277,12 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-23.7.0.tgz",
       "integrity": "sha512-au8KiBgqouEWnJGofLq9VnDDKgUzgWy+vq048jZ0OCZUQVycY8tXGKQR2hZy8atNmcxSTBN4gRAscoNB7oC+ug==",
       "dependencies": {
         "@udecode/plate-common": "23.7.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2430,92 +2307,12 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-23.7.0.tgz",
       "integrity": "sha512-ROTbCRNvypRi15BB8FMYxLJJnyXBEVZGDuBKNoee47IJ8shtts9VGmTe81mXYN7sVwTSPp7eQixha3/533m6JQ==",
       "dependencies": {
         "@udecode/plate-common": "23.7.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2545,46 +2342,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
         "slate-react": ">=0.95.0"
       }
     },
@@ -2668,46 +2425,6 @@
         "slate-react": ">=0.95.0"
       }
     },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table": {
       "version": "23.7.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-23.7.0.tgz",
@@ -2722,46 +2439,6 @@
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-react": ">=0.98.1"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table/node_modules/@udecode/plate-resizable": {
@@ -2785,46 +2462,6 @@
       "integrity": "sha512-ea+rAyhdt+A/QnU6d7L0G6kLuygdSDtyFVkPQ47S/hGpzPMEqeDEzgDWmL/XrJY+3JsCBt/mfK/zYmxFyilZZA==",
       "dependencies": {
         "@udecode/plate-common": "23.7.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block/node_modules/@udecode/plate-common": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.7.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block/node_modules/@udecode/plate-common/node_modules/@udecode/plate-utils": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -7028,26 +6665,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@udecode/plate-common": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
-      "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
-      "dependencies": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
     "node_modules/@udecode/plate-core": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
@@ -7064,26 +6681,6 @@
         "react-hotkeys-hook": "^4.4.1",
         "use-deep-compare": "^1.1.0",
         "zustand": "^3.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.95.0"
-      }
-    },
-    "node_modules/@udecode/plate-utils": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
-      "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -23761,9 +23358,9 @@
       }
     },
     "@contentful/default-field-editors": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.24.tgz",
-      "integrity": "sha512-lckpAkC02amkpc65hD2iopo2P1rDDSDj5Jkn8JDhGwIZZ7tdwV3/oBzwUn2k/6j8/OYAIRCWm6e22OqdmmCKJw==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.5.25.tgz",
+      "integrity": "sha512-8rNXV7dh72ErW9XbF48PzW0mdaEtCbuVR3ILxfyRV1Nzt33oRWBHOTgv9NXme0p0dA5AEHMS+/MVcwg0rUN6yA==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/field-editor-boolean": "^1.4.2",
@@ -23779,7 +23376,7 @@
         "@contentful/field-editor-radio": "^1.4.2",
         "@contentful/field-editor-rating": "^1.4.2",
         "@contentful/field-editor-reference": "^5.20.0",
-        "@contentful/field-editor-rich-text": "^3.16.1",
+        "@contentful/field-editor-rich-text": "^3.16.2",
         "@contentful/field-editor-shared": "^1.4.2",
         "@contentful/field-editor-single-line": "^1.3.4",
         "@contentful/field-editor-slug": "^1.4.2",
@@ -23791,9 +23388,9 @@
       },
       "dependencies": {
         "@contentful/field-editor-rich-text": {
-          "version": "3.16.1",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.1.tgz",
-          "integrity": "sha512-YFicYD1yDzE5q+8g7dvtX9ZgHUtrv4+qA5pEO74YDngfd/131QNNBjeGi0fMlJunwZJjHopFwICtnXvB29UAWw==",
+          "version": "3.16.2",
+          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.16.2.tgz",
+          "integrity": "sha512-6TsgaZQRz3CB+1NbJEtRR4UGpfORxv6621NsyjNjsOxV/3zg4e6JrHtTeARQ6raM+dNvlV+6yfH0aL0GPrPrmA==",
           "requires": {
             "@contentful/app-sdk": "^4.21.1",
             "@contentful/contentful-slatejs-adapter": "^15.16.5",
@@ -23808,6 +23405,7 @@
             "@popperjs/core": "^2.11.5",
             "@udecode/plate-basic-marks": "23.7.0",
             "@udecode/plate-break": "23.7.0",
+            "@udecode/plate-common": "23.7.0",
             "@udecode/plate-core": "23.6.0",
             "@udecode/plate-list": "23.7.0",
             "@udecode/plate-paragraph": "23.7.0",
@@ -23833,36 +23431,6 @@
               "integrity": "sha512-lEtenuSl9EXcMYN9lhe8bPXjLT0PbsQPpo//HvMjDMxIDGDV0YK/zfmPdsBaQQH/MwbdeUrdNaNnikDBA4rjxA==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-break": {
@@ -23871,34 +23439,32 @@
               "integrity": "sha512-RL1pYofmQewMbE2M9a91x3DMMdSuSagayvnwgPwlJWalLcE5QivwbD63otvroPZcpky+9ULp+I7TI/TCg3uVZg==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
+              }
+            },
+            "@udecode/plate-common": {
+              "version": "23.7.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
+              "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
+              "requires": {
+                "@udecode/plate-core": "23.6.0",
+                "@udecode/plate-utils": "23.7.0",
+                "@udecode/slate": "22.0.2",
+                "@udecode/slate-react": "22.0.2",
+                "@udecode/slate-utils": "22.0.2",
+                "@udecode/utils": "19.7.1"
               },
               "dependencies": {
-                "@udecode/plate-common": {
+                "@udecode/plate-utils": {
                   "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
+                  "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
+                  "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
                   "requires": {
+                    "@radix-ui/react-slot": "^1.0.2",
                     "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
                     "@udecode/slate": "22.0.2",
                     "@udecode/slate-react": "22.0.2",
                     "@udecode/slate-utils": "22.0.2",
                     "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
                   }
                 }
               }
@@ -23910,36 +23476,6 @@
               "requires": {
                 "@udecode/plate-common": "23.7.0",
                 "@udecode/plate-reset-node": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-paragraph": {
@@ -23948,36 +23484,6 @@
               "integrity": "sha512-au8KiBgqouEWnJGofLq9VnDDKgUzgWy+vq048jZ0OCZUQVycY8tXGKQR2hZy8atNmcxSTBN4gRAscoNB7oC+ug==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-reset-node": {
@@ -23986,36 +23492,6 @@
               "integrity": "sha512-m+PRF9kusZiE60hw4FRYTQwhbhemiMyHhC4v6G5nN7CGP3Zjmkg3bvuOZ7aqRBk5Vkvjx3wATw2ggisOtG8Fqg==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-select": {
@@ -24024,36 +23500,6 @@
               "integrity": "sha512-ROTbCRNvypRi15BB8FMYxLJJnyXBEVZGDuBKNoee47IJ8shtts9VGmTe81mXYN7sVwTSPp7eQixha3/533m6JQ==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-serializer-docx": {
@@ -24071,34 +23517,6 @@
                 "validator": "^13.9.0"
               },
               "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                },
                 "@udecode/plate-heading": {
                   "version": "23.7.0",
                   "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-23.7.0.tgz",
@@ -24143,36 +23561,6 @@
               "requires": {
                 "@udecode/plate-common": "23.7.0",
                 "html-entities": "^2.4.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@udecode/plate-table": {
@@ -24184,34 +23572,6 @@
                 "@udecode/plate-resizable": "23.7.0"
               },
               "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                },
                 "@udecode/plate-resizable": {
                   "version": "23.7.0",
                   "resolved": "https://registry.npmjs.org/@udecode/plate-resizable/-/plate-resizable-23.7.0.tgz",
@@ -24228,36 +23588,6 @@
               "integrity": "sha512-ea+rAyhdt+A/QnU6d7L0G6kLuygdSDtyFVkPQ47S/hGpzPMEqeDEzgDWmL/XrJY+3JsCBt/mfK/zYmxFyilZZA==",
               "requires": {
                 "@udecode/plate-common": "23.7.0"
-              },
-              "dependencies": {
-                "@udecode/plate-common": {
-                  "version": "23.7.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
-                  "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
-                  "requires": {
-                    "@udecode/plate-core": "23.6.0",
-                    "@udecode/plate-utils": "23.7.0",
-                    "@udecode/slate": "22.0.2",
-                    "@udecode/slate-react": "22.0.2",
-                    "@udecode/slate-utils": "22.0.2",
-                    "@udecode/utils": "19.7.1"
-                  },
-                  "dependencies": {
-                    "@udecode/plate-utils": {
-                      "version": "23.7.0",
-                      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
-                      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
-                      "requires": {
-                        "@radix-ui/react-slot": "^1.0.2",
-                        "@udecode/plate-core": "23.6.0",
-                        "@udecode/slate": "22.0.2",
-                        "@udecode/slate-react": "22.0.2",
-                        "@udecode/slate-utils": "22.0.2",
-                        "@udecode/utils": "19.7.1"
-                      }
-                    }
-                  }
-                }
               }
             },
             "slate-history": {
@@ -27392,19 +26722,6 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@udecode/plate-common": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
-      "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
-      "requires": {
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/plate-utils": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
-      }
-    },
     "@udecode/plate-core": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
@@ -27421,19 +26738,6 @@
         "react-hotkeys-hook": "^4.4.1",
         "use-deep-compare": "^1.1.0",
         "zustand": "^3.7.2"
-      }
-    },
-    "@udecode/plate-utils": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
-      "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
-      "requires": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/plate-core": "23.6.0",
-        "@udecode/slate": "22.0.2",
-        "@udecode/slate-react": "22.0.2",
-        "@udecode/slate-utils": "22.0.2",
-        "@udecode/utils": "19.7.1"
       }
     },
     "@udecode/slate": {

--- a/apps/flexfields/package-lock.json
+++ b/apps/flexfields/package-lock.json
@@ -16,6 +16,7 @@
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
         "@contentful/react-apps-toolkit": "1.2.16",
+        "@udecode/plate-common": "23.6.0",
         "contentful-management": "10.46.4",
         "emotion": "10.0.27",
         "react": "17.0.2",
@@ -7032,7 +7033,6 @@
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
       "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
-      "peer": true,
       "dependencies": {
         "@udecode/plate-core": "23.6.0",
         "@udecode/plate-utils": "23.6.0",
@@ -7078,7 +7078,6 @@
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
       "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.2",
         "@udecode/plate-core": "23.6.0",
@@ -27398,7 +27397,6 @@
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.6.0.tgz",
       "integrity": "sha512-HnbRzVUDnQBjMIivguMk7RKZGIHMBuXjbYv7dPyENiOhcvXr2ddIsn2cyRzTP82Qws5OcvvA1sXtMat2sKE/9w==",
-      "peer": true,
       "requires": {
         "@udecode/plate-core": "23.6.0",
         "@udecode/plate-utils": "23.6.0",
@@ -27430,7 +27428,6 @@
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.6.0.tgz",
       "integrity": "sha512-7IJmXf+WssNYTrG2e/X92P4hmTeDr0iNa8+3eg1gJDTiYgWfmGjYtRxZE3trcwIXob56wEpf2tgKtHDIdciCpw==",
-      "peer": true,
       "requires": {
         "@radix-ui/react-slot": "^1.0.2",
         "@udecode/plate-core": "23.6.0",

--- a/apps/flexfields/package-lock.json
+++ b/apps/flexfields/package-lock.json
@@ -36,8 +36,7 @@
         "typescript": "4.9.5"
       },
       "peerDependencies": {
-        "@udecode/plate-common": "23.6.0",
-        "slate-react": "0.95.0"
+        "@udecode/plate-common": "23.6.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/apps/flexfields/package.json
+++ b/apps/flexfields/package.json
@@ -4,21 +4,17 @@
   "license": "MIT",
   "dependencies": {
     "@contentful/app-sdk": "4.23.1",
-    "@contentful/default-field-editors": "^1.5.24",
+    "@contentful/default-field-editors": "^1.5.25",
     "@contentful/f36-components": "4.54.3",
     "@contentful/f36-multiselect": "^4.21.0",
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/f36-workbench": "^4.21.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",
-    "@udecode/plate-common": "23.6.0",
     "emotion": "10.0.27",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "5.0.1"
-  },
-  "peerDependencies": {
-    "@udecode/plate-common": "23.6.0"
   },
   "scripts": {
     "install-ci": "npm ci",

--- a/apps/flexfields/package.json
+++ b/apps/flexfields/package.json
@@ -18,8 +18,7 @@
     "react-scripts": "5.0.1"
   },
   "peerDependencies": {
-    "@udecode/plate-common": "23.6.0",
-    "slate-react": "0.95.0"
+    "@udecode/plate-common": "23.6.0"
   },
   "scripts": {
     "install-ci": "npm ci",

--- a/apps/flexfields/package.json
+++ b/apps/flexfields/package.json
@@ -11,6 +11,7 @@
     "@contentful/f36-workbench": "^4.21.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",
+    "@udecode/plate-common": "23.6.0",
     "emotion": "10.0.27",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/apps/flexfields/package.json
+++ b/apps/flexfields/package.json
@@ -3,19 +3,22 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@contentful/app-sdk": "4.14.1",
-    "@contentful/default-field-editors": "^1.5.8",
-    "@contentful/f36-components": "4.52.3",
-    "@contentful/f36-multiselect": "^4.20.12",
+    "@contentful/app-sdk": "4.23.1",
+    "@contentful/default-field-editors": "^1.5.24",
+    "@contentful/f36-components": "4.54.3",
+    "@contentful/f36-multiselect": "^4.21.0",
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/f36-workbench": "^4.21.0",
     "@contentful/react-apps-toolkit": "1.2.16",
-    "@udecode/plate-common": "^24.3.6",
     "contentful-management": "10.46.4",
     "emotion": "10.0.27",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "5.0.1"
+  },
+  "peerDependencies": {
+    "@udecode/plate-common": "23.6.0",
+    "slate-react": "0.95.0"
   },
   "scripts": {
     "install-ci": "npm ci",

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -17,7 +17,6 @@ interface DefaultFieldProps {
 // Render default contentful fields using Forma 36 Component
 const DefaultField = (props: DefaultFieldProps) => {
   const { name, sdk, widgetId } = props;
-  console.log("widgetId",widgetId)
   return (
     <FieldWrapper sdk={sdk} name={name} showFocusBar={true}>
       <Field sdk={sdk} widgetId={widgetId!} />

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EditorExtensionSDK } from "@contentful/app-sdk";
+import { EditorAppSDK } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { Field, FieldWrapper } from "@contentful/default-field-editors";
 import { Workbench } from "@contentful/f36-workbench";
@@ -17,6 +17,7 @@ interface DefaultFieldProps {
 // Render default contentful fields using Forma 36 Component
 const DefaultField = (props: DefaultFieldProps) => {
   const { name, sdk, widgetId } = props;
+  console.log("widgetId",widgetId)
   return (
     <FieldWrapper sdk={sdk} name={name} showFocusBar={true}>
       <Field sdk={sdk} widgetId={widgetId!} />
@@ -25,7 +26,7 @@ const DefaultField = (props: DefaultFieldProps) => {
 };
 
 const EntryEditor = () => {
-  const sdk = useSDK<EditorExtensionSDK>();
+  const sdk = useSDK<EditorAppSDK>();
   const entryId = sdk.entry.getSys().id;
   const isFirstLoad = useRef(true);
   const [editorFields, setEditorFields] = useState(
@@ -62,7 +63,7 @@ const EntryEditor = () => {
             // ev.target.id looks like fieldId-locale-contentTypeId
             const fieldId = id.split("-")[0];
             const entryFieldsCopy: any = { ...sdk.entry.fields };
-            entryFieldsCopy[fieldId] = { ...entryFieldsCopy[fieldId], value };
+              entryFieldsCopy[fieldId] = { ...entryFieldsCopy[fieldId], value };
 
             setEditorFields(
               calculateEditorFields(
@@ -79,7 +80,6 @@ const EntryEditor = () => {
               (control) => control.fieldId === field.id
             );
             const widgetId = control?.widgetId || null;
-
             return (
               <DefaultField
                 key={field.id}


### PR DESCRIPTION
## Purpose

Due to dependency issues with the richtextfield component in `default-field-editors`. This was fixed with a pr to the rich-text package to add the missing `@plate/common` dependency. 

This fix bumps the version number of `default-field-editors` to fix the rendering issue