### PR TITLE
chore: change DX codeownership to /apps/*/src & apps/*/public only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @contentful/team-integrations
-apps @contentful/team-integrations @contentful/team-developer-experience @gavinmatt
+apps/*/src @contentful/team-integrations @contentful/team-developer-experience @gavinmatt
+apps/*/public @contentful/team-integrations @contentful/team-developer-experience @gavinmatt


### PR DESCRIPTION
change DX codeownership to /apps/*/src & apps/*/public only to reduce PR noise from dependency upgrades