### PR TITLE
fix(eppo): enforce content-type validations in variants []

### DIFF
--- a/apps/eppo/LICENSE
+++ b/apps/eppo/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2024, Contentful GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/apps/eppo/src/components/EppoEntrySelector/index.tsx
+++ b/apps/eppo/src/components/EppoEntrySelector/index.tsx
@@ -13,6 +13,7 @@ interface ILinkedEntryCardProps {
   onLink: (value: EntityLink) => void;
   onUnlink: (entryId: string) => void;
   isDisabled: boolean;
+  allowedContentTypes: string[];
 }
 
 const getEntryId = (value: EntityLink | undefined): string | undefined => {
@@ -23,7 +24,7 @@ const EXCLUDED_CONTENT_TYPES = [VARIATION_CONTAINER_ID];
 
 export const EppoEntrySelector: React.FunctionComponent<ILinkedEntryCardProps> = (props) => {
   const sdk = props.sdk;
-  const editorPermissions = useEntryEditorPermissions(sdk);
+  const editorPermissions = useEntryEditorPermissions(sdk, props.allowedContentTypes);
   const { fieldValue, isDisabled } = props;
   const entryId = getEntryId(fieldValue);
 

--- a/apps/eppo/src/components/modified/useEditorPermissions.tsx
+++ b/apps/eppo/src/components/modified/useEditorPermissions.tsx
@@ -16,6 +16,9 @@ export type EditorPermissionsProps = {
     };
   };
   allContentTypes: ContentType[];
+  validations: {
+    contentTypes?: string[];
+  };
 };
 
 export function useEditorPermissions(props: EditorPermissionsProps) {
@@ -24,10 +27,8 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
   const { showCreateEntityAction } = instance;
   const [canCreateEntity, setCanCreateEntity] = useState(true);
   const [canLinkEntity, setCanLinkEntity] = useState(true);
-  const validations = {};
   const { creatableContentTypes, availableContentTypes } = useContentTypePermissions({
     ...props,
-    validations,
   });
   const { canPerformAction } = useAccessApi(access);
 
@@ -87,7 +88,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     canLinkEntity,
     creatableContentTypes,
     availableContentTypes,
-    validations,
+    validations: props.validations,
   };
 }
 

--- a/apps/eppo/src/constants.ts
+++ b/apps/eppo/src/constants.ts
@@ -1,4 +1,7 @@
-export const PRODUCTION_API_BASE_URL = 'https://eppo.cloud';
+export const CONFIG_FORM_API_KEY_LABEL = 'Eppo API key';
+export const CONFIG_FORM_DEFAULT_ASSIGNMENT_LABEL = 'Default assignment logging table';
+export const CONFIG_FORM_DEFAULT_ENTITY_LABEL = 'Default randomization entity';
 export const DEVELOPMENT_API_BASE_URL = 'http://localhost:4000';
 export const DEVELOPMENT_FRONTEND_BASE_URL = 'http://localhost:3000';
+export const PRODUCTION_BASE_URL = 'https://eppo.cloud';
 export const VARIATION_CONTAINER_ID = 'eppoVariationContainer';

--- a/apps/eppo/src/helpers/get-api-base-url.ts
+++ b/apps/eppo/src/helpers/get-api-base-url.ts
@@ -1,7 +1,5 @@
-import { PRODUCTION_API_BASE_URL, DEVELOPMENT_API_BASE_URL } from '../constants';
+import { PRODUCTION_BASE_URL, DEVELOPMENT_API_BASE_URL } from '../constants';
 
-export const getApiBaseUrl = () => {
-  return process.env.NODE_ENV === 'development'
-    ? DEVELOPMENT_API_BASE_URL
-    : PRODUCTION_API_BASE_URL;
+export const getApiBaseUrl = (): string => {
+  return process.env.NODE_ENV === 'development' ? DEVELOPMENT_API_BASE_URL : PRODUCTION_BASE_URL;
 };

--- a/apps/eppo/src/hooks/useEntryEditorPermissions.tsx
+++ b/apps/eppo/src/hooks/useEntryEditorPermissions.tsx
@@ -2,10 +2,14 @@ import { EditorAppSDK } from '@contentful/app-sdk';
 import { useEditorPermissions } from '../components/modified/useEditorPermissions';
 import { useMemo } from 'react';
 
-export const useEntryEditorPermissions = (sdk: EditorAppSDK) => {
+export const useEntryEditorPermissions = (
+  sdk: EditorAppSDK,
+  allowedContentTypes: Array<string>,
+) => {
   const contentTypes = useMemo(() => {
     return sdk.space.getCachedContentTypes();
   }, [sdk.space]);
+
   return useEditorPermissions({
     access: sdk.access,
     entityType: 'Entry',
@@ -17,5 +21,8 @@ export const useEntryEditorPermissions = (sdk: EditorAppSDK) => {
       },
     },
     allContentTypes: contentTypes,
+    validations: {
+      contentTypes: allowedContentTypes,
+    },
   });
 };

--- a/apps/eppo/src/locations/ConfigScreen.tsx
+++ b/apps/eppo/src/locations/ConfigScreen.tsx
@@ -12,7 +12,12 @@ import {
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ContentTypeProps } from 'contentful-management';
 
-import { PRODUCTION_API_BASE_URL, VARIATION_CONTAINER_ID } from '../constants';
+import {
+  CONFIG_FORM_API_KEY_LABEL,
+  CONFIG_FORM_DEFAULT_ASSIGNMENT_LABEL,
+  CONFIG_FORM_DEFAULT_ENTITY_LABEL,
+  VARIATION_CONTAINER_ID,
+} from '../constants';
 import { getApiBaseUrl } from '../helpers/get-api-base-url';
 import { apiRequest, ApiRequestProps, unsignedApiRequest } from '../helpers/api-request';
 import { Dropdown } from '../components/Dropdown';
@@ -173,7 +178,6 @@ const ConfigScreen = () => {
         eppoApiKey: apiKey,
         defaultEntityId: selectedEntity?.id,
         defaultAssignmentSourceId: selectedAssignmentSource?.id,
-        eppoApiBaseUrl: PRODUCTION_API_BASE_URL,
       },
       // In case you don't want to submit any update to app
       // locations, you can just pass the currentState as is
@@ -239,7 +243,7 @@ const ConfigScreen = () => {
       <Heading>Eppo app configuration</Heading>
       <Form>
         <FormControl>
-          <FormControl.Label isRequired>Eppo API key</FormControl.Label>
+          <FormControl.Label isRequired>{CONFIG_FORM_API_KEY_LABEL}</FormControl.Label>
           <TextInput
             data-testid="api-key"
             value={apiKey}
@@ -253,7 +257,7 @@ const ConfigScreen = () => {
           )}
         </FormControl>
         <FormControl>
-          <FormControl.Label isRequired>Default randomization entity</FormControl.Label>
+          <FormControl.Label isRequired>{CONFIG_FORM_DEFAULT_ENTITY_LABEL}</FormControl.Label>
           <Dropdown
             items={entities}
             selectedItem={selectedEntity}
@@ -279,7 +283,7 @@ const ConfigScreen = () => {
           )}
         </FormControl>
         <FormControl>
-          <FormControl.Label isRequired>Default assignment logging table</FormControl.Label>
+          <FormControl.Label isRequired>{CONFIG_FORM_DEFAULT_ASSIGNMENT_LABEL}</FormControl.Label>
           <Dropdown
             items={assignmentSources}
             selectedItem={selectedAssignmentSource}

--- a/apps/eppo/src/locations/EntryEditor/FinishConfigSetup.tsx
+++ b/apps/eppo/src/locations/EntryEditor/FinishConfigSetup.tsx
@@ -1,0 +1,44 @@
+import { EditorAppSDK } from '@contentful/app-sdk';
+import { Box, Card, DisplayText, List, Paragraph, TextLink } from '@contentful/f36-components';
+import { css } from 'emotion';
+import React from 'react';
+
+const container = css({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100vh',
+  paddingBottom: '60px',
+});
+
+interface FinishConfigSetupProps {
+  sdk: EditorAppSDK;
+  missingConfigFields: Array<string>;
+}
+
+export const FinishConfigSetup: React.FunctionComponent<FinishConfigSetupProps> = (props) => {
+  const appId = props.sdk.ids.app;
+  const spaceId = props.sdk.ids.space;
+  const configUrl = `https://app.contentful.com/spaces/${spaceId}/apps/${appId}`;
+
+  return (
+    <Box className={container}>
+      <DisplayText>Please finish configuring the Eppo app</DisplayText>
+      <Card style={{ maxWidth: 300 }}>
+        <Paragraph>The following fields are missing:</Paragraph>
+        <List>
+          {props.missingConfigFields.map((field) => (
+            <List.Item key={field}>{field}</List.Item>
+          ))}
+        </List>
+      </Card>
+      <Box style={{ marginTop: '30px' }}>
+        <TextLink href={configUrl} target="_blank" rel="noopener noreferrer">
+          Go to app configuration
+        </TextLink>
+      </Box>
+    </Box>
+  );
+};

--- a/apps/eppo/src/locations/EntryEditor/OptionalTreatmentVariation.tsx
+++ b/apps/eppo/src/locations/EntryEditor/OptionalTreatmentVariation.tsx
@@ -16,6 +16,7 @@ interface OptionalTreatmentVariationProps {
   onUnlinkEntry: (entryId: string) => Promise<void>;
   onRemoveVariation: (index: number) => void | Promise<void>;
   isDisabled: boolean;
+  allowedContentTypes: string[];
 }
 
 export const OptionalTreatmentVariation: React.FunctionComponent<
@@ -71,6 +72,7 @@ export const OptionalTreatmentVariation: React.FunctionComponent<
         onLink={(linkedEntry) => props.onLinkEntry(linkedEntry, props.treatmentIndex)}
         onUnlink={props.onUnlinkEntry}
         isDisabled={props.isDisabled}
+        allowedContentTypes={props.allowedContentTypes}
       />
     </FormControl>
   );


### PR DESCRIPTION
## Purpose

Customers want the ability to enforce content-type validations in the "Control" and "Treatment" variations of their eppo experiments. 

This PR also contains a separate piece of work that shows users an error screen if they have not finished configuring their app

<img width="811" alt="Screenshot 2025-03-26 at 2 04 26 PM" src="https://github.com/user-attachments/assets/34fa4e4d-0aa7-419d-b1ce-fa7696f35fa3" />

## Approach

Use the EntryEditorSDK to find the field validations necessary to limit by content-type

## Testing steps

- Edit `Default Variation (control)` field of the content model for `Eppo variant container`
- Check `Accept only specified entry type` and select specific content types
- Expect that only these content types are allowed in both Control and Treatment variations when filling out an `Eppo variant container` entry.

## Breaking Changes

None

## Dependencies and/or References

None

## Deployment

None
