### PR TITLE
feat: Transifex app remove the default locale restriction

### DIFF
--- a/apps/transifex/src/locations/ConfigScreen.jsx
+++ b/apps/transifex/src/locations/ConfigScreen.jsx
@@ -103,7 +103,6 @@ function ConfigScreen() {
   const [projectTargetLanguages, setProjectTargetLanguages] = useState([]);
   const [selectedContentTypes, setSelectedContentTypes] = useState([]);
   const [selectAllChecked, setSelectAllChecked] = useState(false);
-  const [defaultLocaleDoesNotMatch, setDefaultLocaleDoesNotMatch] = useState(false);
   const [installationId, setInstallationId] = useState('');
   const [appIsInstalled, setAppIsInstalled] = useState('');
   const [pushTrigger, setPushTrigger] = useState('t');
@@ -269,16 +268,6 @@ function ConfigScreen() {
       setProjectAlreadyConnected(
         tokenData.data.attributes.is_project_connected,
       );
-      if (locales && locales.length > 0) {
-        const defaultLocale = locales.filter(
-          (locale) => locale.default === true,
-        )[0];
-        if (defaultLocale.code.replace(/-/g, '_') !== key) {
-          setDefaultLocaleDoesNotMatch(true);
-        } else {
-          setDefaultLocaleDoesNotMatch(false);
-        }
-      }
       setProjectType(tokenData.included[0].attributes.project_type);
     }
     if (tokenData && tokenData.included && tokenData.included[1]) {
@@ -293,13 +282,6 @@ function ConfigScreen() {
   const onConfigure = useCallback(async () => {
     if (installationId === '') {
       sdk.notifier.error('An active Transifex account is required.');
-      return false;
-    }
-
-    if (defaultLocaleDoesNotMatch) {
-      sdk.notifier.error(
-        "This space's default locale should match Transifex project's source language.",
-      );
       return false;
     }
 
@@ -546,14 +528,6 @@ function ConfigScreen() {
                           <Note variant="negative">
                             Contentful integration only supports file projects.
                             Please select another project
-                          </Note>
-                        </Box>
-                      )}
-                      {defaultLocaleDoesNotMatch && (
-                        <Box marginTop="spacingM" marginBottom="spacingM">
-                          <Note variant="negative">
-                            This space&apos;s default locale should match
-                            Transifex project&apos;s source language
                           </Note>
                         </Box>
                       )}


### PR DESCRIPTION
## Purpose

Remove the check for contentful space default locale match with transifex project source language, since they can be different now

## Approach


## Testing steps

Try to connect a transifex project with source language different from contentful space's default locale

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
