### PR TITLE
chore: remove npm-read from repo [INTEG-1822]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -8,4 +8,3 @@ services:
       - semantic-release-ecosystem
       - aws-push-artifacts:
           account-id: '017078452822'
-      - npm-read


### PR DESCRIPTION
## Purpose

This PR removes the `npm-read` vault policy from this repo. We are not using private packages in this repo so it should be able to be safely removed from here. 

## Approach

As part the GH package migration we are removing `npm-read` from repos. We should be ok not replacing this with the new `packages-read` policy since this is a public repo that is not using private packages.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
