### PR TITLE
fix: Field formatting, localization, custom widgets fallback

### DIFF
--- a/apps/flexfields/src/components/DefaultField.tsx
+++ b/apps/flexfields/src/components/DefaultField.tsx
@@ -1,0 +1,92 @@
+import { FieldAppSDK, FieldAPI } from "@contentful/app-sdk";
+import { FieldWrapper, Field } from "@contentful/default-field-editors";
+import {
+  HelpText,
+  FormLabel,
+  Box,
+  Note,
+  Text,
+} from "@contentful/f36-components";
+import { CombinedLinkActions } from "@contentful/field-editor-reference";
+import { type LinkActionsProps } from "@contentful/field-editor-reference/dist/types/components";
+import { Control } from "contentful-management";
+import { css } from "emotion";
+import React from "react";
+import { getLocaleName } from "../utils";
+import { openMarkdownDialog } from '@contentful/field-editor-markdown';
+
+// Prop types for DefaultField component
+export interface DefaultFieldProps {
+  name: string;
+  sdk: FieldAppSDK;
+  widgetId: string | null;
+  locale?: string;
+  control?: Control & { field: FieldAPI };
+}
+
+// Render default contentful fields using Forma 36 Component
+const DefaultField = (props: DefaultFieldProps) => {
+  const { control, name, sdk, locale, widgetId } = props;
+  // This is required to show the dialogs related to markdown (expanded mode and cheatsheet)
+  // ref: https://github.com/contentful/field-editors/blob/master/packages/markdown/stories/MarkdownEditor.stories.tsx#L93
+  if (control?.widgetId === 'markdown') {
+    // @ts-expect-error
+    sdk.dialogs.openCurrent = openMarkdownDialog(sdk);
+  }
+  return (
+    <FieldWrapper
+      name={name}
+      renderHelpText={() => (
+        <>
+          {control?.settings?.helpText && (
+            <HelpText className={css({ fontStyle: "italic" })}>
+              {control?.settings?.helpText}
+            </HelpText>
+          )}
+        </>
+      )}
+      renderHeading={(name: string) => {
+        return (
+          <FormLabel style={{ fontWeight: "normal" }}>
+            {name}
+            {locale && (
+              <Text fontColor="gray500"> | {getLocaleName(sdk, locale)}</Text>
+            )}
+          </FormLabel>
+        );
+      }}
+      sdk={sdk}
+      showFocusBar={true}
+    >
+      <Field
+        sdk={sdk}
+        widgetId={widgetId!}
+        getOptions={(widgetId, _sdk) => ({
+          [widgetId]: {
+            parameters: {
+              instance: control?.settings,
+            },
+            ...(control?.field.type === "Array" ||
+            control?.field.type === "Link"
+              ? {
+                  renderCustomActions: (props: LinkActionsProps) => (
+                    <CombinedLinkActions {...props} />
+                  ),
+                }
+              : {}),
+          },
+        })}
+      />
+      {control?.widgetNamespace !== "builtin" && (
+        <Box marginTop="spacingXs">
+          <Note>
+            This field was configured to use custon field widget. Please use the
+            default Entry Editor to access the custom field widget.
+          </Note>
+        </Box>
+      )}
+    </FieldWrapper>
+  );
+};
+
+export default DefaultField;

--- a/apps/flexfields/src/locations/ConfigScreen.tsx
+++ b/apps/flexfields/src/locations/ConfigScreen.tsx
@@ -356,7 +356,7 @@ const ConfigScreen = () => {
 
         if (fields) {
           // filter contentTypeField from fields
-          if (targetEntity === contentType) {
+          if (isForSameEntity && targetEntity.substring(0, suffixIndex) === contentType) {
             fields = fields.filter((field) => field.id !== contentTypeField);
           }
 

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -1,62 +1,35 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EditorAppSDK } from "@contentful/app-sdk";
+import { EditorAppSDK, EditorLocaleSettings } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
-import { Field, FieldWrapper } from "@contentful/default-field-editors";
+import { getDefaultWidgetId } from "@contentful/default-field-editors";
 import { Workbench } from "@contentful/f36-workbench";
-import { Form, Text } from "@contentful/f36-components";
-import { css } from "emotion";
-import { calculateEditorFields, getFieldExtensionSdk } from "../utils";
+import { Stack, Form, Heading, Text } from "@contentful/f36-components";
+import { calculateEditorFields, getFieldAppSdk, getLocaleName } from "../utils";
 import { type Rule } from "../types/Rule";
-import { DefinedParameters } from "contentful-management";
+// Import for markdown editor
+import "codemirror/lib/codemirror.css";
+import DefaultField, { DefaultFieldProps } from "../components/DefaultField";
+import type { ContentFields, KeyValueMap } from "contentful-management/types";
 
-// Prop types for DefaultField component
-interface DefaultFieldProps {
-  name: string;
-  sdk: any;
-  widgetId: string | null;
-  settings?: DefinedParameters;
-}
-
-// Render default contentful fields using Forma 36 Component
-const DefaultField = (props: DefaultFieldProps) => {
-  const { settings, name, sdk, widgetId } = props;
-  return (
-    <FieldWrapper
-      name={name}
-      renderHelpText={() => (
-        <Text
-          as="div"
-          className={css({ fontStyle: "italic" })}
-          fontColor="gray500"
-          marginTop="spacingXs"
-        >
-          {settings?.helpText}
-        </Text>
-      )}
-      sdk={sdk}
-      showFocusBar={true}
-    >
-      <Field
-        sdk={sdk}
-        widgetId={widgetId!}
-        getOptions={(widgetId, _sdk) => ({
-          [widgetId]: {
-            parameters: {
-              instance: settings,
-            },
-          },
-        })}
-      />
-    </FieldWrapper>
-  );
-};
+const NoLocalizedFields = (props: { localeName: string }) => (
+  <Stack flexDirection="column" alignItems="center" alignContent="center">
+    <Heading>There are no fields to translate</Heading>
+    <Text style={{ textAlign: "center" }}>
+      There are no localized fields to translate for {props.localeName}. You can
+      switch to a different locale using "Translation" in your sidebar.
+    </Text>
+  </Stack>
+);
 
 const EntryEditor = () => {
   const sdk = useSDK<EditorAppSDK>();
   const entryId = sdk.entry.getSys().id;
   const isFirstLoad = useRef(true);
-  const [editorFields, setEditorFields] = useState(
-    calculateEditorFields(entryId, sdk.entry.fields, sdk, isFirstLoad.current)
+  const [editorFields, setEditorFields] = useState<
+    ContentFields<KeyValueMap>[]
+  >([]);
+  const [localeSetings, setLocaleSetings] = useState<EditorLocaleSettings>(
+    sdk.editor.getLocaleSettings()
   );
 
   const handlePageHide = useCallback(() => {
@@ -80,9 +53,19 @@ const EntryEditor = () => {
     };
   }, [handlePageHide]);
 
+  useEffect(() => {
+    sdk.editor.onLocaleSettingsChanged((localeSetings) =>
+      setLocaleSetings(localeSetings)
+    );
+    setEditorFields(
+      calculateEditorFields(entryId, sdk.entry.fields, sdk, isFirstLoad.current)
+    );
+  }, [entryId, sdk, sdk.editor]);
+
+  let hasLocailizedFields = false;
   return (
     <Workbench>
-      <Workbench.Content type="text">
+      <Workbench.Content type="text" style={{ paddingBottom: "200px" }}>
         <Form
           onChange={(ev: any) => {
             const { id, value } = ev.target;
@@ -104,18 +87,78 @@ const EntryEditor = () => {
           {editorFields.map((field) => {
             const control = sdk.editor.editorInterface.controls!.find(
               (control) => control.fieldId === field.id
-            );
-            const widgetId = control?.widgetId || null;
-            return (
-              <DefaultField
-                key={field.id}
-                name={field.name}
-                sdk={getFieldExtensionSdk(field.id, sdk)}
-                widgetId={widgetId}
-                settings={control?.settings}
-              />
-            );
+            ) as DefaultFieldProps["control"];
+            let widgetId = control?.widgetId || null;
+
+            // App frameworks does not have the ability to reference/pull in other apps
+            // Using default widget if field is configured to use custom app
+            if (control?.widgetNamespace !== "builtin") {
+              widgetId = getDefaultWidgetId(
+                getFieldAppSdk(field.id, sdk, sdk.locales.default)
+              );
+            }
+
+            // mode = 'single':
+            //    use `focused`
+            //    no default locale
+            // mode = 'multi':
+            //    use `active`
+            //    need default locale
+            if (localeSetings.mode === "multi") {
+              return (
+                <>
+                  <DefaultField
+                    key={`${field.id}-${sdk.locales.default}`}
+                    name={field.name}
+                    sdk={getFieldAppSdk(field.id, sdk, sdk.locales.default)}
+                    widgetId={widgetId}
+                    control={control}
+                    locale={
+                      field.localized &&
+                      localeSetings.active?.length &&
+                      localeSetings.active?.length > 1
+                        ? sdk.locales.default
+                        : undefined
+                    }
+                  />
+                  {field.localized &&
+                    localeSetings.active
+                      ?.filter((locale) => locale !== sdk.locales.default)
+                      .map((locale) => (
+                        <DefaultField
+                          key={`${field.id}-${locale}`}
+                          name={field.name}
+                          sdk={getFieldAppSdk(field.id, sdk, locale)}
+                          widgetId={widgetId}
+                          control={control}
+                          locale={locale}
+                        />
+                      ))}
+                </>
+              );
+            } else if (
+              field.localized ||
+              localeSetings.focused === sdk.locales.default
+            ) {
+              hasLocailizedFields = true;
+              return (
+                <DefaultField
+                  key={`${field.id}-${localeSetings.focused}`}
+                  name={field.name}
+                  sdk={getFieldAppSdk(field.id, sdk, localeSetings.focused)}
+                  widgetId={widgetId}
+                  control={control}
+                  locale={field.localized ? localeSetings.focused : undefined}
+                />
+              );
+            }
+            return null;
           })}
+          {!hasLocailizedFields && localeSetings.focused && (
+            <NoLocalizedFields
+              localeName={getLocaleName(sdk, localeSetings.focused)}
+            />
+          )}
         </Form>
       </Workbench.Content>
     </Workbench>

--- a/apps/flexfields/test/mocks/mockSdk.ts
+++ b/apps/flexfields/test/mocks/mockSdk.ts
@@ -19,6 +19,10 @@ const mockSdk: any = {
   contentType: {
     fields: [],
   },
+  editor: {
+    getLocaleSettings: () => ({}),
+    onLocaleSettingsChanged: () => {},
+  },
 };
 
 export { mockSdk };


### PR DESCRIPTION
## Purpose

Fixes for https://github.com/contentful/marketplace-partner-apps/issues/707
1. Fix markdown field editor issues
2. Add locale support
3. Custom widgets - Display default widget when field configured to use custom UI
4. Fix field heading colour
5. Update relational fields to look like default entry editor

## Approach

For custom widgets, the app framework does not support importing an app within an app. The workaround for now is to show the default widget for that field type and show an info message about this limitation.

![Screenshot 2024-02-02 at 10 31 53 AM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/147ff390-2f82-492e-9841-63a337dffe9c)

