### PR TITLE
chore: bump ecommerce-app-base in shopify app

### DIFF
--- a/apps/shopify/package-lock.json
+++ b/apps/shopify/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/shopify-sku",
       "version": "1.0.1",
       "dependencies": {
-        "@contentful/ecommerce-app-base": "^3.3.0",
+        "@contentful/ecommerce-app-base": "^3.4.8",
         "@contentful/f36-components": "^4.48.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.2",
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/@contentful/ecommerce-app-base": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.4.6.tgz",
-      "integrity": "sha512-VwkRwig/TO8u+VxX2xYnBryHQiIpFqhoMdHbpBliX6vZxew9Eyr12AOsNyJpdpDACqi082zpJ+xZCQZVFwu0YA==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.4.8.tgz",
+      "integrity": "sha512-7QWkvtNd0uM+b+jWY8YKUuKHduLI160Ip8UJDqm17WFwzjHkZ5QW/wFUgcoT3Sb5wUmgfJlt1hSVCBi1K+TbJw==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -20030,9 +20030,9 @@
       }
     },
     "@contentful/ecommerce-app-base": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.4.6.tgz",
-      "integrity": "sha512-VwkRwig/TO8u+VxX2xYnBryHQiIpFqhoMdHbpBliX6vZxew9Eyr12AOsNyJpdpDACqi082zpJ+xZCQZVFwu0YA==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.4.8.tgz",
+      "integrity": "sha512-7QWkvtNd0uM+b+jWY8YKUuKHduLI160Ip8UJDqm17WFwzjHkZ5QW/wFUgcoT3Sb5wUmgfJlt1hSVCBi1K+TbJw==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "5.0.1"
   },
   "dependencies": {
-    "@contentful/ecommerce-app-base": "^3.3.0",
+    "@contentful/ecommerce-app-base": "^3.4.8",
     "@contentful/f36-components": "^4.48.1",
     "@contentful/f36-icons": "^4.27.0",
     "@contentful/f36-tokens": "^4.0.2",


### PR DESCRIPTION
## Purpose

Bump `ecommerce-base-app` dependency in Shopify app to take advantage of the changes to that package, including [this PR](https://github.com/contentful/apps/pull/5683)

## Approach

## Testing steps

Verified that the config page and field location render as expected.

## Breaking Changes

## Dependencies and/or References

## Deployment
