### PR TITLE
fix(deps): downgrade @contentful/app-sdk from 4.24.0 to 4.19.1 in apps/adapt-essentials-asset-fields (revert)

### DIFF
--- a/apps/adapt-essentials-asset-fields/package-lock.json
+++ b/apps/adapt-essentials-asset-fields/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adapt-essentials-asset-fields",
       "version": "1.0.2",
       "dependencies": {
-        "@contentful/app-sdk": "^4.24.0",
+        "@contentful/app-sdk": "^4.19.1",
         "@contentful/f36-components": "^4.43.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-workbench": "^4.21.0",
@@ -213,10 +213,10 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.24.0.tgz",
-      "integrity": "sha512-5J0DunyRRMB2B37AWnfyEW6rqCSfaNOhkSDPPWhhRR+ymZ7u6j4TI6JxFP7rAKHhb6Zg7Ml46V+uVEvL9OT2FA==",
-      "dependencies": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.19.1.tgz",
+      "integrity": "sha512-Z1XHrvKLaTkJOHtbA0sBi5tUtg0lJ8YPzrc+rWCsxiVaRZuaX8i/iZk1zdYZJ5VgwGpaoPUDWc9jNGeqMykgNg==",
+      "peerDependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
@@ -5482,12 +5482,10 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.24.0.tgz",
-      "integrity": "sha512-5J0DunyRRMB2B37AWnfyEW6rqCSfaNOhkSDPPWhhRR+ymZ7u6j4TI6JxFP7rAKHhb6Zg7Ml46V+uVEvL9OT2FA==",
-      "requires": {
-        "contentful-management": ">=7.30.0"
-      }
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.19.1.tgz",
+      "integrity": "sha512-Z1XHrvKLaTkJOHtbA0sBi5tUtg0lJ8YPzrc+rWCsxiVaRZuaX8i/iZk1zdYZJ5VgwGpaoPUDWc9jNGeqMykgNg==",
+      "requires": {}
     },
     "@contentful/f36-accordion": {
       "version": "4.59.3",

--- a/apps/adapt-essentials-asset-fields/package.json
+++ b/apps/adapt-essentials-asset-fields/package.json
@@ -14,7 +14,7 @@
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 6RGLVmXYrGaIIRIda1HwAC --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "dependencies": {
-    "@contentful/app-sdk": "^4.24.0",
+    "@contentful/app-sdk": "^4.19.1",
     "@contentful/f36-components": "^4.43.0",
     "@contentful/f36-image": "^4.0.0-alpha.0",
     "@contentful/f36-workbench": "^4.21.0",


### PR DESCRIPTION
…/apps/adapt-essentials-asset-fields (#838)"

This reverts commit 7cf2b757188dec4ecf40cdc9f83db5560eae3eed.

## Purpose

* Earlier PR actually broke the build and was mistakenly merged (because of wrong branch protections)

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
