### PR TITLE
chore: decouple dependabot updates per app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,9 @@ version: 2
 
 # note: we split each app out individually to force dependabot to open individual, separate PRs for each apps
 # so that app changes are decoupled from one another
+# yaml anchors and aliases are not support in dependabot -- so lot's of repetition here!
 updates:
-  - &common_settings
-    package-ecosystem: npm
+  - package-ecosystem: npm
     schedule:
       interval: daily
       time: '03:00'
@@ -14,31 +14,148 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/adapt-essentials-asset-fields'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/bynder'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/ceros'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/cloudinary'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/cloudinary2'
     ignore:
       - dependency-name: '@contentful/app-sdk'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/flexfields'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/imageHotspotCreator'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/shopify'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/surfer'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/transifex'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/uploadcare'
-  - <<: *common_settings
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/voucherify'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
   - <<: *common_settings
+    directory: '/'
+  - <<: *common_settings
     directory: '/apps/adapt-essentials-asset-fields'
   - <<: *common_settings
     directory: '/apps/bynder'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,16 +14,6 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
-  - package-ecosystem: npm
-    schedule:
-      interval: daily
-      time: '03:00'
-      timezone: UTC
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: 'fix'
-      prefix-development: 'chore'
-      include: 'scope'
     directory: '/'
   - package-ecosystem: npm
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
     directory: '/apps/cloudinary'
   - <<: *common_settings
     directory: '/apps/cloudinary2'
+    ignore:
+      - dependency-name: '@contentful/app-sdk'
   - <<: *common_settings
     directory: '/apps/flexfields'
   - <<: *common_settings

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,40 @@
 version: 2
 
+# note: we split each app out individually to force dependabot to open individual, separate PRs for each apps
+# so that app changes are decoupled from one another
 updates:
-  - package-ecosystem: npm
-    directory: '/'
+  - &common_settings
+    package-ecosystem: npm
     schedule:
       interval: daily
       time: '03:00'
       timezone: UTC
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
-    ignore:
-      # TODO: Remove this. Why do we ignore app-sdk updates?
-      - dependency-name: '@contentful/app-sdk'
+  - <<: *common_settings
+    directory: '/apps/adapt-essentials-asset-fields'
+  - <<: *common_settings
+    directory: '/apps/bynder'
+  - <<: *common_settings
+    directory: '/apps/ceros'
+  - <<: *common_settings
+    directory: '/apps/cloudinary'
+  - <<: *common_settings
+    directory: '/apps/cloudinary2'
+  - <<: *common_settings
+    directory: '/apps/flexfields'
+  - <<: *common_settings
+    directory: '/apps/imageHotspotCreator'
+  - <<: *common_settings
+    directory: '/apps/shopify'
+  - <<: *common_settings
+    directory: '/apps/surfer'
+  - <<: *common_settings
+    directory: '/apps/transifex'
+  - <<: *common_settings
+    directory: '/apps/uploadcare'
+  - <<: *common_settings
+    directory: '/apps/voucherify'


### PR DESCRIPTION
## Purpose

When we introduced #810 we observed an unanticipated side effect: that dependabot was combining updates for the same dependency across multiple apps into a single PR. An example is here: https://github.com/contentful/marketplace-partner-apps/pull/814

Per our new guidance we will be asking app developers to approve major version updates to their dependencies individually. However, the grouping of PRs adds signficant friction to this process because we would require multiple reviewers on the same PR, and broken updates for a single app would hold up a change for all other updates in that PR.

## Approach

* Force dependabot to treat packages individually by splitting the udpate directories explictily
* Use yaml anchor and alias to avoid repetition
* There's an added benefit here where e.g. we can specify specific ignores per directroy

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
