### PR TITLE
fix: update isRuleValid to run getValue if it exists on the field

### DIFF
--- a/apps/flexfields/src/utils.ts
+++ b/apps/flexfields/src/utils.ts
@@ -46,8 +46,7 @@ export const isRuleValid = (
 
   //get content type field value
   const contentTypeFieldValue =
-    entryFields[contentTypeField].value ||
-    entryFields[contentTypeField].getValue();
+  entryFields[contentTypeField].value || entryFields[contentTypeField].getValue?.();
 
   switch (condition) {
     case "is equal":


### PR DESCRIPTION
## Purpose

Flexfields tries to call `.getValue` on a field when `.value` is falsey. If a field that does not have `.getValue`, but they have an empty field, it will try to call`.getValue` resulting in an error.

## Approach

Putting a `?` before invocation allows typescript to null-check if the method exists and then run it. So instead of `.getValue()` it is now `.getValue?.()`
