### PR TITLE
chore(bynder): upgrade to react v18 and dam-app-base v3

### DIFF
--- a/apps/bynder/package-lock.json
+++ b/apps/bynder/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@contentful/bynder-assets",
       "version": "1.1.9",
       "dependencies": {
-        "@contentful/dam-app-base": "^2.3.2",
-        "react": "16.14.0",
-        "react-dom": "16.14.0"
+        "@contentful/dam-app-base": "^3.0.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.19.1",
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@contentful/dam-app-base": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.3.2.tgz",
-      "integrity": "sha512-Q6kPUCMW6xwh5MwZmE+f4MJ9BfYdXKqGBJGvGl6ou+CKYyjbZgbqrQ9Ig3PMwSyIvRDpjOaoIK2BYWHf5mk6cA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.0.tgz",
+      "integrity": "sha512-XuUq93wem0IMDuDzHnuEZkClFE3fYbdagAw6NIjo38ToKZEWS86WzYoKIJqm41R4jRRBF1tU3fmI48t93OTDmw==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -2185,20 +2185,20 @@
         "emotion": "^10.0.0"
       },
       "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0"
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.39.0.tgz",
-      "integrity": "sha512-XucnOATPicFuaqjTt8rkv3Yom9pJjXLk0ZJnVgHezPgCjUBM2UlQSaXbitTC5V0K83Ojce82aDfaG0IznVDwFg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.65.5.tgz",
+      "integrity": "sha512-2TIERDEQ3ChigDdiMimQl9FiDV8jIKqFil+a1smfPZrUway64NKQ9xo4fEHlFCe3N218zCvhZklzemmO3s2cQA==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2207,15 +2207,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.39.0.tgz",
-      "integrity": "sha512-9aEtFeHeOVYaPKmc2F3FrBEFWePlH5iQnQvCUmrZLGPcjuHOnKczpcxfu0yBKnm1dSb7uWWEGzUlmf7R7YYZYA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.65.5.tgz",
+      "integrity": "sha512-/SIKJ1RA8ZHkVIrgVzijDTQCAhos3eaDYnpcA1q2OCn7uBU5a4QMmCjC8U2vb0rmchSxK9Ddg1bASCdF2wjhuA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2224,19 +2224,19 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.39.0.tgz",
-      "integrity": "sha512-2eHQ1QA32xkHFuAXvbligzGHlxeW/SwF2YCrE74IlJf5HflwMi/YjNV5IscG9s+xvQe7wOmN4SY+ZH8+pE0j2g==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.65.5.tgz",
+      "integrity": "sha512-QmTH8U3VWP/JIZVvLVis4UrHdjqvtFVFQP9q4XOCsjCHpI4QHx05pVD3vozBoWr0vAVeIAu2YQQYqDsqcLkg7w==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -2246,12 +2246,13 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.39.0.tgz",
-      "integrity": "sha512-KO+5SZyYMpgSig3vJ73EwIWHpKCQwh/6qi/cePiZjfnJe1OaAWyIBj6iqMmH4o9C6WZRneb/5xLknh6sgAkHCg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.65.5.tgz",
+      "integrity": "sha512-EEwf1ZGYQBeOxHnFdem0rCXDPWN1VgNxOpkJgpX8gWryb3xTBoa4/rf/ZQb2H/cQzWi7hVjStVgnUdEiIf2jAA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2260,13 +2261,14 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.39.0.tgz",
-      "integrity": "sha512-zV3kQV4sDZXYjG3haE89TsWUsM2b0hh0v6R0WjO03MAHZvVO/nCWNgvL7e9v7PjqV6dmfRaC4w6Zb5TYocWkDg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.65.5.tgz",
+      "integrity": "sha512-+ja1Aba9kBOQNNmZ48esvj/gsR/S6lHT0ZRiR+oIue6eLowdWcurdEhUtv9jzpGiMlA3JOD36M9aalmuVYLA4Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-spinner": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2275,22 +2277,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.39.0.tgz",
-      "integrity": "sha512-NYMBAs+rVlMgO0F2+Onvdz/aG8CRry3BO1ZXsTSmj3/zoRSsRxZeM/yeZBiy/oXPQnc0mpcB+eK8RpWLDReK3w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.65.5.tgz",
+      "integrity": "sha512-4xg0Vm0gF/gzZfOsv4t1NHJ0lE5/QKHpJnoPmxgn4k5PiB6FtODjr29X+jF+m2Q5KB94aBhV3F0k7rX79GdL4Q==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.39.0",
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2300,12 +2302,12 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.39.0.tgz",
-      "integrity": "sha512-gCZZjHYKu3Ey/aOZfhNb56iISA84mjxF4yRI1A8g2ytfPQqvwc1O1icbLORpY+uzbg/V59YBgMYYxrycIQRE6w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.65.5.tgz",
+      "integrity": "sha512-aaVkGlPnEcV/reSbzegrRB8VRPiKWIfMgxrliOzA0uT8btTsKdgXySwFwyFiKyw81bfbLugZYan6jkWVcnVRrg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2314,62 +2316,71 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.39.0.tgz",
-      "integrity": "sha512-gm8jRKptK2xs5ENfozULZhawgiFTnuhgqEOry/SMXGaAOZ++KY7LttWA/4h8cwKXtkTTIcyN9baN8tT8XPuGZg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.65.5.tgz",
+      "integrity": "sha512-xQ6mi7+Rwj04lrF8O1PaAIvRXj6W8U16aYaJXQdc3MgNvUT9eUqEeN09LKTqwTpl/giuetrH/Zey6U+V2ikSkg==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.39.0",
-        "@contentful/f36-asset": "^4.39.0",
-        "@contentful/f36-autocomplete": "^4.39.0",
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-card": "^4.39.0",
-        "@contentful/f36-collapse": "^4.39.0",
-        "@contentful/f36-copybutton": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-datepicker": "^4.39.0",
-        "@contentful/f36-datetime": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-empty-state": "^4.39.0",
-        "@contentful/f36-entity-list": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.39.0",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-modal": "^4.39.0",
-        "@contentful/f36-note": "^4.39.0",
-        "@contentful/f36-notification": "^4.39.0",
-        "@contentful/f36-pagination": "^4.39.0",
-        "@contentful/f36-pill": "^4.39.0",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-spinner": "^4.39.0",
-        "@contentful/f36-table": "^4.39.0",
-        "@contentful/f36-tabs": "^4.39.0",
-        "@contentful/f36-text-link": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.5",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-autocomplete": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-card": "^4.65.5",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-copybutton": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-datepicker": "^4.65.5",
+        "@contentful/f36-datetime": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-empty-state": "^4.65.5",
+        "@contentful/f36-entity-list": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.5",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-modal": "^4.65.5",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.5",
+        "@contentful/f36-notification": "^4.65.5",
+        "@contentful/f36-pagination": "^4.65.5",
+        "@contentful/f36-pill": "^4.65.5",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tabs": "^4.65.5",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.39.0.tgz",
-      "integrity": "sha512-CwfTdZbOeT2BWkBIpmV3JmG7j0g5VkVJj4mHhHnYzJ22hV5UNaa7Oojqv13mGe0TzdOYNc8JxuGTi0Uq0Ms94w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.65.5.tgz",
+      "integrity": "sha512-w4FQst+STqNi5sWQYgbW24eSWUyl2kCO40LK4YKO7Ugv2VUD5b6F25QqRrjs39bryTZWPO6g8ZLP6FEijdzv1g==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2378,11 +2389,11 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.39.0.tgz",
-      "integrity": "sha512-ruUThGRNFsXhDtzIcsRQsu74JKn3qtzqauUY/0MKbgm6oHyzLqhPhBG4fNF1QajunbbM0SSR0KSxosCipmOKPQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.65.5.tgz",
+      "integrity": "sha512-oGQGxRbdUlG6esKjV4NkPRYbIGUWTfwoT8T1CYz//bSGAi+K0Cvzf0oVpvjso1AYlVazXuByb0s1nOT48WlIug==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -2394,20 +2405,20 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.39.0.tgz",
-      "integrity": "sha512-Ik9bmAK86OFH8hKtHf0uRXQd7smxi3uMJ6TdWCXuiiGUJifiQ9IdcvGZmwEI8tDhYEp45IoxrPXRh5YM4a5cbg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.65.5.tgz",
+      "integrity": "sha512-ehA99+gV6i7IUcZopge+ElrVrO6ONQbfCEu9KqQRzrJ3Qg4m2k5HsTzmtkJi7DMKkplTy5Z4VIFDsx+yoNqwqg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
@@ -2416,12 +2427,12 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.39.0.tgz",
-      "integrity": "sha512-UsMTCsdSQA4RtPdJ8AvtKgin20eYd0opWD1rYx0tVfenxTHuFv1TzD7lQNPCdp978+yOTHbN9jzoE+iC/mxRjg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.65.5.tgz",
+      "integrity": "sha512-cs5A53ucqiX78S6wWmSATHo4BzccgUTrQ6Xzz9DLkXfNT/SLePTI9urIp8a/YChr0p76cYDcta4EjVt7ie+Ilw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       },
@@ -2431,13 +2442,14 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.39.0.tgz",
-      "integrity": "sha512-K14ez/t0qaHUFI4VhGNVF2fSh7S+M5E/aiBDtII+TEzIDc8EVCGJO2X3HWSK+inD0xsRbIIHzDjYOG6rDLt5qQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.65.5.tgz",
+      "integrity": "sha512-QZXcWK8TrGYTaES1rWniJlOER673qHjnqiA1YD51Q53ACkDJ2OenzbNlHq7Rg65MLV9JognCXpXJqqjyMXCmxg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2446,12 +2458,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.39.0.tgz",
-      "integrity": "sha512-9qiQk3C+UT1MB+CD1AjKVXlcztbtD88BiiMjv9fZt4EMwBTEQM2nmxJxII4uAjBkuBphRZkTyoy8icoePJbaWA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.65.5.tgz",
+      "integrity": "sha512-ZnB+XtHe57JYBhqePLkp88Kn1xh41tLyJQec23nsz3k8EIyaTUy5tGVJ7JQoZOVYKfXlu6dqg9aKrzVhhgZG6A==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2460,20 +2472,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.39.0.tgz",
-      "integrity": "sha512-SKPrLdforYrPtDQM4LZGJacOmFuwdMAE3g7b6DO+OJPOX7GFTZyCdFpTit444SZeK3dK3a4kczrwZ1pw4a1tJw==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.65.5.tgz",
+      "integrity": "sha512-oN+SGGsd215Kdu9FyVgoywPdpdGBP0yLQMs2iK51pdNfnCbxXQ/vqBsMk6IU9SgIPAKbnQvKXnd6cQIQ2VbSNA==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2482,14 +2494,15 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.39.0.tgz",
-      "integrity": "sha512-ljEQI4EVgivUaBqblZRnf3WQRT/3/pTs9PPkkRPiPyZV2PRGc1UrBtIClXu35pm2ZkvkfKjANbwSoJJBvly+UA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.65.5.tgz",
+      "integrity": "sha512-XkueX0CcF2ZdcwBBe/mD3GUSROsXcIwXmXdPSaQ1kgpCNVf9DS/GMgQPRCh7YCPOfT9jVDaeO8qg2JWRXsxrbg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2498,25 +2511,26 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.39.0.tgz",
-      "integrity": "sha512-YGfijPApMrHEJaoHgZBTzYZTK4OkUtN+n90ICqReKn7I3jZYC2O/bI85aQsLSbZyRuEP6qqKb3W2exYowx4W5A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.65.5.tgz",
+      "integrity": "sha512-ZdASqrHxSRhbOAzHdUqrdX/RrkAake6bjkkQ9/5LYNkM/Ru1hVcn4vgKSx65dA3+Eo6QzTA9zmETRyqn6awzeg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2526,29 +2540,30 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.39.0.tgz",
-      "integrity": "sha512-uKCDlEal+jahTj+lThY7q7jpaJobukVB4CodsNPNNrrJGAFuWq8dbVN3e7V81Cnn50qsJQejt6TUqs0hJd4W/w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.65.5.tgz",
+      "integrity": "sha512-OH+odg2hjB9/9i6k71hqvmufNiFP0l/pob2+Yr2RtReM4+6gdULsNlZpo8SUv8L5ryX2/QdlEulIqk6Do9rYpg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.39.0.tgz",
-      "integrity": "sha512-HzSZe5BJzoDKtqLoDd/4tvrxSX4ONYLVLcllmKbW+5PaL6ybNCbIZubN7KX7Jg7R/He0tZEAnin0sYBdExkOLQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.65.5.tgz",
+      "integrity": "sha512-XrCx3nWMbtl4KjobntUpzkccSdU/mmFHi3TSMV1VZ8aECIu3FuEx2RgBY5XRIQOSw4AfbA72RQO/HA4opsmJUQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2557,15 +2572,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.39.0.tgz",
-      "integrity": "sha512-CSjYdW1bWa7ncUfZ8RXqvg/DJCZgzTbj2PH2q6NZMzn7g2z9GGWWcNYx6ARw+4VwDfr0EqGANlC3G9fsK6GZbg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.65.5.tgz",
+      "integrity": "sha512-LoL948QiBUrRiWqQAmEIWtYb00Q2LDgvWwjL1LQDIpUx+Rvig657r5umypYUS31OKTYlOrkfo+J1JfpWi8/bMQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2575,17 +2590,36 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-note": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.39.0.tgz",
-      "integrity": "sha512-EEICs4dW/IxCJ0pk7Nw4dbS9KUDPkEU2v/eqG/lHgKSll9LLLoiUtRpBqVWI8v5MBLqOESUswObxwb7XVx9/Bg==",
+    "node_modules/@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
         "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-note": {
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.65.5.tgz",
+      "integrity": "sha512-TFd9p8Qg/Y+1Oq5aJEw5ybjaZs49CoBuhjxrybC8U4ODh0gpCUA0lJEVyWcaejyitTt2mSYJIhn9l/7CPrb+iw==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2594,16 +2628,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.39.0.tgz",
-      "integrity": "sha512-GXVCgeYrH3mKWyJcB1DAzgTiyduiuyGa9beOOdJaf7OW1xUhWjyy4fb78MfeFP4Rr74fE7eUxZm+J/HfQdiavA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.65.5.tgz",
+      "integrity": "sha512-jGtPKDc7mIHgNtSQQvN25c+L6JIf5mR9aXE8b7WPOc3vaFq8bln9OMMiivvD+iMDPbWf0bukNNn3NNP/bt+oZw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2614,32 +2648,34 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.39.0.tgz",
-      "integrity": "sha512-5Opkm2hblU39AavGGXMJhwevS0zgUFvIxMyhLlmN7FU/7XHT1YzgJ7r6z+aShlmitF61PGvWxYk6e8UXmMBt6w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.65.5.tgz",
+      "integrity": "sha512-+UBNt5UbmPQElwhtzS6OLRWAbR/pi45HKSl3uGLlJ5V1HNhEcebLzqWGPeQuv7xkHMVUbTTJKwM0G2zD7b8dQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.39.0.tgz",
-      "integrity": "sha512-hQtRAu3CWBRby5lWRC999mdkC4QJMXx0D+ebIK+3vm3+vzMkOFodmFwJppAjxsZ7cuocMRLEXwJsMpXKURxggg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.65.5.tgz",
+      "integrity": "sha512-mpK3StAaXmP/XpDDR6fVvM910RfY0C97VnVcbXA3ZZ9itb68jKzb7Y+gRfEJXGHza9oE/qgQEQuLHdNTqhuHEw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2648,29 +2684,30 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.39.0.tgz",
-      "integrity": "sha512-YgVxzl3M+BMF6Auuuv9pAUX+qLyflGzI68IdumhoiVeOErythwnhuEt7+0CAslOFkeREsWjXEqjTkFXTJ1rLfw==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.65.5.tgz",
+      "integrity": "sha512-qZO0T8qyTg4FsSsgfPTk4/ZxQSFOWbajLI+LxpeC0UH95gb5xoTkb+jHBDRdJ+xQyIZqYAcycI2HK6IJZEfboQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.39.0.tgz",
-      "integrity": "sha512-N6mtHs0II7h0T7itiqLa2OTs2abMpm0cU7S+0Cd5A17qfPIhq66SS08d3egnPzKnJbg9gZ5z++nxzfMvuC/S1A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.65.5.tgz",
+      "integrity": "sha512-qb48ythK06bShtJh3VopNVygg9h3psjbo45weh1IlQrlMFZRXsGtn5sdvMAK/982QcUuUSvxjWhAyU3QYkpeMQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-table": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2679,27 +2716,28 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.39.0.tgz",
-      "integrity": "sha512-DWJ5lJs6w8/qMXhFVqQ1kO/VqeiVSd5YP4VpdWFN2inXaGF/NOp00jaDkq6vO3uNj8MVb8PbHnmlREv4PQw+Vg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.65.5.tgz",
+      "integrity": "sha512-nMn5ul1nrLcUOygzZ8LPavuFHnfPMZAo1BSarYhutz83CmEEVzlkAoGwM/cJCCrm6ylb3oXiQOZSUxmEJeqxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.39.0.tgz",
-      "integrity": "sha512-8FbJu6N/JSqHDJfIjjkJMHcvgH5ZVVIoNFhNEis/dyFYpAkFZyuGJj7gqWQGjL7Kc0TM5PmA/rMiBTl0tPG8DQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.65.5.tgz",
+      "integrity": "sha512-HBp1yC7y8+/5fq46d0uPgYtGiKXEmUHFAvnJQfOQYdmQcnYHYoHvxII2d606cpfulBjydNDMha+HZV09jepQaA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2708,12 +2746,12 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.39.0.tgz",
-      "integrity": "sha512-e+tmL2SdED/dKC2NDRz3yeKMEd4xL/ZjEyOj4a6Pbcbv73PqwMoIIFNgvwLn6d5Kdu/SIjebK6VWaKBfyYhe5A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.65.5.tgz",
+      "integrity": "sha512-7lEFs4IoYwIEOXqlEBQnO0dnKmGkASoKqeTP/lA6XS80Ymoled3XZLcc3ICZhjsZvtSRrXQ+3yIiDc1Y2EzIfg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       },
@@ -2723,31 +2761,32 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.39.0.tgz",
-      "integrity": "sha512-ya+VtwnnYb5Neg1CFcs8QeD+t5SCQ14BOXzOuqA/dPb0UmoOo8ozx3G5HIjYHA9a/TAXLvAf8MmpRqqIa8fWPQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.65.5.tgz",
+      "integrity": "sha512-1Jk/tebqIif+f4ef8QV+mxdzfA7g+YotAGRkkFjVCPjO1KX1GI6Ocyr0xI4h0fRjnUOJ4qqy7AU3a2DnbX07jw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-tokens": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
-      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.5.tgz",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.39.0.tgz",
-      "integrity": "sha512-9oxwO3texxJEyZqaXaaxPr1S9TUbKF73bKYTPu08ift500EBh0NuvuRcAf3Xyt5ZGo5uvQKaVtA0ZIUv6LMIUg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.65.5.tgz",
+      "integrity": "sha512-12U5tYHIBEwK4WDXlt6riNWLEKLeatjtsz9H0zXp0ANANkNFSpVO32ED6fFHHDCtK6iekm/3EQ2QJ7Jua4y0iQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -2759,22 +2798,24 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.39.0.tgz",
-      "integrity": "sha512-gkhcokIIpKykL1X5LR1DZwD5lDQlCgw1S3b+fP+BWBo889u+ei9yr4DP/gY2bro8tzFAZzUZXLy0/CA9zn2xdA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.65.5.tgz",
+      "integrity": "sha512-hprmtdy0y661nxUYn2QddbKJyuHszG8j5p6Iz3CFEN2nCNaOe1OtCENrv1amZmDBHOj1x8ldWF7Bm/Nnqva45g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "dependencies": {
         "emotion": "^10.0.17"
       },
@@ -3169,9 +3210,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -3996,195 +4037,293 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
-      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
-      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
-      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.2",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
-      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-roving-focus": "1.0.3",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -4625,10 +4764,11 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "dependencies": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -4868,9 +5008,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4891,27 +5031,18 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dependencies": {
-        "@types/react": "^16"
-      }
-    },
     "node_modules/@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4930,11 +5061,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -7575,9 +7701,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7615,9 +7741,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -9421,9 +9547,9 @@
       "dev": true
     },
     "node_modules/focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -12146,6 +12272,15 @@
       "dependencies": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.7.3"
+      }
+    },
+    "node_modules/legacy-swc-helpers": {
+      "name": "@swc/helpers",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/leven": {
@@ -14886,22 +15021,20 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14939,15 +15072,15 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
-      "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0",
+        "date-fns": "^2.28.0 || ^3.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
@@ -15008,17 +15141,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "16.14.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-error-overlay": {
@@ -15028,20 +15159,20 @@
       "dev": true
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
-      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       },
       "peerDependencies": {
@@ -15750,12 +15881,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -17339,9 +17469,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -19957,9 +20087,9 @@
       }
     },
     "@contentful/dam-app-base": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.3.2.tgz",
-      "integrity": "sha512-Q6kPUCMW6xwh5MwZmE+f4MJ9BfYdXKqGBJGvGl6ou+CKYyjbZgbqrQ9Ig3PMwSyIvRDpjOaoIK2BYWHf5mk6cA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.0.tgz",
+      "integrity": "sha512-XuUq93wem0IMDuDzHnuEZkClFE3fYbdagAw6NIjo38ToKZEWS86WzYoKIJqm41R4jRRBF1tU3fmI48t93OTDmw==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -19971,163 +20101,164 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.39.0.tgz",
-      "integrity": "sha512-XucnOATPicFuaqjTt8rkv3Yom9pJjXLk0ZJnVgHezPgCjUBM2UlQSaXbitTC5V0K83Ojce82aDfaG0IznVDwFg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.65.5.tgz",
+      "integrity": "sha512-2TIERDEQ3ChigDdiMimQl9FiDV8jIKqFil+a1smfPZrUway64NKQ9xo4fEHlFCe3N218zCvhZklzemmO3s2cQA==",
       "requires": {
-        "@contentful/f36-collapse": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.39.0.tgz",
-      "integrity": "sha512-9aEtFeHeOVYaPKmc2F3FrBEFWePlH5iQnQvCUmrZLGPcjuHOnKczpcxfu0yBKnm1dSb7uWWEGzUlmf7R7YYZYA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.65.5.tgz",
+      "integrity": "sha512-/SIKJ1RA8ZHkVIrgVzijDTQCAhos3eaDYnpcA1q2OCn7uBU5a4QMmCjC8U2vb0rmchSxK9Ddg1bASCdF2wjhuA==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.39.0.tgz",
-      "integrity": "sha512-2eHQ1QA32xkHFuAXvbligzGHlxeW/SwF2YCrE74IlJf5HflwMi/YjNV5IscG9s+xvQe7wOmN4SY+ZH8+pE0j2g==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.65.5.tgz",
+      "integrity": "sha512-QmTH8U3VWP/JIZVvLVis4UrHdjqvtFVFQP9q4XOCsjCHpI4QHx05pVD3vozBoWr0vAVeIAu2YQQYqDsqcLkg7w==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.39.0.tgz",
-      "integrity": "sha512-KO+5SZyYMpgSig3vJ73EwIWHpKCQwh/6qi/cePiZjfnJe1OaAWyIBj6iqMmH4o9C6WZRneb/5xLknh6sgAkHCg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.65.5.tgz",
+      "integrity": "sha512-EEwf1ZGYQBeOxHnFdem0rCXDPWN1VgNxOpkJgpX8gWryb3xTBoa4/rf/ZQb2H/cQzWi7hVjStVgnUdEiIf2jAA==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.39.0.tgz",
-      "integrity": "sha512-zV3kQV4sDZXYjG3haE89TsWUsM2b0hh0v6R0WjO03MAHZvVO/nCWNgvL7e9v7PjqV6dmfRaC4w6Zb5TYocWkDg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.65.5.tgz",
+      "integrity": "sha512-+ja1Aba9kBOQNNmZ48esvj/gsR/S6lHT0ZRiR+oIue6eLowdWcurdEhUtv9jzpGiMlA3JOD36M9aalmuVYLA4Q==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-spinner": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.39.0.tgz",
-      "integrity": "sha512-NYMBAs+rVlMgO0F2+Onvdz/aG8CRry3BO1ZXsTSmj3/zoRSsRxZeM/yeZBiy/oXPQnc0mpcB+eK8RpWLDReK3w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.65.5.tgz",
+      "integrity": "sha512-4xg0Vm0gF/gzZfOsv4t1NHJ0lE5/QKHpJnoPmxgn4k5PiB6FtODjr29X+jF+m2Q5KB94aBhV3F0k7rX79GdL4Q==",
       "requires": {
-        "@contentful/f36-asset": "^4.39.0",
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.39.0.tgz",
-      "integrity": "sha512-gCZZjHYKu3Ey/aOZfhNb56iISA84mjxF4yRI1A8g2ytfPQqvwc1O1icbLORpY+uzbg/V59YBgMYYxrycIQRE6w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.65.5.tgz",
+      "integrity": "sha512-aaVkGlPnEcV/reSbzegrRB8VRPiKWIfMgxrliOzA0uT8btTsKdgXySwFwyFiKyw81bfbLugZYan6jkWVcnVRrg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.39.0.tgz",
-      "integrity": "sha512-gm8jRKptK2xs5ENfozULZhawgiFTnuhgqEOry/SMXGaAOZ++KY7LttWA/4h8cwKXtkTTIcyN9baN8tT8XPuGZg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.65.5.tgz",
+      "integrity": "sha512-xQ6mi7+Rwj04lrF8O1PaAIvRXj6W8U16aYaJXQdc3MgNvUT9eUqEeN09LKTqwTpl/giuetrH/Zey6U+V2ikSkg==",
       "requires": {
-        "@contentful/f36-accordion": "^4.39.0",
-        "@contentful/f36-asset": "^4.39.0",
-        "@contentful/f36-autocomplete": "^4.39.0",
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-card": "^4.39.0",
-        "@contentful/f36-collapse": "^4.39.0",
-        "@contentful/f36-copybutton": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-datepicker": "^4.39.0",
-        "@contentful/f36-datetime": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-empty-state": "^4.39.0",
-        "@contentful/f36-entity-list": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.39.0",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-modal": "^4.39.0",
-        "@contentful/f36-note": "^4.39.0",
-        "@contentful/f36-notification": "^4.39.0",
-        "@contentful/f36-pagination": "^4.39.0",
-        "@contentful/f36-pill": "^4.39.0",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-spinner": "^4.39.0",
-        "@contentful/f36-table": "^4.39.0",
-        "@contentful/f36-tabs": "^4.39.0",
-        "@contentful/f36-text-link": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.5",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-autocomplete": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-card": "^4.65.5",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-copybutton": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-datepicker": "^4.65.5",
+        "@contentful/f36-datetime": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-empty-state": "^4.65.5",
+        "@contentful/f36-entity-list": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.5",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-modal": "^4.65.5",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.5",
+        "@contentful/f36-notification": "^4.65.5",
+        "@contentful/f36-pagination": "^4.65.5",
+        "@contentful/f36-pill": "^4.65.5",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tabs": "^4.65.5",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.39.0.tgz",
-      "integrity": "sha512-CwfTdZbOeT2BWkBIpmV3JmG7j0g5VkVJj4mHhHnYzJ22hV5UNaa7Oojqv13mGe0TzdOYNc8JxuGTi0Uq0Ms94w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.65.5.tgz",
+      "integrity": "sha512-w4FQst+STqNi5sWQYgbW24eSWUyl2kCO40LK4YKO7Ugv2VUD5b6F25QqRrjs39bryTZWPO6g8ZLP6FEijdzv1g==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.39.0.tgz",
-      "integrity": "sha512-ruUThGRNFsXhDtzIcsRQsu74JKn3qtzqauUY/0MKbgm6oHyzLqhPhBG4fNF1QajunbbM0SSR0KSxosCipmOKPQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.65.5.tgz",
+      "integrity": "sha512-oGQGxRbdUlG6esKjV4NkPRYbIGUWTfwoT8T1CYz//bSGAi+K0Cvzf0oVpvjso1AYlVazXuByb0s1nOT48WlIug==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -20135,282 +20266,300 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.39.0.tgz",
-      "integrity": "sha512-Ik9bmAK86OFH8hKtHf0uRXQd7smxi3uMJ6TdWCXuiiGUJifiQ9IdcvGZmwEI8tDhYEp45IoxrPXRh5YM4a5cbg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.65.5.tgz",
+      "integrity": "sha512-ehA99+gV6i7IUcZopge+ElrVrO6ONQbfCEu9KqQRzrJ3Qg4m2k5HsTzmtkJi7DMKkplTy5Z4VIFDsx+yoNqwqg==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.39.0.tgz",
-      "integrity": "sha512-UsMTCsdSQA4RtPdJ8AvtKgin20eYd0opWD1rYx0tVfenxTHuFv1TzD7lQNPCdp978+yOTHbN9jzoE+iC/mxRjg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.65.5.tgz",
+      "integrity": "sha512-cs5A53ucqiX78S6wWmSATHo4BzccgUTrQ6Xzz9DLkXfNT/SLePTI9urIp8a/YChr0p76cYDcta4EjVt7ie+Ilw==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.39.0.tgz",
-      "integrity": "sha512-K14ez/t0qaHUFI4VhGNVF2fSh7S+M5E/aiBDtII+TEzIDc8EVCGJO2X3HWSK+inD0xsRbIIHzDjYOG6rDLt5qQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.65.5.tgz",
+      "integrity": "sha512-QZXcWK8TrGYTaES1rWniJlOER673qHjnqiA1YD51Q53ACkDJ2OenzbNlHq7Rg65MLV9JognCXpXJqqjyMXCmxg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.39.0.tgz",
-      "integrity": "sha512-9qiQk3C+UT1MB+CD1AjKVXlcztbtD88BiiMjv9fZt4EMwBTEQM2nmxJxII4uAjBkuBphRZkTyoy8icoePJbaWA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.65.5.tgz",
+      "integrity": "sha512-ZnB+XtHe57JYBhqePLkp88Kn1xh41tLyJQec23nsz3k8EIyaTUy5tGVJ7JQoZOVYKfXlu6dqg9aKrzVhhgZG6A==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.39.0.tgz",
-      "integrity": "sha512-SKPrLdforYrPtDQM4LZGJacOmFuwdMAE3g7b6DO+OJPOX7GFTZyCdFpTit444SZeK3dK3a4kczrwZ1pw4a1tJw==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.65.5.tgz",
+      "integrity": "sha512-oN+SGGsd215Kdu9FyVgoywPdpdGBP0yLQMs2iK51pdNfnCbxXQ/vqBsMk6IU9SgIPAKbnQvKXnd6cQIQ2VbSNA==",
       "requires": {
-        "@contentful/f36-badge": "^4.39.0",
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-drag-handle": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.39.0",
-        "@contentful/f36-skeleton": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.39.0.tgz",
-      "integrity": "sha512-ljEQI4EVgivUaBqblZRnf3WQRT/3/pTs9PPkkRPiPyZV2PRGc1UrBtIClXu35pm2ZkvkfKjANbwSoJJBvly+UA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.65.5.tgz",
+      "integrity": "sha512-XkueX0CcF2ZdcwBBe/mD3GUSROsXcIwXmXdPSaQ1kgpCNVf9DS/GMgQPRCh7YCPOfT9jVDaeO8qg2JWRXsxrbg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.39.0.tgz",
-      "integrity": "sha512-YGfijPApMrHEJaoHgZBTzYZTK4OkUtN+n90ICqReKn7I3jZYC2O/bI85aQsLSbZyRuEP6qqKb3W2exYowx4W5A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.65.5.tgz",
+      "integrity": "sha512-ZdASqrHxSRhbOAzHdUqrdX/RrkAake6bjkkQ9/5LYNkM/Ru1hVcn4vgKSx65dA3+Eo6QzTA9zmETRyqn6awzeg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.39.0.tgz",
-      "integrity": "sha512-uKCDlEal+jahTj+lThY7q7jpaJobukVB4CodsNPNNrrJGAFuWq8dbVN3e7V81Cnn50qsJQejt6TUqs0hJd4W/w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.65.5.tgz",
+      "integrity": "sha512-OH+odg2hjB9/9i6k71hqvmufNiFP0l/pob2+Yr2RtReM4+6gdULsNlZpo8SUv8L5ryX2/QdlEulIqk6Do9rYpg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.39.0.tgz",
-      "integrity": "sha512-HzSZe5BJzoDKtqLoDd/4tvrxSX4ONYLVLcllmKbW+5PaL6ybNCbIZubN7KX7Jg7R/He0tZEAnin0sYBdExkOLQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.65.5.tgz",
+      "integrity": "sha512-XrCx3nWMbtl4KjobntUpzkccSdU/mmFHi3TSMV1VZ8aECIu3FuEx2RgBY5XRIQOSw4AfbA72RQO/HA4opsmJUQ==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.39.0.tgz",
-      "integrity": "sha512-CSjYdW1bWa7ncUfZ8RXqvg/DJCZgzTbj2PH2q6NZMzn7g2z9GGWWcNYx6ARw+4VwDfr0EqGANlC3G9fsK6GZbg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.65.5.tgz",
+      "integrity": "sha512-LoL948QiBUrRiWqQAmEIWtYb00Q2LDgvWwjL1LQDIpUx+Rvig657r5umypYUS31OKTYlOrkfo+J1JfpWi8/bMQ==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
-    "@contentful/f36-note": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.39.0.tgz",
-      "integrity": "sha512-EEICs4dW/IxCJ0pk7Nw4dbS9KUDPkEU2v/eqG/lHgKSll9LLLoiUtRpBqVWI8v5MBLqOESUswObxwb7XVx9/Bg==",
+    "@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icon": "^4.39.0",
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
         "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/f36-note": {
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.65.5.tgz",
+      "integrity": "sha512-TFd9p8Qg/Y+1Oq5aJEw5ybjaZs49CoBuhjxrybC8U4ODh0gpCUA0lJEVyWcaejyitTt2mSYJIhn9l/7CPrb+iw==",
+      "requires": {
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.39.0.tgz",
-      "integrity": "sha512-GXVCgeYrH3mKWyJcB1DAzgTiyduiuyGa9beOOdJaf7OW1xUhWjyy4fb78MfeFP4Rr74fE7eUxZm+J/HfQdiavA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.65.5.tgz",
+      "integrity": "sha512-jGtPKDc7mIHgNtSQQvN25c+L6JIf5mR9aXE8b7WPOc3vaFq8bln9OMMiivvD+iMDPbWf0bukNNn3NNP/bt+oZw==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.39.0.tgz",
-      "integrity": "sha512-5Opkm2hblU39AavGGXMJhwevS0zgUFvIxMyhLlmN7FU/7XHT1YzgJ7r6z+aShlmitF61PGvWxYk6e8UXmMBt6w==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.65.5.tgz",
+      "integrity": "sha512-+UBNt5UbmPQElwhtzS6OLRWAbR/pi45HKSl3uGLlJ5V1HNhEcebLzqWGPeQuv7xkHMVUbTTJKwM0G2zD7b8dQA==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-forms": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.39.0.tgz",
-      "integrity": "sha512-hQtRAu3CWBRby5lWRC999mdkC4QJMXx0D+ebIK+3vm3+vzMkOFodmFwJppAjxsZ7cuocMRLEXwJsMpXKURxggg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.65.5.tgz",
+      "integrity": "sha512-mpK3StAaXmP/XpDDR6fVvM910RfY0C97VnVcbXA3ZZ9itb68jKzb7Y+gRfEJXGHza9oE/qgQEQuLHdNTqhuHEw==",
       "requires": {
-        "@contentful/f36-button": "^4.39.0",
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.39.0",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.39.0.tgz",
-      "integrity": "sha512-YgVxzl3M+BMF6Auuuv9pAUX+qLyflGzI68IdumhoiVeOErythwnhuEt7+0CAslOFkeREsWjXEqjTkFXTJ1rLfw==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.65.5.tgz",
+      "integrity": "sha512-qZO0T8qyTg4FsSsgfPTk4/ZxQSFOWbajLI+LxpeC0UH95gb5xoTkb+jHBDRdJ+xQyIZqYAcycI2HK6IJZEfboQ==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.39.0.tgz",
-      "integrity": "sha512-N6mtHs0II7h0T7itiqLa2OTs2abMpm0cU7S+0Cd5A17qfPIhq66SS08d3egnPzKnJbg9gZ5z++nxzfMvuC/S1A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.65.5.tgz",
+      "integrity": "sha512-qb48ythK06bShtJh3VopNVygg9h3psjbo45weh1IlQrlMFZRXsGtn5sdvMAK/982QcUuUSvxjWhAyU3QYkpeMQ==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-table": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.39.0.tgz",
-      "integrity": "sha512-DWJ5lJs6w8/qMXhFVqQ1kO/VqeiVSd5YP4VpdWFN2inXaGF/NOp00jaDkq6vO3uNj8MVb8PbHnmlREv4PQw+Vg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.65.5.tgz",
+      "integrity": "sha512-nMn5ul1nrLcUOygzZ8LPavuFHnfPMZAo1BSarYhutz83CmEEVzlkAoGwM/cJCCrm6ylb3oXiQOZSUxmEJeqxiA==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.39.0.tgz",
-      "integrity": "sha512-8FbJu6N/JSqHDJfIjjkJMHcvgH5ZVVIoNFhNEis/dyFYpAkFZyuGJj7gqWQGjL7Kc0TM5PmA/rMiBTl0tPG8DQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.65.5.tgz",
+      "integrity": "sha512-HBp1yC7y8+/5fq46d0uPgYtGiKXEmUHFAvnJQfOQYdmQcnYHYoHvxII2d606cpfulBjydNDMha+HZV09jepQaA==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.39.0",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.39.0.tgz",
-      "integrity": "sha512-e+tmL2SdED/dKC2NDRz3yeKMEd4xL/ZjEyOj4a6Pbcbv73PqwMoIIFNgvwLn6d5Kdu/SIjebK6VWaKBfyYhe5A==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.65.5.tgz",
+      "integrity": "sha512-7lEFs4IoYwIEOXqlEBQnO0dnKmGkASoKqeTP/lA6XS80Ymoled3XZLcc3ICZhjsZvtSRrXQ+3yIiDc1Y2EzIfg==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.39.0.tgz",
-      "integrity": "sha512-ya+VtwnnYb5Neg1CFcs8QeD+t5SCQ14BOXzOuqA/dPb0UmoOo8ozx3G5HIjYHA9a/TAXLvAf8MmpRqqIa8fWPQ==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.65.5.tgz",
+      "integrity": "sha512-1Jk/tebqIif+f4ef8QV+mxdzfA7g+YotAGRkkFjVCPjO1KX1GI6Ocyr0xI4h0fRjnUOJ4qqy7AU3a2DnbX07jw==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tokens": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
-      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.5.tgz",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.39.0.tgz",
-      "integrity": "sha512-9oxwO3texxJEyZqaXaaxPr1S9TUbKF73bKYTPu08ift500EBh0NuvuRcAf3Xyt5ZGo5uvQKaVtA0ZIUv6LMIUg==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.65.5.tgz",
+      "integrity": "sha512-12U5tYHIBEwK4WDXlt6riNWLEKLeatjtsz9H0zXp0ANANkNFSpVO32ED6fFHHDCtK6iekm/3EQ2QJ7Jua4y0iQ==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -20418,19 +20567,20 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.39.0.tgz",
-      "integrity": "sha512-gkhcokIIpKykL1X5LR1DZwD5lDQlCgw1S3b+fP+BWBo889u+ei9yr4DP/gY2bro8tzFAZzUZXLy0/CA9zn2xdA==",
+      "version": "4.65.5",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.65.5.tgz",
+      "integrity": "sha512-hprmtdy0y661nxUYn2QddbKJyuHszG8j5p6Iz3CFEN2nCNaOe1OtCENrv1amZmDBHOj1x8ldWF7Bm/Nnqva45g==",
       "requires": {
-        "@contentful/f36-core": "^4.39.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "requires": {
         "emotion": "^10.0.17"
       }
@@ -20657,9 +20807,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "requires": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -21296,145 +21446,145 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
-      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
-      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-roving-focus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
-      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.2",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
-      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-roving-focus": "1.0.3",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       }
     },
     "@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -21736,10 +21886,11 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "requires": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -21973,9 +22124,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -21996,27 +22147,18 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
-    "@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "requires": {
-        "@types/react": "^16"
-      }
-    },
     "@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "requires": {
         "@types/react": "*"
       }
@@ -22035,11 +22177,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -24023,9 +24160,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -24053,9 +24190,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -25450,9 +25587,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -27461,6 +27598,14 @@
         "shell-quote": "^1.7.3"
       }
     },
+    "legacy-swc-helpers": {
+      "version": "npm:@swc/helpers@0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -29326,19 +29471,17 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "requires": {}
     },
     "react-app-polyfill": {
@@ -29364,9 +29507,9 @@
       }
     },
     "react-day-picker": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
-      "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "requires": {}
     },
     "react-dev-utils": {
@@ -29416,14 +29559,12 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.0"
       }
     },
     "react-error-overlay": {
@@ -29433,20 +29574,20 @@
       "dev": true
     },
     "react-fast-compare": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
-      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       }
     },
@@ -29942,12 +30083,11 @@
       }
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -31169,9 +31309,9 @@
       }
     },
     "use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -8,9 +8,9 @@
     "react-scripts": "5.0.1"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "^2.3.2",
-    "react": "16.14.0",
-    "react-dom": "16.14.0"
+    "@contentful/dam-app-base": "^3.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",


### PR DESCRIPTION
## Purpose
Update the Bynder app's version of react to 18, as well as update dam-app-base to v3.0.0

## Breaking Changes
v3 of the dam-app-base is a breaking change for consumers that are on a version of react less than 18.0.0.  Fortunately for the dropbox app, we don't render any actual react code, instead depending on dam-app-base to render react code.  So no changes to the dropbox app necessary.

See [dam-app-base changelog](https://github.com/contentful/apps/blob/master/packages/dam-app-base/CHANGELOG.md#300-2024-05-07)

### Video of bynder working locally
![bydner-working](https://github.com/contentful/marketplace-partner-apps/assets/158083968/0e455a5b-a8d5-4f00-be94-5d840bb5878c)


