### PR TITLE
fix: adds workflow to close branches after merge [INTEG-2453]

### DIFF
--- a/.github/workflows/delete-branch-on-close.yml
+++ b/.github/workflows/delete-branch-on-close.yml
@@ -1,0 +1,25 @@
+name: Auto Merge and Delete Branch
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  auto-merge-and-delete:
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Delete branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch=${{ github.event.pull_request.head.ref }}
+          if [ "$branch" != "main" ]; then
+            git push origin --delete $branch
+          fi

--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -18,6 +18,10 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Auto-merge dependabot PRs
         uses: contentful/github-auto-merge@v2
+        # Logic to delete branch from github-auto-merge causes merge to fail due to merge queue
+        # We will handle branch deletion in a separate workflow
+        with:
+          delete-branch: false
         # Don't auto-merge major version upgrades, we'll handle these manually
         if: ${{steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'}}
         with:


### PR DESCRIPTION
When dependabot puts up a PR that is theoretically auto-merge-able (minor dependency bump) the auto merge feature is failing because the "automatically delete branch" portion of the workflow fails. That apparently results in the PR failing to merge entirely rather than just failing to delete the branch. 

There are two parts here:

A new workflow that deletes branches on merge into main rather than attempting to do it when added to the merge queue Customizing our dependabot auto merge job to not attempt to delete the branch so it doesn't fail
