### PR TITLE
fix: Field customizations and additional config scenarios

### DIFF
--- a/apps/flexfields/src/components/RulesList.tsx
+++ b/apps/flexfields/src/components/RulesList.tsx
@@ -166,6 +166,7 @@ const RulesList = (props: any) => {
                     {/* {rule.targetEntity} */}
                     {getContentTypeName(rule.targetEntity, allContentTypes) ??
                       rule.contentType}
+                    {rule.isForSameEntity ? " (Same Entry)" : ""}
                   </span>{" "}
                   hide the{" "}
                   <span

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -3,23 +3,50 @@ import { EditorAppSDK } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { Field, FieldWrapper } from "@contentful/default-field-editors";
 import { Workbench } from "@contentful/f36-workbench";
-import { Form } from "@contentful/f36-components";
+import { Form, Text } from "@contentful/f36-components";
+import { css } from "emotion";
 import { calculateEditorFields, getFieldExtensionSdk } from "../utils";
 import { type Rule } from "../types/Rule";
+import { DefinedParameters } from "contentful-management";
 
 // Prop types for DefaultField component
 interface DefaultFieldProps {
   name: string;
   sdk: any;
   widgetId: string | null;
+  settings?: DefinedParameters;
 }
 
 // Render default contentful fields using Forma 36 Component
 const DefaultField = (props: DefaultFieldProps) => {
-  const { name, sdk, widgetId } = props;
+  const { settings, name, sdk, widgetId } = props;
   return (
-    <FieldWrapper sdk={sdk} name={name} showFocusBar={true}>
-      <Field sdk={sdk} widgetId={widgetId!} />
+    <FieldWrapper
+      name={name}
+      renderHelpText={() => (
+        <Text
+          as="div"
+          className={css({ fontStyle: "italic" })}
+          fontColor="gray500"
+          marginTop="spacingXs"
+        >
+          {settings?.helpText}
+        </Text>
+      )}
+      sdk={sdk}
+      showFocusBar={true}
+    >
+      <Field
+        sdk={sdk}
+        widgetId={widgetId!}
+        getOptions={(widgetId, _sdk) => ({
+          [widgetId]: {
+            parameters: {
+              instance: settings,
+            },
+          },
+        })}
+      />
     </FieldWrapper>
   );
 };
@@ -62,7 +89,7 @@ const EntryEditor = () => {
             // ev.target.id looks like fieldId-locale-contentTypeId
             const fieldId = id.split("-")[0];
             const entryFieldsCopy: any = { ...sdk.entry.fields };
-              entryFieldsCopy[fieldId] = { ...entryFieldsCopy[fieldId], value };
+            entryFieldsCopy[fieldId] = { ...entryFieldsCopy[fieldId], value };
 
             setEditorFields(
               calculateEditorFields(
@@ -85,6 +112,7 @@ const EntryEditor = () => {
                 name={field.name}
                 sdk={getFieldExtensionSdk(field.id, sdk)}
                 widgetId={widgetId}
+                settings={control?.settings}
               />
             );
           })}

--- a/apps/flexfields/src/types/Rule.tsx
+++ b/apps/flexfields/src/types/Rule.tsx
@@ -3,6 +3,7 @@ export type Rule = {
   contentTypeField: string;
   condition: string;
   conditionValue: string;
+  isForSameEntity: boolean;
   targetEntity: string;
   targetEntityField: string[];
   entryId?: string;

--- a/apps/flexfields/src/utils.ts
+++ b/apps/flexfields/src/utils.ts
@@ -16,10 +16,13 @@ export const getFieldExtensionSdk = (
 const isFieldHidden = (
   fieldId: string,
   contentType: string,
-  rules: Rule[]
+  rules: Rule[],
+  entryId: string
 ): boolean => {
   return !!rules.find(
     (rule) =>
+      ((rule.isForSameEntity && rule.entryId === entryId) ||
+        (!rule.isForSameEntity && rule.entryId !== entryId)) &&
       rule.targetEntity === contentType &&
       rule.targetEntityField.includes(fieldId)
   );
@@ -46,7 +49,8 @@ export const isRuleValid = (
 
   //get content type field value
   const contentTypeFieldValue =
-  entryFields[contentTypeField].value || entryFields[contentTypeField].getValue?.();
+    entryFields[contentTypeField].value ||
+    entryFields[contentTypeField].getValue?.();
 
   switch (condition) {
     case "is equal":
@@ -82,9 +86,9 @@ export const calculateEditorFields = (
     sessionStorage.getItem("filteredRules") || "[]"
   ).filter((rule: Rule) => rule.entryId !== entryId);
 
-  const rules = sdk.parameters.installation.rules as Rule[];
+  const rules = sdk.parameters.installation.rules || [] as Rule[];
   const filteredRules: Rule[] = rules
-    .filter((rule: Rule) =>
+    ?.filter((rule: Rule) =>
       isRuleValid(rule, entryFields, sdk.contentType.sys.id)
     )
     .map((rule: Rule) => ({ ...rule, entryId }));
@@ -112,7 +116,8 @@ export const calculateEditorFields = (
   }
 
   return sdk.contentType.fields.filter(
-    (field) => !isFieldHidden(field.id, sdk.contentType.sys.id, uniqueRulesList)
+    (field) =>
+      !isFieldHidden(field.id, sdk.contentType.sys.id, uniqueRulesList, entryId)
   );
 };
 


### PR DESCRIPTION
## Purpose

1. Fix for https://github.com/contentful/marketplace-partner-apps/issues/642 - Show field customizations on FlexFields entry editor
2. Fix rules configuration for child entities from single reference fields.
3. Fix rules configuration and hiding fields for references to same content type.

## Testing steps

1. Add help text for any field and/or custom true/false labels for boolean field in content type configured in FlexFields. It should now show up in the FlexFields entry editor.
![Screenshot 2024-01-09 at 5 16 44 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/ab3b4549-957e-4059-bfd6-48a7630e9c6e)
2. Add reference field with single reference to content type configured in FlexFields. The content type(s) should be listed in the `Hide Field` section
3. Add reference field referencing the same content type. The entry editor should correctly hide fields in the same entry vs child entry based on the rule configured.

