### PR TITLE
ci: only lint PRs that target the main branch

### DIFF
--- a/.github/workflows/lint-pull-requests.yml
+++ b/.github/workflows/lint-pull-requests.yml
@@ -6,11 +6,11 @@ on:
       - opened
       - edited
       - synchronize
+    branches:
+      - 'main'
 
 permissions:
   pull-requests: read
-  branches:
-  - 'main'
 
 jobs:
   main:

--- a/.github/workflows/lint-pull-requests.yml
+++ b/.github/workflows/lint-pull-requests.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   pull-requests: read
+  branches:
+  - 'main'
 
 jobs:
   main:


### PR DESCRIPTION
## Purpose

Linting PR rules were targeting our deploy (when we merge main into production). But we don't care about this. We only care about linting merges into the `main` branch.

Example failure: https://github.com/contentful/marketplace-partner-apps/actions/runs/7121013328/job/19389425649

## Approach

Scope to main. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
