### PR TITLE
chore: update dependabot with new apps and change to valid timezone []

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -38,7 +38,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -53,7 +53,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -68,7 +68,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -83,7 +83,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -98,7 +98,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -114,7 +114,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -129,7 +129,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -144,7 +144,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -159,7 +159,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -174,7 +174,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -189,7 +189,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -204,7 +204,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -222,7 +222,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -237,7 +237,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'
@@ -252,7 +252,7 @@ updates:
     schedule:
       interval: daily
       time: '03:00'
-      timezone: UTC
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
       prefix: 'fix'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,21 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
+    directory: '/apps/amplitude-experiment'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
     directory: '/apps/bynder'
     ignore:
       - dependency-name: '@types/node'
@@ -229,6 +244,21 @@ updates:
       prefix-development: 'chore'
       include: 'scope'
     directory: '/apps/wix'
+    ignore:
+      - dependency-name: '@types/node'
+        versions:
+          - '>18.15.3'
+  - package-ecosystem: npm
+    schedule:
+      interval: daily
+      time: '03:00'
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
+    directory: '/apps/xilio-transcreate'
     ignore:
       - dependency-name: '@types/node'
         versions:


### PR DESCRIPTION
## Purpose

This PR adds two apps to the dependabot.yml: Amplitude and Xilio Transcreate. This will then mean that the updates for these apps will be separate from other apps so that we can merge these in isolation and have the partner developers look at the PRs for their apps. I also updated the timezone for all dependabot PRs since `UTC` was showing as invalid in VS Code.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
