### PR TITLE
ci: add PR write permission to github action

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
## Purpose

Per discussion in this thread https://github.com/cli/cli/issues/8352 the issue with our dependabot approve and merge might be that it lacks correct permissions.

## Approach

* Try adding pull-request permission. See here https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
