### PR TITLE
ci: don't deploy to staging on release

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -43,8 +43,9 @@ jobs:
         run: npm run install-apps:deploy
       - name: Build apps
         run: npm run build-apps:deploy
-      - name: Deploy staging
+      - name: Deploy apps (staging)
+        if: ${{ !needs.release-please.outputs.releases_created }}
         run: npm run deploy:staging
-      - name: Deploy apps
+      - name: Deploy apps (production)
         if: ${{ needs.release-please.outputs.releases_created }}
         run: npm run deploy:production


### PR DESCRIPTION
## Purpose

Since we deploy to staging on all merges to main, we don't need to redeploy the same thing on the release please PR merge.

## Approach

* Suppress staging deploy when releases are created

See https://docs.github.com/en/actions/learn-github-actions/expressions#operators

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
