### PR TITLE
chore: add transifex to release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
 		"apps/imageHotspotCreator": {},
 		"apps/shopify": {},
 		"apps/surfer": {},
+		"apps/transifex": {},
 		"apps/uploadcare": {},
 		"apps/voucherify": {}
 	}


### PR DESCRIPTION
## Purpose

This PR adds the new Transifex app to the release-please config to support the initial release and future versioning of the app itself. Following this merge, an automated PR will be opened for initial release of the Transifex app at version number 1.0.0 and with a Changelog file added.
