### PR TITLE
fix: type error in uploadcare build

### DIFF
--- a/apps/uploadcare/src/locations/Dialog.tsx
+++ b/apps/uploadcare/src/locations/Dialog.tsx
@@ -25,7 +25,7 @@ export default function Dialog(): ReactElement {
   const assetsRef = useRef<Asset[]>([]);
 
   useEffect(() => {
-    const handleUploadEvent = (e: CustomEvent<{ data: Asset[] }>) => {
+    const handleUploadEvent = (e: CustomEvent) => {
       if (e.detail?.data) {
         assetsRef.current = e.detail.data;
       }


### PR DESCRIPTION
## Purpose

A build error crept in for the uploadcare app and it's breaking the `main` branch: https://app.circleci.com/pipelines/github/contentful/marketplace-partner-apps/1377/workflows/4bb19a18-934c-43b3-88e6-7d805bb3cb09/jobs/1332

## Approach

* Use a plain `CustomEvent` instead of specific type, since Typescript can't make the guarantee that the event listener will in fact receive event data that matches the provided type (See https://github.com/contentful/marketplace-partner-apps/blob/1d74d8cdb7278d53cbd40527f299b757c064313f/apps/uploadcare/src/locations/Dialog.tsx#L38-L44)

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
