### PR TITLE
feat: Better error message when server does not return JSON []

### DIFF
--- a/apps/growthbook/src/locations/Sidebar.tsx
+++ b/apps/growthbook/src/locations/Sidebar.tsx
@@ -36,7 +36,18 @@ const Sidebar = () => {
   const displayError = useCallback(
     (error: string) => {
       const configUrl = `https://app.contentful.com/spaces/${sdk.ids.space}/apps/${sdk.ids.app}`;
-      if (error.includes('Invalid data source')) {
+      if (error.includes('is not valid JSON')) {
+        setError(
+          <>
+            The server {sdk.parameters.installation.growthbookServerUrl} did not return valid JSON. It is possible that the server is not set correctly
+            (api.growthbook.io for Growthbook Cloud). Go to the{' '}
+            <a href={configUrl} target="_blank">
+              Configuration page
+            </a>{' '}
+            to edit.
+          </>
+        );
+      } else if (error.includes('Invalid data source')) {
         setError(
           <>
             Datasource {sdk.parameters.installation.datasourceId} is invalid. Go to the{' '}


### PR DESCRIPTION
## Purpose
A customer set the wrong Growthbook API server.  The server they put returned non-JSON response which failed to respond. The Growthbook API  server should always return JSON, if the server is not returning JSON then they probably do not have the right server, and hence this PR adds a better error message telling them to check that the server is correct.

## Approach

We could have tried catching the error when we json decode and then rethrow a more detailed message, this approach of just checking the message for "is not valid JSON" is probably good enough.

## Testing steps

In plugin settings put in "cdn.growthbook.io".  Then create a new "Growthbook Experiment" content entry.  Add a title, and two variations and then click "Create Experiment"

## Breaking Changes
None

## Dependencies and/or References
None

## Deployment
None
