### PR TITLE
fix: update copy for store url [INTEG-1440]

### DIFF
--- a/apps/shopify/src/index.js
+++ b/apps/shopify/src/index.js
@@ -64,7 +64,7 @@ export function validateParameters(parameters) {
   }
 
   if (parameters.apiEndpoint.length < 1) {
-    return 'Provide the Shopify API endpoint.';
+    return 'Provide the Shopify store URL.';
   }
 
   return null;
@@ -138,8 +138,8 @@ setup({
     },
     {
       id: 'apiEndpoint',
-      name: 'API Endpoint',
-      description: 'The Shopify API endpoint',
+      name: 'Store URL',
+      description: 'The Shopify store URL (e.g. [your-shop-name].myshopify.com)',
       type: 'Symbol',
       required: true,
     },


### PR DESCRIPTION
## Purpose

The existing field on the app config page "API Endpoint" is confusing, users actually need to enter the Shopify store URL.

## Approach

Update field name and description to be more clear about what needs to be entered in this field.

## Testing steps

Ensured the app still worked as expected.

## Breaking Changes

## Dependencies and/or References

## Deployment
