### PR TITLE
feat: upgrade shopify storefront API version

### DIFF
--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -3,7 +3,7 @@
 // whether the returned variant is the default one or not
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
 // upgrade API version to next stable version every quarter
-export const SHOPIFY_API_VERSION = '2023-04';
+export const SHOPIFY_API_VERSION = '2024-01';
 export const SHOPIFY_ENTITY_LIMIT = 250;
 
 export const ENTITY_TYPE = {

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -2,7 +2,8 @@
 // returned with this unfortunate title, and there is no other way to check
 // whether the returned variant is the default one or not
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
-export const SHOPIFY_API_VERSION = '2023-01';
+// upgrade API version to next stable version every quarter
+export const SHOPIFY_API_VERSION = '2023-04';
 export const SHOPIFY_ENTITY_LIMIT = 250;
 
 export const ENTITY_TYPE = {


### PR DESCRIPTION
## Purpose

Currently the Shopify Storefront API version that we are using, 01-2023, within the Shopify app has been deprecated as of January 1st, 2024. 
![Screenshot 2024-01-03 at 12 12 30 PM](https://github.com/contentful/marketplace-partner-apps/assets/58186851/c2b6a335-897d-48ec-8417-032b24bce086).

User's of the Shopify app are now receiving messages that they are interacting with a deprecated API. We therefore need to update this. 

## Approach

I updated the API version to the latest version, in conjunction with a decision reached with the External References team, who will simultaneously update to the same version. The breaking changes that span the updates in the last year do not apply to our functionality. 

Question: How do we best keep track of these updates in the future? Since we don't receive these emails from Shopify, users do. A reminder? ticket?

## Testing steps

Test that the Shopify app still works locally. 

## Breaking Changes

To my knowledge after reading the changelog, there should be no breaking changes within the context of our use of this API. 
