### PR TITLE
fix: syntax for avoiding running pr title check on dependabot [INTEG-2340]

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-title:
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@master


### PR DESCRIPTION
The title workflow was still running on dependabot PRs after merging in my attempted fix. I asked github copilot in the pr title check failure why it ran on the PR and it suggested this corrected syntax for the if condition. hopefully this one works!