### PR TITLE
chore: Update CODEOWNERS to mktp (SEE NOTE BEFORE MERGING) []

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contentful/team-tundra
+* @contentful/team-marketplace


### PR DESCRIPTION
Updates ownership to new marketplace team in github. We need to change delivery teams at the same time so don't merge this unless you know that is happening