### PR TITLE
chore: add dep to be ignored by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -185,6 +185,9 @@ updates:
       - dependency-name: '@types/node'
         versions:
           - '>18.15.3'
+      - dependency-name: '@uploadcare/blocks'
+        versions:
+          - '>0.35.2'
   - package-ecosystem: npm
     schedule:
       interval: daily


### PR DESCRIPTION
## Purpose

The developer of the UploadCare app is requesting that dependabot ignores updates to a particular dependency: `@uploadcare/blocks` as per [this](https://github.com/contentful/marketplace-partner-apps/pull/1133#issuecomment-2001998656) comment. They would like this done in order to avoid future breaking changes, as an auto update to this API caused the app to break, given the API is v0/WIP. 

## Approach

I have added this dependency to be ignored by auto updates within the UploadCare app. This configuration exists in the dependabot config specifically. 

Question: the same developer has expressed concerns that our dependabot would update a v0 dependency, given those are considered "unstable", see [this](https://github.com/contentful/marketplace-partner-apps/pull/1133) PR comment. Any immediate opinions on this? I dug around a bit and have yet found much precedence for ignoring v0 dependencies.  
