### PR TITLE
fix: Hide fields hidden for editing

### DIFF
--- a/apps/flexfields/src/locations/ConfigScreen.tsx
+++ b/apps/flexfields/src/locations/ConfigScreen.tsx
@@ -665,16 +665,16 @@ const ConfigScreen = () => {
                     )}
                     className={css({ width: 300 })}
                   >
-                    {targetEntityFields.map(({ id, name }: any) => {
+                    {targetEntityFields.map((tef: any) => {
                       return (
                         <Multiselect.Option
-                          key={`key-${id}}`}
-                          itemId={`space-${id}}`}
-                          value={id}
-                          label={name}
+                          key={`key-${tef.id}}`}
+                          itemId={`space-${tef.id}}`}
+                          value={tef.id}
+                          label={`${tef.name} ${tef.disabled ? '(Hidden when editing)' : ''}`}
                           onSelectItem={(ev) => {
                             setTargetEntityField((targetEntityField) => {
-                              if (targetEntityField?.includes(id)) {
+                              if (targetEntityField?.includes(tef.id)) {
                                 const targetEntityFieldCopy = [
                                   ...targetEntityField,
                                 ];
@@ -689,7 +689,7 @@ const ConfigScreen = () => {
                               return [...targetEntityField, ev.target.value];
                             });
                           }}
-                          isChecked={targetEntityField.includes(id)}
+                          isChecked={targetEntityField.includes(tef.id)}
                         />
                       );
                     })}

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -57,6 +57,16 @@ const EntryEditor = () => {
     sdk.editor.onLocaleSettingsChanged((localeSetings) =>
       setLocaleSetings(localeSetings)
     );
+    sdk.editor.onShowHiddenFieldsChanged(() =>
+      setEditorFields(
+        calculateEditorFields(
+          entryId,
+          sdk.entry.fields,
+          sdk,
+          isFirstLoad.current
+        )
+      )
+    );
     setEditorFields(
       calculateEditorFields(entryId, sdk.entry.fields, sdk, isFirstLoad.current)
     );

--- a/apps/flexfields/src/utils.ts
+++ b/apps/flexfields/src/utils.ts
@@ -123,10 +123,18 @@ export const calculateEditorFields = (
     sessionStorage.setItem("filteredRules", JSON.stringify(uniqueRulesList));
   }
 
-  return sdk.contentType.fields.filter(
-    (field) =>
-      !isFieldHidden(field.id, sdk.contentType.sys.id, uniqueRulesList, entryId)
-  );
+  return sdk.contentType.fields
+    // Hide if field is hidden for editing or show if `Show hidden fields` is enabled
+    .filter((field) => !field.disabled || sdk.editor.getShowHiddenFields())
+    .filter(
+      (field) =>
+        !isFieldHidden(
+          field.id,
+          sdk.contentType.sys.id,
+          uniqueRulesList,
+          entryId
+        )
+    );
 };
 
 //Get content type name from content type id

--- a/apps/flexfields/test/mocks/mockSdk.ts
+++ b/apps/flexfields/test/mocks/mockSdk.ts
@@ -22,6 +22,7 @@ const mockSdk: any = {
   editor: {
     getLocaleSettings: () => ({}),
     onLocaleSettingsChanged: () => {},
+    onShowHiddenFieldsChanged: () => {},
   },
 };
 


### PR DESCRIPTION
## Purpose

Fix for https://github.com/contentful/marketplace-partner-apps/issues/931 

## Testing steps

Setup
- Set a field to be `Hidden when editing` for a content type. 
- Configure that content type to have a rule in FlexFields.

Result
- The field should be hidden in the FlexFields entry editor. 
- It should also show when selecting `Show hidden fields` in editor options.
- When creating a rule, the hidden field is called out in the options to hide field

![Screenshot 2024-02-20 at 5 10 18 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/e21e20e2-676f-48d0-a7e4-e3461e371e74)

https://github.com/contentful/marketplace-partner-apps/assets/31496466/14faf645-bfc5-4195-a5fd-d583f29336a1

![Screenshot 2024-02-20 at 5 10 10 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/686d164c-a622-4f25-a100-195744846888)

