### PR TITLE
fix: update path for raster icon [EXT-5671]

### DIFF
--- a/apps/raster/src/locations/ConfigScreen.tsx
+++ b/apps/raster/src/locations/ConfigScreen.tsx
@@ -68,7 +68,7 @@ function ConfigScreen() {
       <Form>
         <Heading>Raster</Heading>
         <Flex flexDirection="column" className="space-y-3">
-          <img src="/raster-icon.svg" alt="Raster" className="w-24 h-24 mb-4 mx-auto" />
+          <img src="./raster-icon.svg" alt="Raster" className="w-24 h-24 mb-4 mx-auto" />
           <Paragraph>
             To utilize the Raster plugin, you must configure it. This requires your Organization ID and Public API Key, which must be set up in Raster
             beforehand. These values can be found on your Raster organization settings page.


### PR DESCRIPTION
## Purpose

The Raster icon on the config page wasn't loading. This PR updates the path to the icon so that it references it properly and it renders.

![Screenshot 2024-09-06 at 2 15 27 PM](https://github.com/user-attachments/assets/04435e56-c475-4afb-b425-17bc4a675f25)

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

Uploaded the bundle with this change to a testing app and confirmed that the logo is visible on the config page.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
