### PR TITLE
feat: adds labels to dependabot prs for contentful owned apps [INTEG-2430]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,8 @@ updates:
           - patch
         patterns:
           - '*'
+    labels:
+      - 'contentful-owned'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -197,6 +199,8 @@ updates:
           - patch
         patterns:
           - '*'
+    labels:
+      - 'contentful-owned'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -550,6 +554,8 @@ updates:
           - patch
         patterns:
           - '*'
+    labels:
+      - 'contentful-owned'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -648,7 +654,7 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'          
+          - '*'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -680,7 +686,7 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'  
+          - '*'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -712,7 +718,7 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'         
+          - '*'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -744,7 +750,7 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'          
+          - '*'
   - package-ecosystem: npm
     schedule:
       interval: daily
@@ -776,4 +782,4 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'          
+          - '*'


### PR DESCRIPTION
Some apps in this repo are supported by Contentful. When dependabot PRs are open it would be nice to see at a quick glance whether or not the PR is something we can approve and update that dependency ourselves versus getting approval from the app developer. I added a label to the apps we own that have a dependabot configuration. 
