### PR TITLE
chore: remove deployment path for frontify v2

### DIFF
--- a/apps/frontify/README.md
+++ b/apps/frontify/README.md
@@ -1,3 +1,6 @@
 # Frontify & Contentful
 
 This Contentful UI Extension enables you to have all of your Frontify assets at your fingertips
+
+# !! Deployment note !!
+This app is currently being reverted to its apps repo deployment while the frontify team works on a fix for the v2 issues.

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -14,9 +14,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build --base=./",
-    "install-ci": "npm ci",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5wHGALSJtz7y2EQOLfGhKH --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
+    "install-ci": "npm ci"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
The frontify team is working on a fix for their v2 app. For now, I propose we simply remove the deployment path, which will allow for a cleaning commit diff in the future when they introduce a fix