### PR TITLE
fix: Prefix env variable with 'VITE' to be injected

### DIFF
--- a/apps/surfer/.env.production
+++ b/apps/surfer/.env.production
@@ -1,2 +1,2 @@
-REACT_APP_SURFER_GUIDELINES_URL=https://app.surferseo.com/static/surfer_guidelines_1_x_x.js
+VITE_REACT_APP_SURFER_GUIDELINES_URL=https://app.surferseo.com/static/surfer_guidelines_1_x_x.js
 

--- a/apps/surfer/index.html
+++ b/apps/surfer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script src="%REACT_APP_SURFER_GUIDELINES_URL%"></script>
+    <script src="%VITE_REACT_APP_SURFER_GUIDELINES_URL%"></script>
     <style>
       iframe,
       #root {


### PR DESCRIPTION
## Purpose

Due to migration from react-scripts to vite, env variable was not injected to html template (by default VITE injects only envs that start with `VITE` (https://vitejs.dev/guide/env-and-mode))

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
Followed default vite behavior.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->
Simply build the app by running `npm run build` and inspect `build/index.html` output file (check src of script tag in head).

## Breaking Changes

Contentful x Surfer app will work again 😁 

## Dependencies and/or References

PR with react-scripts -> vite migration: https://github.com/contentful/marketplace-partner-apps/pull/2469
