### PR TITLE
fix: Transifex app handle deleted project case

### DIFF
--- a/apps/transifex/src/locations/ConfigScreen.jsx
+++ b/apps/transifex/src/locations/ConfigScreen.jsx
@@ -111,6 +111,7 @@ function ConfigScreen() {
   const [projectAlreadyConnected, setProjectAlreadyConnected] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [projectType, setProjectType] = useState('');
+  const [selectOtherProject, setSelectOtherProject] = useState(false);
   const [enableFetchInterval, setEnableFetchInterval] = useState(false);
   const cma = createClient(
     { apiAdapter: sdk.cmaAdapter },
@@ -275,6 +276,12 @@ function ConfigScreen() {
       setPullContent(
         tokenData.included[1].attributes.fetch_initial_translations,
       );
+    }
+    if (tokenData && tokenData.data.attributes.reset_project) {
+      setSelectOtherProject(true);
+      setTokenExists(true);
+    } else {
+      setSelectOtherProject(false);
     }
   }, [tokenData]);
 
@@ -523,7 +530,7 @@ function ConfigScreen() {
                           <Note variant="negative">{errorMessage}</Note>
                         </Box>
                       )}
-                      {projectType !== 'file' && (
+                      {projectType !== 'file' && !selectOtherProject && (
                         <Box marginTop="spacingM" marginBottom="spacingM">
                           <Note variant="negative">
                             Contentful integration only supports file projects.
@@ -531,26 +538,40 @@ function ConfigScreen() {
                           </Note>
                         </Box>
                       )}
-                      <Heading>Connected Transifex Project</Heading>
-                      <Paragraph>
-                        Project name:&nbsp;
-                        <b>{projectName}</b>
-                      </Paragraph>
-                      <Paragraph>
-                        Source language:&nbsp;
-                        <b>{projectSourceLanguage}</b>
-                      </Paragraph>
-                      <Paragraph>Target languages:&nbsp;</Paragraph>
-                      <Box marginTop="spacingM">
-                        <Stack>
-                          {projectTargetLanguages.length > 0
-                            && projectTargetLanguages.map((targetLanguage) => (
-                              <Badge variant="secondary" key={targetLanguage}>
-                                {targetLanguage}
-                              </Badge>
-                            ))}
-                        </Stack>
-                      </Box>
+                      {!selectOtherProject && (
+                        <>
+                          <Heading>Connected Transifex Project</Heading>
+                          <Paragraph>
+                            Project name:&nbsp;
+                            <b>{projectName}</b>
+                          </Paragraph>
+                          <Paragraph>
+                            Source language:&nbsp;
+                            <b>{projectSourceLanguage}</b>
+                          </Paragraph>
+                          <Paragraph>Target languages:&nbsp;</Paragraph>
+                          <Box marginTop="spacingM">
+                            <Stack>
+                              {projectTargetLanguages.length > 0
+                                && projectTargetLanguages.map((targetLanguage) => (
+                                  <Badge variant="secondary" key={targetLanguage}>
+                                    {targetLanguage}
+                                  </Badge>
+                                ))}
+                            </Stack>
+                          </Box>
+                        </>
+                      )}
+                      {selectOtherProject && (
+                        <>
+                          <Heading>Connected Transifex Project</Heading>
+                          <Box marginTop="spacingM" marginBottom="spacingM">
+                            <Note variant="negative">
+                              Your project has not been found. Please select another project.
+                            </Note>
+                          </Box>
+                        </>
+                      )}
                       {!appIsInstalled && (
                         <Box marginTop="spacingM">
                           <Button


### PR DESCRIPTION
## Purpose

Improve the error we get on configuration page when transifex project is deleted and app's installation has not been completed yet.

## Approach

Display a relevant error message and allow users to reset selected project

## Testing steps

- Install transisfex native app and connect it with a transifex project without completing the installation
- Delete transifex project
- On refresh user should see the following view

![Screenshot 2024-04-30 at 12 11 18 PM](https://github.com/contentful/marketplace-partner-apps/assets/112862979/0e966ef0-5157-418e-a9f2-9a3e1f74fbdb)

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
