### PR TITLE
fix: use cwd for new-app-review workflow, specify node release type for release-and-deploy workflow [EXT-00]

### DIFF
--- a/.github/workflows/new-app-review.yml
+++ b/.github/workflows/new-app-review.yml
@@ -24,4 +24,6 @@ jobs:
         with:
           script: |
             const { review } = require('./.github/workflows/dist/new-app-review');
+            const { chdir, cwd } = require('node:process');
+            chdir(cwd())
             await review({ github, ctx: context, ghCore: core })

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -18,6 +18,7 @@ jobs:
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
+          release-type: node
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

- new-app-review workflow needs a minor tweak to execute in the correct working directory
- release-and-deploy workflow was complaining about the release-type not being specified
