### PR TITLE
ci: restore v1 approver

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: contentful/github-auto-merge@4d65d64870c70e7c2f6d78d726d12a0c1764dc98
+      - uses: contentful/github-auto-merge@v1
         with:
           VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
## Purpose

The experiment in #574 was a success, so we can now restore our action configuration to how it was before.

(See https://github.com/contentful/marketplace-partner-apps/pull/572 for an example that worked against that other branch of the action)