### PR TITLE
fix: Update EntryEditor.tsx adds attributes attributes data-field-id={entr…

### DIFF
--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -114,7 +114,6 @@ const EntryEditor = () => {
               );
               control = { ...control, widgetId };
             }
-
             // mode = 'single':
             //    use `focused`
             //    no default locale

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -124,6 +124,7 @@ const EntryEditor = () => {
             if (localeSetings.mode === "multi") {
               return (
                 <>
+                  <div data-field-id={entryId} data-field-api-name={field.id}>
                   <DefaultField
                     key={`${field.id}-${sdk.locales.default}`}
                     name={field.name}
@@ -149,6 +150,7 @@ const EntryEditor = () => {
                           locale={locale}
                         />
                       ))}
+               </div>
                 </>
               );
             } else if (
@@ -157,6 +159,7 @@ const EntryEditor = () => {
             ) {
               hasLocailizedFields = true;
               return (
+              <div data-field-id={entryId} data-field-api-name={field.id}>
                 <DefaultField
                   key={`${field.id}-${localeSetings.focused}`}
                   name={field.name}
@@ -164,6 +167,7 @@ const EntryEditor = () => {
                   control={control}
                   locale={field.localized ? localeSetings.focused : undefined}
                 />
+                </div>
               );
             }
             return null;


### PR DESCRIPTION
## Description
The missing attributes data-field-id={entryId} and data-field-api-name={field.id} are making the Live Preview SDK incompatible with the FlexFields app. Adding these attributes allows users to benefit from both features seamlessly.

## Purpose

The purpose of this change is to address compatibility issues between the Live Preview SDK and the FlexFields app. By adding the data-field-id and data-field-api-name attributes, the Live Preview SDK can properly recognize fields, making it compatible with FlexFields. This resolves an existing limitation where users had to choose one feature over the other.

## Approach

	•	Introduced a new div wrapper around the <DefaultField> component.
	•	The wrapper includes the data-field-id and data-field-api-name attributes, scoped to the field ID (field.id) and entry ID (entryId).
	•	This approach ensures minimal changes to the existing structure while enabling compatibility with the Live Preview SDK.


## Testing steps

	1.	Open a Contentful entry in a space where FlexFields and the Live Preview SDK are enabled.
	2.	Inspect the DOM and verify that each <DefaultField> is now wrapped in a div with the attributes data-field-id and data-field-api-name.
	3. 	Confirm that the Live Preview SDK works as expected alongside FlexFields.
	4.     Ensure that FlexFields functionality remains unaffected.

## Breaking Changes

There are no breaking changes introduced in this update. Existing functionality remains intact, with added support for the Live Preview SDK.

## Dependencies and/or References
https://www.contentful.com/developers/docs/tutorials/preview/live-preview/

