### PR TITLE
chore: resolve adapt-essentials-asset-fields locale issue

### DIFF
--- a/apps/adapt-essentials-asset-fields/src/components/hooks/useLocales.tsx
+++ b/apps/adapt-essentials-asset-fields/src/components/hooks/useLocales.tsx
@@ -10,8 +10,7 @@ const useLocales = () => {
     defaultValue: [sdk.locales.default]
   });
   const enabledLocales = useMemo(() => {
-    const enabledLocalesParam = _enabledLocales ??
-      sdk.parameters?.instance?.enabledLocales ?? [sdk.locales.default];
+    const enabledLocalesParam = _enabledLocales ?? [sdk.locales.default];
     if (enabledLocalesParam.length < 1) {
       setEnabledLocales([sdk.locales.default]);
     }
@@ -22,7 +21,6 @@ const useLocales = () => {
   }, [
     _enabledLocales,
     sdk.locales?.default,
-    sdk.parameters?.instance?.enabledLocales,
     setEnabledLocales,
   ]);
 

--- a/apps/adapt-essentials-asset-fields/tsconfig.json
+++ b/apps/adapt-essentials-asset-fields/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Purpose

The developer of adapt-essentials-asset-fields resolved a major dep update issue in [this](https://github.com/contentful/marketplace-partner-apps/pull/1076) PR, but unfortunately we then merged this into an existing dependabot PR and dependabot is not a fan of that and will not rebase [this](https://github.com/contentful/marketplace-partner-apps/pull/1042) original PR 😢 . Therefore, I have recreated the developers changes here, to merge proactively - I will then rebase the original dependabot PR (which will overwrite the changes merged into it), and all will be well. Lesson learning about manipulating existing dependabot PRs 🙃 

