### PR TITLE
feat: Show warning when Growthbook sidebar is used in other content models []

### DIFF
--- a/apps/growthbook/src/locations/Sidebar.tsx
+++ b/apps/growthbook/src/locations/Sidebar.tsx
@@ -8,23 +8,8 @@ import { ExperimentAPIResponse } from '../../types/experiment';
 import Link from 'next/link';
 import { ContentTypesContext } from '../contexts/ContentTypesContext';
 
-const Sidebar = () => {
+const SidebarContent = () => {
   const sdk = useSDK<SidebarAppSDK>();
-
-  const contentTypeId = sdk.contentType.sys.id;
-  const contentType = sdk.contentType.name;
-  if (contentTypeId !== 'growthbookExperiment') {
-    return (
-      <>
-        The Growthbook sidebar widget only works on the "Growthbook Experiment" content type. You can remove this widget from the sidebar of {contentType}{' '}
-        content model{' '}
-        <a href={`https://app.contentful.com/spaces/${sdk.ids.space}/content_types/${contentTypeId}/sidebar_configuration`} target="_blank">
-          here
-        </a>
-        .
-      </>
-    );
-  }
 
   const { growthbookAPI: growthbookExperimentApi } = useContext(GrowthbookAPIContext);
 
@@ -350,6 +335,27 @@ ${entries
       {error && <Note variant="negative">{error}</Note>}
     </Stack>
   );
+};
+
+const Sidebar = () => {
+  const sdk = useSDK<SidebarAppSDK>();
+  const contentTypeId = sdk.contentType.sys.id;
+  const contentType = sdk.contentType.name;
+
+  if (contentTypeId !== 'growthbookExperiment') {
+    return (
+      <>
+        The Growthbook sidebar widget only works on the &quot;Growthbook Experiment&quot; content type. You can remove this widget from the sidebar of{' '}
+        {contentType} content model{' '}
+        <a href={`https://app.contentful.com/spaces/${sdk.ids.space}/content_types/${contentTypeId}/sidebar_configuration`} target="_blank">
+          here
+        </a>
+        .
+      </>
+    );
+  }
+
+  return <SidebarContent />;
 };
 
 export default Sidebar;

--- a/apps/growthbook/src/locations/Sidebar.tsx
+++ b/apps/growthbook/src/locations/Sidebar.tsx
@@ -11,6 +11,21 @@ import { ContentTypesContext } from '../contexts/ContentTypesContext';
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
 
+  const contentTypeId = sdk.contentType.sys.id;
+  const contentType = sdk.contentType.name;
+  if (contentTypeId !== 'growthbookExperiment') {
+    return (
+      <>
+        The Growthbook sidebar widget only works on the "Growthbook Experiment" content type. You can remove this widget from the sidebar of {contentType}{' '}
+        content model{' '}
+        <a href={`https://app.contentful.com/spaces/${sdk.ids.space}/content_types/${contentTypeId}/sidebar_configuration`} target="_blank">
+          here
+        </a>
+        .
+      </>
+    );
+  }
+
   const { growthbookAPI: growthbookExperimentApi } = useContext(GrowthbookAPIContext);
 
   const [formExperimentName, setFormExperimentName] = useFieldValue<string>(sdk.entry.fields.experimentName.id);

--- a/apps/growthbook/tests/locations/Sidebar.spec.tsx
+++ b/apps/growthbook/tests/locations/Sidebar.spec.tsx
@@ -1,118 +1,124 @@
-import React from "react";
-import {
-  render,
-  fireEvent,
-  act,
-} from "@testing-library/react";
-import { mockCma, mockSdk } from "../mocks";
-import Sidebar from "@/locations/Sidebar";
-import { useFieldValue } from "@contentful/react-apps-toolkit";
-import { GrowthbookAPIContext } from "@/contexts/GrowthbookAPIContext";
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { mockCma, mockSdk } from '../mocks';
+import Sidebar from '@/locations/Sidebar';
+import { useFieldValue } from '@contentful/react-apps-toolkit';
+import { GrowthbookAPIContext } from '@/contexts/GrowthbookAPIContext';
 
-jest.mock("@contentful/react-apps-toolkit", () => ({
+jest.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 
   useFieldValue: jest.fn(),
 }));
 
-describe("Sidebar component", () => {
-  describe("with no experiment name", () => {
+describe('Sidebar component', () => {
+  describe('with the wrong content type', () => {
     beforeEach(() => {
+      mockSdk.contentType = { name: 'super hero', sys: { id: 'superHero' } };
+      mockSdk.ids.space = 'spaceId';
+    });
+
+    it('renders warning', () => {
+      const { getByText } = render(<Sidebar />);
+      expect(getByText('here')).toHaveAttribute('href', 'https://app.contentful.com/spaces/spaceId/content_types/superHero/sidebar_configuration');
+    });
+  });
+
+  describe('with no experiment name', () => {
+    beforeEach(() => {
+      mockSdk.contentType = { name: 'Growthbook Experiment', sys: { id: 'growthbookExperiment' } };
       (useFieldValue as jest.Mock).mockImplementation((fieldId) => {
-        if (fieldId === "experiment") {
+        if (fieldId === 'experiment') {
           return [];
         }
-        if (fieldId === "variationNames") {
-          return [["Control", "Variation A"]];
+        if (fieldId === 'variationNames') {
+          return [['Control', 'Variation A']];
         }
-        if (fieldId === "variations") {
-          return [[{ id: "control-tshirt" }, { id: "variation-tshirt" }]];
+        if (fieldId === 'variations') {
+          return [[{ id: 'control-tshirt' }, { id: 'variation-tshirt' }]];
         }
-        if (fieldId === "experimentName") {
-          return ["", jest.fn()];
+        if (fieldId === 'experimentName') {
+          return ['', jest.fn()];
         }
         return [null, jest.fn()];
       });
     });
 
-    it("disables the create button", () => {
+    it('disables the create button', () => {
       const { getByRole } = render(<Sidebar />);
-      const button = getByRole("button", {
-        name: "Create New Experiment",
+      const button = getByRole('button', {
+        name: 'Create New Experiment',
       }) as HTMLButtonElement;
       expect(button.disabled).toBe(true);
     });
   });
 
-  describe("with no experiment name", () => {
+  describe('with no experiment name', () => {
     beforeEach(() => {
+      mockSdk.contentType = { name: 'Growthbook Experiment', sys: { id: 'growthbookExperiment' } };
       (useFieldValue as jest.Mock).mockImplementation((fieldId) => {
-        if (fieldId === "experiment") {
+        if (fieldId === 'experiment') {
           return [];
         }
-        if (fieldId === "variationNames") {
+        if (fieldId === 'variationNames') {
           return [[]];
         }
-        if (fieldId === "variations") {
+        if (fieldId === 'variations') {
           return [[]];
         }
-        if (fieldId === "experimentName") {
-          return ["my experiment", jest.fn()];
+        if (fieldId === 'experimentName') {
+          return ['my experiment', jest.fn()];
         }
         return [null, jest.fn()];
       });
     });
 
-    it("disables the create button", () => {
+    it('disables the create button', () => {
       const { getByRole } = render(<Sidebar />);
-      const button = getByRole("button", {
-        name: "Create New Experiment",
+      const button = getByRole('button', {
+        name: 'Create New Experiment',
       }) as HTMLButtonElement;
       expect(button.disabled).toBe(true);
     });
   });
 
-  describe("with valid fields", () => {
+  describe('with valid fields', () => {
     const setExperimentName = jest.fn();
     const setFormFeatureFlagId = jest.fn();
     const setFormTrackingKey = jest.fn();
     const setFormExperiment = jest.fn();
 
     beforeEach(() => {
+      mockSdk.contentType = { name: 'Growthbook Experiment', sys: { id: 'growthbookExperiment' } };
       (useFieldValue as jest.Mock).mockImplementation((fieldId) => {
-        if (fieldId === "experiment") {
+        if (fieldId === 'experiment') {
           return [undefined, setFormExperiment];
         }
-        if (fieldId === "variationNames") {
-          return [["Control", "Variation A"]];
+        if (fieldId === 'variationNames') {
+          return [['Control', 'Variation A']];
         }
-        if (fieldId === "variations") {
-          return [
-            [
-              { sys: { id: "control-tshirt" } },
-              { sys: { id: "variation-tshirt" } },
-            ],
-          ];
+        if (fieldId === 'variations') {
+          return [[{ sys: { id: 'control-tshirt' } }, { sys: { id: 'variation-tshirt' } }]];
         }
-        if (fieldId === "experimentName") {
-          return ["  my experiment  ", setExperimentName];
+        if (fieldId === 'experimentName') {
+          return ['  my experiment  ', setExperimentName];
         }
-        if (fieldId === "featureFlagId") {
-          return ["my-experiment", setFormFeatureFlagId];
+        if (fieldId === 'featureFlagId') {
+          return ['my-experiment', setFormFeatureFlagId];
         }
-        if (fieldId === "trackingKey") {
-          return ["my-experiment", setFormTrackingKey];
+        if (fieldId === 'trackingKey') {
+          return ['my-experiment', setFormTrackingKey];
         }
-        console.log("test not handling fieldId", fieldId);
+        console.log('test not handling fieldId', fieldId);
         return [null, jest.fn()];
       });
     });
 
-    it("calls growthbook on button click", async () => {
+    it('calls growthbook on button click', async () => {
       const mockExperiment = {
-        id: "exp-id",
-        variations: [{ id: "id1" }, { id: "id2" }],
+        id: 'exp-id',
+        variations: [{ id: 'id1' }, { id: 'id2' }],
       };
       const mockCreateExperiment = jest.fn(async () => {
         return Promise.resolve({
@@ -123,8 +129,8 @@ describe("Sidebar component", () => {
         getExperiment: jest.fn(),
         createExperiment: mockCreateExperiment,
         updateExperiment: jest.fn(),
-        serverUrl: "http://mock-server-url",
-        apiKey: "mock-api-key",
+        serverUrl: 'http://mock-server-url',
+        apiKey: 'mock-api-key',
         fetchWithAuth: jest.fn(),
         createFeatureFlag: jest.fn(),
         updateFeatureFlag: jest.fn(),
@@ -133,20 +139,19 @@ describe("Sidebar component", () => {
       const { getByRole } = render(
         <GrowthbookAPIContext.Provider
           // @ts-ignore - a simplified experiment interface is enough to test.
-          value={{ growthbookAPI: mockGrowthbookExperimentApi }}
-        >
+          value={{ growthbookAPI: mockGrowthbookExperimentApi }}>
           <Sidebar />
         </GrowthbookAPIContext.Provider>
       );
-      const button = getByRole("button", {
-        name: "Create New Experiment",
+      const button = getByRole('button', {
+        name: 'Create New Experiment',
       }) as HTMLButtonElement;
       await act(async () => {
         fireEvent.click(button);
       });
-      expect(setExperimentName).toHaveBeenCalledWith("my experiment");
-      expect(setFormFeatureFlagId).toHaveBeenCalledWith("my-experiment");
-      expect(setFormTrackingKey).toHaveBeenCalledWith("my-experiment");
+      expect(setExperimentName).toHaveBeenCalledWith('my experiment');
+      expect(setFormFeatureFlagId).toHaveBeenCalledWith('my-experiment');
+      expect(setFormTrackingKey).toHaveBeenCalledWith('my-experiment');
     });
   });
 });


### PR DESCRIPTION
## Purpose
A user added Growthbook Experiment Sidebar to a different content model.  The sidebar then errored.  This adds a warning that it only works on "Growthbook Experiment" content type, and provides a link to remove it from the current content model if it is not correct.  

## Approach
We check the content type and show the warning if it is the wrong one.  

## Testing steps

`yarn test`
Add "Growthbook Experiment" to the sidebar of a different content type.  
Create an entry of that type.
See the warning in the entry, with the correct content type name.
Click the link and see it goes back to editing that content types sidebar.
Create a Growthbook Experiment Content type entry.
See the warning does not show when editing that entry.

## Breaking Changes
None

## Dependencies and/or References

None

## Deployment
None
