### PR TITLE
chore: fix customevent types to resolve build error

### DIFF
--- a/apps/uploadcare/src/locations/Dialog.tsx
+++ b/apps/uploadcare/src/locations/Dialog.tsx
@@ -25,7 +25,10 @@ export default function Dialog(): ReactElement {
   const assetsRef = useRef<Asset[]>([]);
 
   useEffect(() => {
-    const handleUploadEvent = (e: CustomEvent) => {
+    const handleUploadEvent = (event: Event) => {
+      // see https://github.com/uploadcare/blocks/blob/69105e4806e9ca2d4254bce297c48e0990663212/abstract/UploaderBlock.js#L420-L435
+      const e = event as CustomEvent<{ data: Asset[] }>
+
       if (e.detail?.data) {
         assetsRef.current = e.detail.data;
       }


### PR DESCRIPTION
## Purpose

The main build has started failing due to a build error in Uploadcare: https://app.circleci.com/pipelines/github/contentful/marketplace-partner-apps/2263/workflows/152e6e91-3646-4f66-bc2a-c88c49223e67/jobs/1996?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

The deeper issue here is that Typescript puts some restrictions on what kind of function can be assigned as an `EventListener`. It appears that `CustomEvent` used to work but now no longer does.
 
## Approach

* Just use type assertions to handle the custom event sent from the uploadcare/blocks library

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
