### PR TITLE
feat: Allow multi-reference field for condition and include Select all option for hide field

### DIFF
--- a/apps/flexfields/src/locations/ConfigScreen.tsx
+++ b/apps/flexfields/src/locations/ConfigScreen.tsx
@@ -309,7 +309,7 @@ const ConfigScreen = () => {
       cma.contentType.get({ contentTypeId: contentType }).then((data) => {
         const children = data?.fields;
         let childrenEntities: any[] = [];
-  
+
         children?.forEach((obj) => {
           const linkedContentTypes =
             obj.validations?.[0]?.linkContentType ||
@@ -318,13 +318,10 @@ const ConfigScreen = () => {
             childrenEntities = [...childrenEntities, ...linkedContentTypes];
           }
         });
-  
+
         if (children) {
-          // filter fields with type reference
-          setChildEntities(
-            children?.filter((obj: any) => !obj.hasOwnProperty("items"))
-          );
-  
+          setChildEntities(children);
+
           const targetEntities = [
             {
               id: `${contentType}-sameEntity`,
@@ -338,7 +335,7 @@ const ConfigScreen = () => {
                 ?.name,
             })),
           ];
-  
+
           setTargetEntities(targetEntities);
         }
       });
@@ -446,6 +443,14 @@ const ConfigScreen = () => {
       rules: rulesCopy,
     });
     setIsRuleDeleted(true);
+  };
+
+  const toggleAll = (checked: boolean) => {
+    if (checked) {
+      setTargetEntityField(targetEntityFields.map((field) => field.id));
+    } else {
+      setTargetEntityField([]);
+    }
   };
 
   return (
@@ -695,6 +700,12 @@ const ConfigScreen = () => {
                     )}
                     className={css({ width: "300px !important" })}
                   >
+                    <Multiselect.SelectAll
+                      onSelectItem={(event) => toggleAll(event.target.checked)}
+                      isChecked={
+                        targetEntityField.length === targetEntityFields.length
+                      }
+                    />
                     {targetEntityFields.map((tef: any) => {
                       return (
                         <Multiselect.Option


### PR DESCRIPTION
## Purpose

1. Allow multi-reference fields to be used in the rule condition.
2. Add Select/deselect all option in the hide field dropdown.

## Approach

1. Removed a filter that restricted showing multi-reference fields.
2. `Multiselect.SelectAll` was used as part of the forma36 multi-select component.

![Screenshot 2024-06-17 at 3 42 17 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/4bace818-0814-4a37-bb19-ad808f1098af)
![Screenshot 2024-06-17 at 3 42 35 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/26f4f9dc-3afc-4a15-8da0-96b656033dd3)
![Screenshot 2024-06-17 at 3 42 42 PM](https://github.com/contentful/marketplace-partner-apps/assets/31496466/c2b29156-d0c5-4203-81c8-5246fb188ef4)


## Testing steps

1. Create a content type with a multi-reference field. Open the FlexFields configuration screen and select the content type. The multi-reference field should show up in the `With field` dropdown.
2. When configuring the rule, the `Hide field` dropdown should show the `Select all` option when `With content type` is selected.
