### PR TITLE
fix: Fix edit rule for same entry

### DIFF
--- a/apps/flexfields/src/locations/ConfigScreen.tsx
+++ b/apps/flexfields/src/locations/ConfigScreen.tsx
@@ -225,7 +225,8 @@ const ConfigScreen = () => {
         setContentTypeField(ruleToEdit.contentTypeField);
         setCondition(ruleToEdit.condition);
         setConditionValue(ruleToEdit.conditionValue);
-        setTargetEntity(ruleToEdit.targetEntity);
+        // If the rule is set for same entity, add `-sameEntity` to targetEntity
+        setTargetEntity(`${ruleToEdit.isForSameEntity ? `${ruleToEdit.targetEntity}-sameEntity`: ruleToEdit.targetEntity}`);
         setTargetEntityField(ruleToEdit.targetEntityField);
       }, 100);
     }


### PR DESCRIPTION
## Purpose

Fix for https://github.com/contentful/marketplace-partner-apps/issues/702 

## Testing steps

Create a rule for hiding fields in the same entry. Then edit that rule and confirm that the rule remains for same entry


https://github.com/contentful/marketplace-partner-apps/assets/31496466/80457d7e-edb8-4171-ae64-330b98908ee3

