### PR TITLE
fix: bump dam-app-base for delete functionality fix [ZEND-5025]

### DIFF
--- a/apps/bynder/package-lock.json
+++ b/apps/bynder/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/bynder-assets",
       "version": "1.1.11",
       "dependencies": {
-        "@contentful/dam-app-base": "^3.0.4",
+        "@contentful/dam-app-base": "^3.0.5",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@contentful/dam-app-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.4.tgz",
-      "integrity": "sha512-aCOvykV7xodadeWdZ7bORyW4kVzEr58FamyfEK0sT4KyX5mHNcEpG4+3dBpdjWa5jDEsHOjwhKtAc9P/KybWqA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.5.tgz",
+      "integrity": "sha512-AfHl5ppd7UJTp/h4MbMgJkmkAMmSmKd7/WyGqFcIkYTsXcijWoQuianlseuPcwcLxaKWOgpj6RIyrTfegstF8g==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -20087,9 +20087,9 @@
       }
     },
     "@contentful/dam-app-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.4.tgz",
-      "integrity": "sha512-aCOvykV7xodadeWdZ7bORyW4kVzEr58FamyfEK0sT4KyX5mHNcEpG4+3dBpdjWa5jDEsHOjwhKtAc9P/KybWqA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-3.0.5.tgz",
+      "integrity": "sha512-AfHl5ppd7UJTp/h4MbMgJkmkAMmSmKd7/WyGqFcIkYTsXcijWoQuianlseuPcwcLxaKWOgpj6RIyrTfegstF8g==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "5.0.1"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "^3.0.4",
+    "@contentful/dam-app-base": "^3.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
## Purpose

Bump `dam-app-base` package in Bynder app to update app with fix to delete functionality from [this PR](https://github.com/contentful/apps/pull/7932).

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

I tested the app locally and confirmed that this fixes the issue with deleting selected assets. Also confirmed that key app functionality still works as expected.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

We will need to merge in the `release-please` PR after this to deploy this changes.
