### PR TITLE
fix: Use relative path for documentation images in `Adapt Essentials: Asset Fields` app

### DIFF
--- a/apps/adapt-essentials-asset-fields/src/components/MarkdownRender.tsx
+++ b/apps/adapt-essentials-asset-fields/src/components/MarkdownRender.tsx
@@ -28,7 +28,6 @@ const MarkdownRender = ({ value }: { value: string }) => (
           {children}
         </a>
       ),
-      img: ({ src }) => <img src={`/${src}`} alt="" />,
     }}>
     {value}
   </Markdown>


### PR DESCRIPTION
## Purpose

Absolute images where not showing up in documentation. This PR fixes it. 

## Approach

Removed absolute path I've hardcoded for development.

## Testing steps

Go to app configuation page and confirm that you can see instructional images.

## Breaking Changes

No breaking changes

## Dependencies and/or References

https://github.com/adaptdk/adapt-essentials-asset-fields/issues/9

