### PR TITLE
fix: only consider PRs to be for new apps if they contain a new package.json [EXT-5337]

### DIFF
--- a/.github/workflows/app-review-utils.ts
+++ b/.github/workflows/app-review-utils.ts
@@ -19,7 +19,8 @@ const getPullRequestFiles = async (github: ValidatorOptions['github'], ctx: Vali
 
 const getNewAppDirectories = (files: PullRequestFile[]) => {
   const newAppDirs = files
-    .filter((file) => file.status === 'added' && file.filename.startsWith('apps/'))
+    // Only consider an PR to contain a new app if a new package.json file was added inside an `apps/` directory
+    .filter((file) => file.status === 'added' && file.filename.startsWith('apps/') && file.filename.endsWith('package.json'))
     .map((file) => file.filename.split('/').slice(0, 2).join('/'));
   return [...new Set(newAppDirs)];
 };

--- a/.github/workflows/new-app-review/index.ts
+++ b/.github/workflows/new-app-review/index.ts
@@ -29,9 +29,7 @@ async function loadValidators(directory: string): Promise<Record<PropertyKey, Va
 }
 
 async function review({ github, ctx, ghCore }: ValidatorOptions): Promise<void> {
-  const validators = await loadValidators(path.join(__dirname, 'validators'));
   const prNumber = ctx.payload.pull_request?.number;
-
   if (!prNumber) {
     console.log('Pull request number is not found in the context payload.');
     return;
@@ -47,6 +45,7 @@ async function review({ github, ctx, ghCore }: ValidatorOptions): Promise<void> 
 
   console.log('New app submissions found:', newAppDirs);
 
+  const validators = await loadValidators(path.join(__dirname, 'validators'));
   const { failures, warnings } = await validateNewApps(validators, { github, ctx, ghCore }, newAppDirs, files);
 
   if (Object.keys(warnings).length > 0) {


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

This is a tweak to the New App Review check that was recently added in https://github.com/contentful/marketplace-partner-apps/pull/2480. It ensures only new apps go through these checks.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

Ended up being little tricky to determine if an app is new because the github rest api does not return directories in their pr listFiles method. We opted to just check if a new package.json file was added. 

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

1. Submit a change to an existing app - checks should NOT run.
2. Submit a new app with a package.json file - checks should run. 

