### PR TITLE
chore: pin node types to match supported node version (v18)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -26,6 +30,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/adapt-essentials-asset-fields'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -37,6 +45,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/bynder'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -48,6 +60,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/ceros'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -59,6 +75,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/cloudinary'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -72,6 +92,9 @@ updates:
     directory: '/apps/cloudinary2'
     ignore:
       - dependency-name: '@contentful/app-sdk'
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -83,6 +106,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/flexfields'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -94,6 +121,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/imageHotspotCreator'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -105,6 +136,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/shopify'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -116,6 +151,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/surfer'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -127,6 +166,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/transifex'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -138,6 +181,10 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/uploadcare'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -149,3 +196,7 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/voucherify'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'


### PR DESCRIPTION
## Purpose

We have a lot of dependabot PRs trying to push up types to v20, eg https://github.com/contentful/marketplace-partner-apps/pull/864

Types should match the supported version of node which is `v18.17`

## Approach

* Pin to highest types package available for node 18

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
