### PR TITLE
chore: Adjust build script to explicitly point to prod env

### DIFF
--- a/apps/transifex/package.json
+++ b/apps/transifex/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "install-ci": "npm ci",
     "start": "vite",
-    "build": "vite build",
+    "build": "vite build --mode=prod",
     "build:staging": "vite build --mode=staging",
     "build:dev": "vite build --mode=development",
     "lint": "prettier --write ./src && eslint --fix --ext js,jsx ./src",


### PR DESCRIPTION
## Purpose

The transifex app is not rendering effectively on the config page. We believe it is an issue of not using the appropriate env variables to make network calls. 

## Approach

To ensure we are pointing to the production env, I have added the prod flag to the build script. 

## Breaking Changes

This will not cause a breaking change. 
