### PR TITLE
fix: placeholder text for Shopify SkuPicker [INTEG-2024]

### DIFF
--- a/apps/shopify/package-lock.json
+++ b/apps/shopify/package-lock.json
@@ -17,8 +17,7 @@
         "emotion": "^11.0.0",
         "react": "16.14.0",
         "react-dom": "16.14.0",
-        "shopify-buy": "2.21.1",
-        "typescript": "5.4.5"
+        "shopify-buy": "2.21.1"
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.19.0",
@@ -17564,15 +17563,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -31696,9 +31696,10 @@
       }
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -17,8 +17,7 @@
     "emotion": "^11.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "shopify-buy": "2.21.1",
-    "typescript": "5.4.5"
+    "shopify-buy": "2.21.1"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",

--- a/apps/shopify/src/index.js
+++ b/apps/shopify/src/index.js
@@ -58,6 +58,18 @@ function makeSaveBtnText(skuType) {
   };
 }
 
+function makeSearchPlaceholderText(skuType) {
+  if (skuType === 'product') {
+    return 'Search for a product...';
+  }
+
+  if (skuType === 'collection') {
+    return 'Search for a collection...';
+  }
+
+  return 'Search for a product variant...';
+}
+
 export function validateParameters(parameters) {
   if (parameters.storefrontAccessToken.length < 1) {
     return 'Provide the storefront access token to your Shopify store.';
@@ -98,6 +110,7 @@ async function renderDialog(sdk) {
     searchDelay: 750,
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
+    makeSearchPlaceholderText,
   });
 
   sdk.window.startAutoResizer();


### PR DESCRIPTION
## Purpose

The placeholder text in the `ecommerce-app-base` was hardcoded so it was not reflecting the correct text for product variants and collections. We updated the `ecommerce-app-base` to have a configurable placeholder, and this PR implements that.

## Approach

Bump the `ecommerce-app-base` and add `makeSearchPlaceholderText` to the `renderSkuPicker`. Also, I was running into an issue installing dependencies locally with this app due to a conflict with the `react-scripts` version and typescript version. I noticed that we are not using typescript in this app, so I removed the dependency and it is working now.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
