### PR TITLE
fix: Docs to Rich Text - Resolves bugs on configuration screen []

### DIFF
--- a/apps/docs-to-rich-text/package-lock.json
+++ b/apps/docs-to-rich-text/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs-to-rich-text",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs-to-rich-text",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@contentful/app-sdk": "^4.29.3",
         "@contentful/f36-components": "^4.78.0",

--- a/apps/docs-to-rich-text/package.json
+++ b/apps/docs-to-rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-to-rich-text",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.29.3",

--- a/apps/docs-to-rich-text/src/utils/editorInterfaceUtil.ts
+++ b/apps/docs-to-rich-text/src/utils/editorInterfaceUtil.ts
@@ -12,10 +12,6 @@ export async function getRichTextFields(cma: CMAClient, appDefinitionId: string)
   // Get all content types
   const contentTypes = await cma.contentType.getMany({});
 
-  // Get our widgetId
-  const def = await cma.appDefinition.get({ appDefinitionId: appDefinitionId });
-  const appWidgetId = def.sys.id;
-
   const richTextFields: RtfField[] = [];
   for (const contentType of contentTypes.items) {
     const editorInterface = await cma.editorInterface.get({ contentTypeId: contentType.sys.id });
@@ -27,7 +23,7 @@ export async function getRichTextFields(cma: CMAClient, appDefinitionId: string)
         contentTypeName: contentType.name,
         fieldId: rtfField.id,
         fieldName: rtfField.name,
-        isEnabled: control!.widgetId === appWidgetId,
+        isEnabled: control!.widgetId === appDefinitionId,
       });
     }
   }
@@ -48,8 +44,7 @@ export async function getRichTextFields(cma: CMAClient, appDefinitionId: string)
 
 export async function setAppRichTextEditor(sdk: ConfigAppSDK, contentTypeId: string, fieldId: string) {
   lock.acquire(contentTypeId, async function () {
-    const def = await sdk.cma.appDefinition.get({ appDefinitionId: sdk.ids.app });
-    const appWidgetId = def.sys.id;
+    const appWidgetId = sdk.ids.app;
 
     const editorInterface = await sdk.cma.editorInterface.get({ contentTypeId: contentTypeId });
     const control = editorInterface.controls!.find((w) => w.fieldId === fieldId)!;


### PR DESCRIPTION
## Purpose

Resolves two issues on the configuration screen:

1. Configuration screen should handle being displayed in a pre-installation state
2. Calls to `cma.appDefinition.get({ appDefinitionId: sdk.ids.app });` fail on the configuration page with a 404 error (installation state irrelevant), for an unknown reason. This call succeeds when the app is installed locally, but not when released by the marketplace.

## Approach

Issue 1 - Configuration screen should handle being displayed in a pre-installation state
To address this `sdk.app.isInstalled()` is used to determine the installation state, and components are reactively displayed based on this state.

Issue 2 - Calls to `cma.appDefinition.get({ appDefinitionId: sdk.ids.app });` fail on the configuration page with 404 error
I was unable to determine why this api call works from a local installation but not through the marketplace installation. Regardless, on further inspection the api call was found to be unnecessary so it was removed.

## Testing steps

1. Uninstall the application
2. Begin the application installation process
3. Note that before the application is installed the user is brought to the configuration page
4. Note that on the configuration page in a pre-installation state, the "Configure Rich Text Fields" component displays the text "Install to begin"
5. Install the application
6. Confirm that the "Configure Rich Text Fields" component now displays a table of rich text fields
7. Confirm that rich text fields are able to be enabled in the component

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A
