### PR TITLE
feat: Added support for AVIF image thumbnails [CCS-1240]

### DIFF
--- a/apps/cloudinary2/src/constants.ts
+++ b/apps/cloudinary2/src/constants.ts
@@ -12,5 +12,5 @@ export const DEFAULT_APP_INSTALLATION_PARAMETERS: AppInstallationParameters = {
 export const DEFAULT_BACKEND_PARAMETERS: BackendParameters = {
   apiSecret: '',
 };
-export const VALID_IMAGE_FORMATS = ['svg', 'jpg', 'png', 'gif', 'jpeg', 'tiff', 'ico', 'webp', 'pdf', 'bmp', 'psd', 'eps', 'jxr', 'wdp'];
+export const VALID_IMAGE_FORMATS = ['svg', 'jpg', 'png', 'gif', 'jpeg', 'tiff', 'ico', 'webp', 'pdf', 'bmp', 'psd', 'eps', 'jxr', 'wdp', 'avif'];
 export const BACKEND_BASE_URL = import.meta.env.VITE_CLOUDINARY_BACKEND_BASE_URL;


### PR DESCRIPTION
## Purpose

Customers have asked for AVIF thumbnail support in the cloudinary app [CCS-1240]

## Approach

It's already supported on Cloudinary, just needed to update the list of allowed files




[CCS-1240]: https://contentful.atlassian.net/browse/CCS-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ