### PR TITLE
ci: fix permission name

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      pull-request: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:


### PR DESCRIPTION
## Purpose

Small type on the permission name. Should be `pull-requests`. See https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview

## Approach

Add correct permission

## Dependencies and/or References

Note: opened a PR here to fix our internal docs: https://github.com/contentful/github-auto-merge/pull/24

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
