### PR TITLE
chore: adjust deployment scripts for Transifex

### DIFF
--- a/apps/transifex/package.json
+++ b/apps/transifex/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "install-ci": "npm ci",
     "start": "vite",
-    "build": "vite build --mode=prod",
+    "build": "vite build",
     "build:staging": "vite build --mode=staging",
     "build:dev": "vite build --mode=development",
     "lint": "prettier --write ./src && eslint --fix --ext js,jsx ./src",
@@ -28,7 +28,7 @@
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id b7SVv0k1EYbQRsusviQDi --token ${CONTENTFUL_CMA_TOKEN}"
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id b7SVv0k1EYbQRsusviQDi --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "devDependencies": {
     "@contentful/app-scripts": "^1.13.1",


### PR DESCRIPTION
## Purpose

This PR makes some adjustments to the Transifex deployment scripts that were not caught originally because of the specific vite vs webpack differences. The pipeline is currently not effectively deploying to the app definition because it is not referencing the right directory. See [these](https://github.com/contentful/marketplace-partner-apps/actions/runs/7467471120/job/20321063583) logs.

## Approach

The build script doesn't need the mode configuration because `vite build` does production build automatically unless told otherwise so I removed that ([docs](https://vitejs.dev/guide/env-and-mode#:~:text=In%20some%20cases%2C%20you%20may,vite%20build%20%2D%2Dmode%20staging) for reference). The real fix comes in with referencing a `/dist` file as opposed to a `/build `directory in the deploy script, as the default vite config creates a `dist` directory instead. 

You will notice the deploy errors in [these](https://github.com/contentful/marketplace-partner-apps/actions/runs/7467471120/job/20321063583) logs. Screenshot below: 
<img width="1245" alt="Screenshot 2024-01-09 at 4 26 07 PM" src="https://github.com/contentful/marketplace-partner-apps/assets/58186851/932c8d7d-4c8f-4cd9-a298-9f931a10e73c">


## Breaking Changes

Deploy is currently not working, so this should not cause any other breaking changes. 

