### PR TITLE
chore(eppo): Simplify flag key generation

### DIFF
--- a/apps/eppo/src/locations/EntryEditor/EntryEditor.tsx
+++ b/apps/eppo/src/locations/EntryEditor/EntryEditor.tsx
@@ -36,6 +36,7 @@ const generateFlagKey = (entryName: string) => {
   const lowerSnakeCaseEntryName = entryName
     .replace(/\s+/g, '-')
     .replace(/[^a-zA-Z0-9-]/g, '')
+    .replace(/-+/g, '-')
     .toLowerCase();
   return `${lowerSnakeCaseEntryName}-${Date.now()}`;
 };


### PR DESCRIPTION
## Purpose

This is a simple simplification to the Eppo feature flag key name generatio to replace multiple subsequent dashes with a single dash, eg.: `flag---key` becomes `flag-key`

## Approach

This is simple enough that it requires no additional context. It should have no visible customer impact.

## Testing steps

N/A

## Breaking Changes

None

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
