### PR TITLE
chore: bump node to v18 LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v18.17
+lts/hydrogen


### PR DESCRIPTION
since our `.npmrc` dictates `engine-strict=true`, make sure we're always allowing the latest v18 LTS