### PR TITLE
feat: Enhance app configuration page []

### DIFF
--- a/apps/docs-to-rich-text/package-lock.json
+++ b/apps/docs-to-rich-text/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs-to-rich-text",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs-to-rich-text",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.29.3",
         "@contentful/f36-components": "^4.74.1",
@@ -14,6 +14,8 @@
         "@contentful/field-editor-rich-text": "^4.1.2",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@emotion/css": "^11.13.4",
+        "@types/async-lock": "^1.4.2",
+        "async-lock": "^1.4.1",
         "axios": "^1.7.7",
         "contentful-management": "^11.38.0",
         "file-type": "^19.6.0",
@@ -3335,6 +3337,11 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4349,6 +4356,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/apps/docs-to-rich-text/package.json
+++ b/apps/docs-to-rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-to-rich-text",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.29.3",
@@ -9,6 +9,8 @@
     "@contentful/field-editor-rich-text": "^4.1.2",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@emotion/css": "^11.13.4",
+    "@types/async-lock": "^1.4.2",
+    "async-lock": "^1.4.1",
     "axios": "^1.7.7",
     "contentful-management": "^11.38.0",
     "file-type": "^19.6.0",

--- a/apps/docs-to-rich-text/src/api/licensing.ts
+++ b/apps/docs-to-rich-text/src/api/licensing.ts
@@ -18,26 +18,6 @@ export async function IsWithinLicenseLimits(cma: CMAClient, appDefinitionId: str
   return (await IsSpaceLicensed(spaceId)) || (await getFieldWidgetUsageCount(cma, appDefinitionId)) <= 5;
 }
 
-export async function getEditorUsages(cma: CMAClient, appDefinitionId: string): Promise<{ contentModel: string; field: string }[]> {
-  const def = await cma.appDefinition.get({ appDefinitionId: appDefinitionId });
-  const widgetId = def.sys.id;
-  const interfaces = await cma.editorInterface.getMany({});
-
-  const usages: { contentModel: string; field: string }[] = [];
-  for (let i = 0; i < interfaces.items.length; i++) {
-    const contentType = interfaces.items[i];
-    const widgets = contentType.controls!.filter((x) => x.widgetId === widgetId);
-    for (let j = 0; j < widgets.length; j++) {
-      usages.push({
-        contentModel: contentType.sys.contentType.sys.id,
-        field: widgets[j].fieldId,
-      });
-    }
-  }
-
-  return usages;
-}
-
 export async function getFieldWidgetUsageCount(cma: CMAClient, appDefinitionId: string): Promise<number> {
   const def = await cma.appDefinition.get({ appDefinitionId: appDefinitionId });
   const widgetId = def.sys.id;

--- a/apps/docs-to-rich-text/src/locations/ConfigScreen.spec.tsx
+++ b/apps/docs-to-rich-text/src/locations/ConfigScreen.spec.tsx
@@ -8,6 +8,10 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
   useCMA: () => mockCma,
 }));
 
+vi.mock('../utils/editorInterfaceUtil', () => ({
+  getRichTextFields: vi.fn(),
+}));
+
 describe('Config Screen component', () => {
   it('Component text exists', async () => {
     const { getByText } = render(<ConfigScreen />);

--- a/apps/docs-to-rich-text/src/locations/Field.spec.tsx
+++ b/apps/docs-to-rich-text/src/locations/Field.spec.tsx
@@ -36,6 +36,7 @@ describe('Field', () => {
       getIsDisabled: vi.fn(),
       setInvalid: vi.fn(),
       locale: 'en-US',
+      validations: [],
     },
     locales: {
       default: 'en-US',

--- a/apps/docs-to-rich-text/src/types.ts
+++ b/apps/docs-to-rich-text/src/types.ts
@@ -43,3 +43,11 @@ export interface GoogleDrivePickerResult {
   html: string;
   markdown: string;
 }
+
+export interface RtfField {
+  contentTypeId: string;
+  contentTypeName: string;
+  fieldId: string;
+  fieldName: string;
+  isEnabled: boolean;
+}

--- a/apps/docs-to-rich-text/src/utils/editorInterfaceUtil.ts
+++ b/apps/docs-to-rich-text/src/utils/editorInterfaceUtil.ts
@@ -1,0 +1,86 @@
+import { CMAClient, ConfigAppSDK } from '@contentful/app-sdk';
+import { RtfField } from '../types';
+import AsyncLock from 'async-lock';
+const lock = new AsyncLock();
+
+const RichTextFieldType = 'RichText';
+const AppWidgetNamespace = 'app';
+const BuiltinWidgetNamesspace = 'builtin';
+const DefaultWidgetId = 'richTextEditor';
+
+export async function getRichTextFields(cma: CMAClient, appDefinitionId: string): Promise<RtfField[]> {
+  // Get all content types
+  const contentTypes = await cma.contentType.getMany({});
+
+  // Get our widgetId
+  const def = await cma.appDefinition.get({ appDefinitionId: appDefinitionId });
+  const appWidgetId = def.sys.id;
+
+  const richTextFields: RtfField[] = [];
+  for (const contentType of contentTypes.items) {
+    const editorInterface = await cma.editorInterface.get({ contentTypeId: contentType.sys.id });
+
+    for (const rtfField of contentType.fields.filter((f) => f.type === RichTextFieldType)) {
+      const control = editorInterface.controls!.find((w) => w.fieldId === rtfField.id);
+      richTextFields.push({
+        contentTypeId: contentType.sys.id,
+        contentTypeName: contentType.name,
+        fieldId: rtfField.id,
+        fieldName: rtfField.name,
+        isEnabled: control!.widgetId === appWidgetId,
+      });
+    }
+  }
+
+  richTextFields.sort((a, b) => {
+    // Sort by contentTypeName first
+    const typeCompare = a.contentTypeName.localeCompare(b.contentTypeName);
+    if (typeCompare !== 0) {
+      return typeCompare;
+    }
+
+    // Then by fieldName
+    return a.fieldName.localeCompare(b.fieldName);
+  });
+
+  return richTextFields;
+}
+
+export async function setAppRichTextEditor(sdk: ConfigAppSDK, contentTypeId: string, fieldId: string) {
+  lock.acquire(contentTypeId, async function () {
+    const def = await sdk.cma.appDefinition.get({ appDefinitionId: sdk.ids.app });
+    const appWidgetId = def.sys.id;
+
+    const editorInterface = await sdk.cma.editorInterface.get({ contentTypeId: contentTypeId });
+    const control = editorInterface.controls!.find((w) => w.fieldId === fieldId)!;
+    control.widgetId = appWidgetId;
+    control.widgetNamespace = AppWidgetNamespace;
+
+    await sdk.cma.editorInterface.update(
+      {
+        spaceId: sdk.ids.space,
+        environmentId: sdk.ids.environment,
+        contentTypeId: contentTypeId,
+      },
+      editorInterface,
+    );
+  });
+}
+
+export async function setDefaultRichTextEditor(sdk: ConfigAppSDK, contentTypeId: string, fieldId: string) {
+  lock.acquire(contentTypeId, async function () {
+    const editorInterface = await sdk.cma.editorInterface.get({ contentTypeId: contentTypeId });
+    const control = editorInterface.controls!.find((w) => w.fieldId === fieldId)!;
+    control.widgetId = DefaultWidgetId;
+    control.widgetNamespace = BuiltinWidgetNamesspace;
+
+    await sdk.cma.editorInterface.update(
+      {
+        spaceId: sdk.ids.space,
+        environmentId: sdk.ids.environment,
+        contentTypeId: contentTypeId,
+      },
+      editorInterface,
+    );
+  });
+}

--- a/apps/docs-to-rich-text/src/utils/imageUpload.ts
+++ b/apps/docs-to-rich-text/src/utils/imageUpload.ts
@@ -18,7 +18,6 @@ export async function processImages(sdk: BaseAppSDK, assets: EmbeddedAsset[]): P
   );
 
   const uploadResults = await Promise.allSettled(uploadPromises);
-
   result.success = !uploadResults.some((result) => result.status === 'rejected');
   result.failedImages = uploadResults.filter((result) => result.status === 'rejected').map((result) => result.reason.image);
 
@@ -39,7 +38,7 @@ export async function processImagesFromGoogleDrive(sdk: BaseAppSDK, assets: Embe
     const uploadPromises = assets.map(async (asset, i) => {
       asset.assetBase64 = base64Images[i];
       return uploadImage(sdk, asset).catch((error) => {
-        error.asset = asset;
+        error.image = asset;
         throw error;
       });
     });

--- a/apps/docs-to-rich-text/test/api/licensing.spec.ts
+++ b/apps/docs-to-rich-text/test/api/licensing.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import axios from 'axios';
 import { CMAClient } from '@contentful/app-sdk';
-import { IsSpaceLicensed, IsWithinLicenseLimits, getEditorUsages, getFieldWidgetUsageCount } from '../../src/api/licensing';
+import { IsSpaceLicensed, IsWithinLicenseLimits } from '../../src/api/licensing';
 
 // Mock axios
 vi.mock('axios');
@@ -75,93 +75,6 @@ describe('Licensing', () => {
       const result = await IsWithinLicenseLimits(mockCma, 'app-id', 'space-id');
       
       expect(result).toBe(false);
-    });
-  });
-
-  describe('getEditorUsages', () => {
-    const mockCma = {
-      appDefinition: {
-        get: vi.fn().mockResolvedValue({ sys: { id: 'widget-id' } }),
-      },
-      editorInterface: {
-        getMany: vi.fn().mockResolvedValue({ items: [] }),
-      },
-    } as unknown as CMAClient;
-
-    it('should return correct usages array', async () => {
-      (mockCma.appDefinition.get as Mock).mockResolvedValue({ sys: { id: 'widget-id' } });
-      (mockCma.editorInterface.getMany as Mock).mockResolvedValue({
-        items: [
-          {
-            controls: [
-              { widgetId: 'widget-id', fieldId: 'field1' },
-              { widgetId: 'widget-id', fieldId: 'field2' },
-            ],
-            sys: { contentType: { sys: { id: 'content-type-1' } } }
-          }
-        ]
-      });
-
-      const result = await getEditorUsages(mockCma, 'app-id');
-
-      expect(result).toEqual([
-        { contentModel: 'content-type-1', field: 'field1' },
-        { contentModel: 'content-type-1', field: 'field2' },
-      ]);
-    });
-
-    it('should return empty array when no usages found', async () => {
-      (mockCma.appDefinition.get as Mock).mockResolvedValue({ sys: { id: 'widget-id' } });
-      (mockCma.editorInterface.getMany as Mock).mockResolvedValue({ items: [] });
-
-      const result = await getEditorUsages(mockCma, 'app-id');
-
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('getFieldWidgetUsageCount', () => {
-    const mockCma = {
-      appDefinition: {
-        get: vi.fn().mockResolvedValue({ sys: { id: 'widget-id' } }),
-      },
-      editorInterface: {
-        getMany: vi.fn().mockResolvedValue({ items: [] }),
-      },
-    } as unknown as CMAClient;
-
-    it('should return correct usage count', async () => {
-      (mockCma.appDefinition.get as Mock).mockResolvedValue({ sys: { id: 'widget-id' } });
-      (mockCma.editorInterface.getMany as Mock).mockResolvedValue({
-        items: [
-          {
-            controls: [
-              { widgetId: 'widget-id' },
-              { widgetId: 'widget-id' },
-            ],
-            sys: { contentType: { sys: { id: 'content-type-1' } } }
-          },
-          {
-            controls: [
-              { widgetId: 'widget-id' },
-            ],
-            sys: { contentType: { sys: { id: 'content-type-2' } } }
-          }
-        ]
-      });
-
-      const result = await getFieldWidgetUsageCount(mockCma, 'app-id');
-
-      expect(result).toBe(3);
-    });
-
-    it('should return 0 when no usages found', async () => {
-      (mockCma.appDefinition.get as Mock).mockResolvedValue({ sys: { id: 'widget-id' } });
-      (mockCma.editorInterface.getMany as Mock).mockResolvedValue({ items: [] });
-
-      const result = await getFieldWidgetUsageCount(mockCma, 'app-id');
-
-      expect(result).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Purpose

This change adds two new features to the Docs to Rich Text app:

1. Enhanced configuration page to allow users to easily enable the Docs to Rich Text appearance editor for their rich text fields
2. A warning icon is displayed on rich text fields that have restrictions configured, to warn users that importing may result in validation errors 

## Approach

- The enhanced configuration page allows users fine-grained control over where the Docs to Rich Text appearance editor is used without the hassle of having to individually modifying every rich text field on every content model.
- The warning icon gives users an indication of why validation errors might occur.

## Testing steps

1. Install the application
2. Navigate to the configuration page
3. See that a new section for "Configure Rich Text Fields" now exists
4. Enable one or more fields
5. Open a content model where Docs to Rich Text was enabled
6. Confirm Docs to Rich Text is displayed as the appearance editor
7. Test importing a Google or HTML document

## Breaking Changes

None

## Dependencies and/or References

N/A

## Deployment

N/A
