### PR TITLE
fix: styling in flexfields: wrapper-width

### DIFF
--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -10,6 +10,7 @@ import { type Rule } from "../types/Rule";
 import "codemirror/lib/codemirror.css";
 import DefaultField, { DefaultFieldProps } from "../components/DefaultField";
 import type { ContentFields, KeyValueMap } from "contentful-management/types";
+import { css } from "@emotion/css";
 
 const NoLocalizedFields = (props: { localeName: string }) => (
   <Stack flexDirection="column" alignItems="center" alignContent="center">
@@ -75,8 +76,14 @@ const EntryEditor = () => {
   let hasLocailizedFields = false;
   return (
     <Workbench>
-      <Workbench.Content type="text" style={{ paddingBottom: "200px" }}>
+      <Workbench.Content type="text" style={{ padding: '1.5rem 0px 200px' }}>
         <Form
+          className={css`
+            div {
+              margin-left: 0;
+              margin-right: 0;
+            }
+          `}
           onChange={(ev: any) => {
             const { id, value } = ev.target;
             // ev.target.id looks like fieldId-locale-contentTypeId


### PR DESCRIPTION
## Purpose

The field created by this app are thiner than the original fields


## Approach

provide the same width for flexfields as for the original contentful fields


## Testing steps

it's just a minor css fix


## Breaking Changes

none


## Dependencies and/or References

none


## Deployment

no deploment changes
