### PR TITLE
update Hugging face app page and and add inference providers to config

### DIFF
--- a/apps/hugging-face/README.md
+++ b/apps/hugging-face/README.md
@@ -1,79 +1,23 @@
-This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
+## 🎉 Welcome to Hugging Face
 
-## How to use
+This project is a **Contentful Page App** that allows you to create stock images directly inside Contentful.
 
-Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+## What is Hugging Face?
 
-```bash
-# npx
-npx create-contentful-app --example vite-react
+Hugging Face is an open source, machine learning platform. For this app, we are using Hugging Face's AI interface to create images.
 
-# npm
-npm init contentful-app --example vite-react
+## 🚀 Getting Started
 
-# Yarn
-yarn create contentful-app --example vite-react
-```
+1. Install the app in your Contentful space, making sure to set your Hugging Face API key, the id for the text model you would like to use, and the id for the image model you would like to use
+2. Open the "Apps" tab and select "Hugging Face"
+3. Enter your image description in the text area
+4. Press "Refine prompt" to see the AI suggested text based on your prompt
+5. Edit the "refined" text as your see fit and hit the "Generate image" button when you are happy with your prompt text 
+5. See your AI generated image based on your prompt, if you are happy with it, hit the "Next" button, if not, hit the "Cancel" button
+6. If you are happy with your image, give it a name and save it to you media library
 
-## Available Scripts
+## Tools used
 
-In the project directory, you can run:
-
-#### `npm start`
-
-Creates or updates your app definition in Contentful, and runs the app in development mode.
-Open your app to view it in the browser.
-
-The page will reload if you make edits.
-You will also see any lint errors in the console.
-
-#### `npm run build`
-
-Builds the app for production to the `dist` folder.
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.
-Your app is ready to be deployed!
-
-#### `npm run upload`
-
-Uploads the `dist` folder to Contentful and creates a bundle that is automatically activated.
-The command guides you through the deployment process and asks for all required arguments.
-Read [here](https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/#deploy-with-contentful) for more information about the deployment process.
-
-#### `npm run upload-ci`
-
-Similar to `npm run upload` it will upload your app to contentful and activate it. The only difference is  
-that with this command all required arguments are read from the environment variables, for example when you add
-the upload command to your CI pipeline.
-
-For this command to work, the following environment variables must be set:
-
-- `CONTENTFUL_ORG_ID` - The ID of your organization
-- `CONTENTFUL_APP_DEF_ID` - The ID of the app to which to add the bundle
-- `CONTENTFUL_ACCESS_TOKEN` - A personal [access token](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/personal-access-tokens)
-
-## Libraries to use
-
-To make your app look and feel like Contentful use the following libraries:
-
-- [Forma 36](https://f36.contentful.com/) – Contentful's design system
-- [Contentful Field Editors](https://www.contentful.com/developers/docs/extensibility/field-editors/) – Contentful's field editor React components
-
-## Using the `contentful-management` SDK
-
-In the default create contentful app output, a contentful management client is
-passed into each location. This can be used to interact with Contentful's
-management API. For example
-
-```js
-// Use the client
-cma.locale.getMany({}).then((locales) => console.log(locales));
-```
-
-Visit the [`contentful-management` documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library)
-to find out more.
-
-## Learn More
-
-[Read more](https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/) and check out the video on how to use the CLI.
+@contentful/app-sdk - A library for building Contentful UI Apps
+@contentful/f36-components - A library of Contentful UI components
+@contentful/react-apps-toolkit - A toolkit for building Contentful UI Apps

--- a/apps/hugging-face/package.json
+++ b/apps/hugging-face/package.json
@@ -46,7 +46,8 @@
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id 7dJ4K2h5qKXisoxIeR1Z2B --token ${TEST_CMA_TOKEN}"
   },
   "eslintConfig": {
     "extends": [

--- a/apps/hugging-face/src/components/GenerateImageModal.spec.tsx
+++ b/apps/hugging-face/src/components/GenerateImageModal.spec.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import { GenerateImageModal } from './GenerateImageModal';
+
+describe('GenerateImageModal', () => {
+  const defaultProps = {
+    showGeneratingImageModal: true,
+    prompt: 'A beautiful sunset over the mountains',
+    generatedImage: null,
+    error: null,
+    timer: 30,
+    isGenerating: false,
+    onClickNextAfterImageGeneration: vi.fn(),
+    onRetryImageGeneration: vi.fn(),
+    closeGeneratingImageModal: vi.fn(),
+  };
+
+  it('renders the modal', () => {
+    render(<GenerateImageModal {...defaultProps} />);
+    expect(screen.getByText('Hugging Face image generator')).toBeInTheDocument();
+  });
+
+  it('displays the prompt text', () => {
+    render(<GenerateImageModal {...defaultProps} />);
+    expect(screen.getByText(`"${defaultProps.prompt}"`)).toBeInTheDocument();
+  });
+
+  it('shows the timer with the correct value', () => {
+    render(<GenerateImageModal {...defaultProps} />);
+    expect(screen.getByText(`Timer: ${defaultProps.timer} seconds`)).toBeInTheDocument();
+  });
+
+  it('displays an error message when there is an error', () => {
+    const props = { ...defaultProps, error: 'Something went wrong' };
+    render(<GenerateImageModal {...props} />);
+    expect(screen.getByText('Error: Something went wrong. Please try again.')).toBeInTheDocument();
+  });
+
+  it('renders a skeleton loader when the image is not generated and there is no error', () => {
+    render(<GenerateImageModal {...defaultProps} />);
+    expect(screen.getByLabelText('Loading component...')).toBeInTheDocument();
+  });
+
+  it('renders the generated image when available', () => {
+    const props = { ...defaultProps, generatedImage: 'image-url' };
+    render(<GenerateImageModal {...props} />);
+    expect(screen.getByAltText('Generated image')).toHaveAttribute('src', 'image-url');
+  });
+
+  it('calls closeGeneratingImageModal when the Cancel button is clicked', () => {
+    render(<GenerateImageModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(defaultProps.closeGeneratingImageModal).toHaveBeenCalled();
+  });
+
+  it('calls onRetryImageGeneration when the Retry button is clicked and there is an error', () => {
+    const props = { ...defaultProps, error: 'Something went wrong' };
+    render(<GenerateImageModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(props.onRetryImageGeneration).toHaveBeenCalled();
+  });
+
+  it('calls onClickNextAfterImageGeneration when the Next button is clicked and the image is generated', () => {
+    const props = { ...defaultProps, generatedImage: 'image-url' };
+    render(<GenerateImageModal {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(props.onClickNextAfterImageGeneration).toHaveBeenCalled();
+  });
+
+  it('disables the Retry button when isGenerating is true', () => {
+    const props = { ...defaultProps, error: 'Something went wrong', isGenerating: true };
+    render(<GenerateImageModal {...props} />);
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
+  });
+
+  it('disables the Next button when isGenerating is true', () => {
+    const props = { ...defaultProps, isGenerating: true };
+    render(<GenerateImageModal {...props} />);
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('disables the Next button when there is no generated image', () => {
+    const propsWithoutImage = { ...defaultProps, generatedImage: null };
+    render(<GenerateImageModal {...propsWithoutImage} />);
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});

--- a/apps/hugging-face/src/components/GenerateImageModal.tsx
+++ b/apps/hugging-face/src/components/GenerateImageModal.tsx
@@ -1,0 +1,94 @@
+import { Button, Flex, Heading, Paragraph, Modal, Text, Skeleton, Subheading, Image, Note } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { ClockIcon } from '@contentful/f36-icons';
+
+interface GenerateImageModalProps {
+  showGeneratingImageModal: boolean;
+  prompt: string;
+  generatedImage: string | null;
+  error: string | null;
+  timer: number;
+  isGenerating: boolean;
+  onClickNextAfterImageGeneration: (event: React.FormEvent) => void;
+  onRetryImageGeneration: (event: React.FormEvent) => void;
+  closeGeneratingImageModal: () => void;
+}
+
+export const GenerateImageModal = ({
+  showGeneratingImageModal,
+  prompt,
+  generatedImage,
+  error,
+  timer,
+  isGenerating,
+  onClickNextAfterImageGeneration,
+  onRetryImageGeneration,
+  closeGeneratingImageModal,
+}: GenerateImageModalProps) => {
+  return (
+    <Modal onClose={closeGeneratingImageModal} isShown={showGeneratingImageModal} size="fullscreen">
+      {() => (
+        <>
+          <Modal.Header title="Hugging Face image generator" onClose={closeGeneratingImageModal} />
+          <Modal.Content style={{ paddingBottom: 0, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Flex style={{ width: '1024px', height: '100%', gap: tokens.spacingL, flexDirection: 'column' }}>
+              <Heading style={{ marginBottom: 0 }}>Generating your image</Heading>
+              <Flex justifyContent="space-between">
+                <Flex flexDirection="column" style={{ width: '600px' }}>
+                  <Subheading as="h2" marginBottom="spacingXs">
+                    Prompt
+                  </Subheading>
+                  <Paragraph style={{ marginBottom: 0 }}>"{prompt}"</Paragraph>
+                </Flex>
+                <Flex
+                  justifyContent="center"
+                  flexDirection="column"
+                  style={{
+                    border: `1px solid ${tokens.gray300}`,
+                    borderRadius: tokens.borderRadiusSmall,
+                    padding: tokens.spacingM,
+                    height: '112px',
+                    gap: tokens.spacingXs,
+                  }}>
+                  <Flex alignItems="center" gap={tokens.spacing2Xs}>
+                    <ClockIcon style={{ fill: tokens.gray900 }} />
+                    <Subheading style={{ marginBottom: 0 }}>Timer: {timer} seconds</Subheading>
+                  </Flex>
+                  <Text fontColor="gray700">Some models take ~60 seconds for image generation.</Text>
+                </Flex>
+              </Flex>
+              {error && (
+                <Flex
+                  alignItems="center"
+                  justifyContent="center"
+                  style={{ height: '100%', width: '100%', border: `1px solid ${tokens.red500}`, borderRadius: tokens.borderRadiusSmall }}>
+                  <Note variant="negative">Error: {error}. Please try again.</Note>
+                </Flex>
+              )}
+              {!error && !generatedImage && (
+                <Skeleton.Container>
+                  <Skeleton.Image height="100%" width="100%" />
+                </Skeleton.Container>
+              )}
+              {!error && !!generatedImage && <Image height="100%" width="100%" src={generatedImage} alt="Generated image" />}
+            </Flex>
+          </Modal.Content>
+          <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
+            <Button size="small" onClick={closeGeneratingImageModal}>
+              Cancel
+            </Button>
+            {error ? (
+              <Button size="small" variant="primary" isDisabled={isGenerating} onClick={onRetryImageGeneration}>
+                Retry
+              </Button>
+            ) : (
+              <Button size="small" variant="primary" isDisabled={isGenerating || !generatedImage} onClick={onClickNextAfterImageGeneration}>
+                Next
+              </Button>
+            )}
+          </Modal.Controls>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/apps/hugging-face/src/components/InitialPrompt.spec.tsx
+++ b/apps/hugging-face/src/components/InitialPrompt.spec.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { InitialPrompt } from './InitialPrompt';
+
+describe('InitialPrompt Component', () => {
+  const mockSetInitialPrompt = vi.fn();
+  const mockOnClickRefinePrompt = vi.fn((e) => e.preventDefault());
+  const mockOnClickGenerateImage = vi.fn((e) => e.preventDefault());
+
+  const defaultProps = {
+    initialPrompt: '',
+    setInitialPrompt: mockSetInitialPrompt,
+    isDisabled: false,
+    onClickRefinePrompt: mockOnClickRefinePrompt,
+    onClickGenerateImage: mockOnClickGenerateImage,
+  };
+
+  it('renders the component correctly', () => {
+    render(<InitialPrompt {...defaultProps} />);
+    expect(screen.getByText('Hugging Face Image Generator')).toBeInTheDocument();
+    expect(screen.getByText('Describe your image')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('A sunrise at a farm')).toBeInTheDocument();
+  });
+
+  it('calls setInitialPrompt when the textarea value changes', () => {
+    render(<InitialPrompt {...defaultProps} />);
+    const textarea = screen.getByPlaceholderText('A sunrise at a farm');
+    fireEvent.change(textarea, { target: { value: 'A sunset at the beach' } });
+    expect(mockSetInitialPrompt).toHaveBeenCalledWith('A sunset at the beach');
+  });
+
+  it('disables buttons and textarea when isDisabled is true', () => {
+    render(<InitialPrompt {...defaultProps} isDisabled={true} />);
+    const refineButton = screen.getByRole('button', { name: 'Refine prompt' });
+    const generateButton = screen.getByRole('button', { name: 'Generate image' });
+    const textarea = screen.getByPlaceholderText('A sunrise at a farm');
+    expect(textarea).toBeDisabled();
+    expect(refineButton).toBeDisabled();
+    expect(generateButton).toBeDisabled();
+  });
+
+  it('disables buttons when initialPrompt is empty', () => {
+    render(<InitialPrompt {...defaultProps} />);
+    const refineButton = screen.getByRole('button', { name: 'Refine prompt' });
+    const generateButton = screen.getByRole('button', { name: 'Generate image' });
+    expect(refineButton).toBeDisabled();
+    expect(generateButton).toBeDisabled();
+  });
+
+  it('enables buttons and textarea when initialPrompt is not empty and isDisabled is false', () => {
+    render(<InitialPrompt {...defaultProps} initialPrompt="A sunset at the beach" />);
+    const refineButton = screen.getByRole('button', { name: 'Refine prompt' });
+    const generateButton = screen.getByRole('button', { name: 'Generate image' });
+    const textarea = screen.getByPlaceholderText('A sunrise at a farm');
+    expect(textarea).not.toBeDisabled();
+    expect(refineButton).not.toBeDisabled();
+    expect(generateButton).not.toBeDisabled();
+  });
+
+  it('calls onClickRefinePrompt when the refine button is clicked', () => {
+    render(<InitialPrompt {...defaultProps} initialPrompt="A sunset at the beach" />);
+    const refineButton = screen.getByRole('button', { name: 'Refine prompt' });
+    fireEvent.click(refineButton);
+    expect(mockOnClickRefinePrompt).toHaveBeenCalled();
+  });
+
+  it('calls onClickGenerateImage when the generate button is clicked', () => {
+    render(<InitialPrompt {...defaultProps} initialPrompt="A sunset at the beach" />);
+    const generateButton = screen.getByRole('button', { name: 'Generate image' });
+    fireEvent.click(generateButton);
+    expect(mockOnClickGenerateImage).toHaveBeenCalled();
+  });
+});

--- a/apps/hugging-face/src/components/InitialPrompt.tsx
+++ b/apps/hugging-face/src/components/InitialPrompt.tsx
@@ -1,0 +1,60 @@
+import { Form, FormControl, Textarea, Button, Flex, Heading, Paragraph } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+interface InitialPromptProps {
+  initialPrompt: string;
+  setInitialPrompt: (prompt: string) => void;
+  isDisabled: boolean;
+  onClickRefinePrompt: (e: React.FormEvent) => void;
+  onClickGenerateImage: (e: React.FormEvent) => void;
+}
+
+export const InitialPrompt = ({ initialPrompt, setInitialPrompt, isDisabled, onClickRefinePrompt, onClickGenerateImage }: InitialPromptProps) => (
+  <Flex
+    flexDirection="column"
+    style={{
+      backgroundColor: tokens.colorWhite,
+      margin: `0 ${tokens.spacingL}`,
+      borderRadius: tokens.borderRadiusMedium,
+      padding: tokens.spacingXl,
+      alignItems: 'center',
+      height: '100vh',
+    }}>
+    <Flex flexDirection="column" style={{ width: '900px', gap: tokens.spacingL }}>
+      <Flex flexDirection="column">
+        <Heading style={{ marginBottom: tokens.spacing2Xs }}>Hugging Face Image Generator</Heading>
+        <Paragraph style={{ marginBottom: 0 }}>Enter your initial image concept, optimize it for the best results and generate an image.</Paragraph>
+      </Flex>
+
+      <Form onSubmit={onClickRefinePrompt} style={{ border: `1px solid ${tokens.gray300}`, borderRadius: tokens.borderRadiusSmall, padding: tokens.spacingL }}>
+        <Flex flexDirection="column">
+          <Heading as="h2" style={{ fontSize: tokens.fontSizeL, marginBottom: 0 }}>
+            Describe your image
+          </Heading>
+          <Paragraph>Be descriptive, but concise. You can either refine your prompt first or generate an image directly.</Paragraph>
+        </Flex>
+        <FormControl isRequired style={{ marginBottom: tokens.spacingS }}>
+          <FormControl.Label>Image concept</FormControl.Label>
+          <Textarea
+            name="initialPrompt"
+            value={initialPrompt}
+            onChange={(e) => setInitialPrompt(e.target.value)}
+            placeholder="A sunrise at a farm"
+            isDisabled={isDisabled}
+            rows={4}
+            resize="vertical"
+            style={{ height: '64px' }}
+          />
+        </FormControl>
+        <Flex justifyContent="flex-end" gap="spacingM">
+          <Button size="small" onClick={onClickRefinePrompt} isDisabled={initialPrompt.length === 0 || isDisabled}>
+            Refine prompt
+          </Button>
+          <Button variant="primary" size="small" onClick={onClickGenerateImage} isDisabled={initialPrompt.length === 0 || isDisabled}>
+            Generate image
+          </Button>
+        </Flex>
+      </Form>
+    </Flex>
+  </Flex>
+);

--- a/apps/hugging-face/src/components/RefinePromptModal.spec.tsx
+++ b/apps/hugging-face/src/components/RefinePromptModal.spec.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import { RefinePromptModal } from './RefinePromptModal';
+
+describe('RefinePromptModal', () => {
+  const defaultProps = {
+    showRefinePromptModal: true,
+    refinedPrompt: 'AI Refined prompt',
+    setRefinedPrompt: vi.fn(),
+    error: null,
+    isRefining: false,
+    onSubmitRefinedPrompt: vi.fn(),
+    closeRefinePromptModal: vi.fn(),
+  };
+
+  it('renders the modal when showRefinePromptModal is true', () => {
+    render(<RefinePromptModal {...defaultProps} />);
+    expect(screen.getByText('Refine prompt')).toBeInTheDocument();
+  });
+
+  it('displays an error note when error is present', () => {
+    render(<RefinePromptModal {...defaultProps} error="Something went wrong" />);
+    expect(screen.getByText('Error: Something went wrong. Please try again.')).toBeInTheDocument();
+  });
+
+  it('shows loading state when isRefining is true', () => {
+    render(<RefinePromptModal {...defaultProps} isRefining={true} />);
+    expect(screen.getByText('Generating new prompt')).toBeInTheDocument();
+  });
+
+  it('renders the textarea with the refined prompt', () => {
+    render(<RefinePromptModal {...defaultProps} />);
+    const textarea = screen.getByText('AI Refined prompt') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('AI Refined prompt');
+  });
+
+  it('calls setRefinedPrompt when the textarea value changes', () => {
+    render(<RefinePromptModal {...defaultProps} />);
+    const textarea = screen.getByText('AI Refined prompt') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Updated prompt' } });
+    expect(defaultProps.setRefinedPrompt).toHaveBeenCalledWith('Updated prompt');
+  });
+
+  it('disables the "Generate image" button when isRefining is true', () => {
+    render(<RefinePromptModal {...defaultProps} isRefining={true} />);
+    const button = screen.getByRole('button', { name: 'Generate image' });
+    expect(button).toBeDisabled();
+  });
+
+  it('disables the "Generate image" button when refinedPrompt is empty', () => {
+    render(<RefinePromptModal {...defaultProps} refinedPrompt="" />);
+    const button = screen.getByRole('button', { name: 'Generate image' });
+    expect(button).toBeDisabled();
+  });
+
+  it('disables the "Generate image" button when there is an error', () => {
+    render(<RefinePromptModal {...defaultProps} error="Something went wrong" />);
+    const button = screen.getByRole('button', { name: 'Generate image' });
+    expect(button).toBeDisabled();
+  });
+
+  it('calls onSubmitRefinedPrompt when "Generate image" button is clicked', () => {
+    render(<RefinePromptModal {...defaultProps} />);
+    const button = screen.getByRole('button', { name: 'Generate image' });
+    fireEvent.click(button);
+    expect(defaultProps.onSubmitRefinedPrompt).toHaveBeenCalled();
+  });
+
+  it('calls closeRefinePromptModal when "Cancel" button is clicked', () => {
+    render(<RefinePromptModal {...defaultProps} />);
+    const button = screen.getByRole('button', { name: 'Cancel' });
+    fireEvent.click(button);
+    expect(defaultProps.closeRefinePromptModal).toHaveBeenCalled();
+  });
+});

--- a/apps/hugging-face/src/components/RefinePromptModal.tsx
+++ b/apps/hugging-face/src/components/RefinePromptModal.tsx
@@ -1,0 +1,61 @@
+import { Form, FormControl, Textarea, Button, Flex, Modal, Spinner, Text, Note } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+interface RefinePromptModalProps {
+  showRefinePromptModal: boolean;
+  refinedPrompt: string;
+  setRefinedPrompt: (prompt: string) => void;
+  error: string | null;
+  isRefining: boolean;
+  onSubmitRefinedPrompt: (event: React.FormEvent) => void;
+  closeRefinePromptModal: () => void;
+}
+
+export const RefinePromptModal = ({
+  showRefinePromptModal,
+  refinedPrompt,
+  setRefinedPrompt,
+  error,
+  isRefining,
+  onSubmitRefinedPrompt,
+  closeRefinePromptModal,
+}: RefinePromptModalProps) => (
+  <Modal onClose={closeRefinePromptModal} isShown={showRefinePromptModal}>
+    {() => (
+      <>
+        <Modal.Header title="Refine prompt" onClose={closeRefinePromptModal} />
+        <Modal.Content style={{ paddingBottom: 0 }}>
+          {error && <Note variant="negative">Error: {error}. Please try again.</Note>}
+          {isRefining && !error && (
+            <Flex>
+              <Text marginRight="spacingXs">Generating new prompt</Text>
+              <Spinner />
+            </Flex>
+          )}
+          {!isRefining && !error && (
+            <Form onSubmit={onSubmitRefinedPrompt}>
+              <FormControl style={{ marginBottom: 0 }}>
+                <Textarea
+                  value={refinedPrompt}
+                  onChange={(e) => {
+                    setRefinedPrompt(e.target.value);
+                  }}
+                  style={{ paddingBottom: 0, height: '140px', maxHeight: '260px', minHeight: '64px' }}
+                />
+                <FormControl.HelpText>This is the AI-optimized version of your prompt. You can edit it further if needed.</FormControl.HelpText>
+              </FormControl>
+            </Form>
+          )}
+        </Modal.Content>
+        <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
+          <Button size="small" onClick={closeRefinePromptModal}>
+            Cancel
+          </Button>
+          <Button size="small" variant="primary" isDisabled={isRefining || refinedPrompt.trim().length === 0 || !!error} onClick={onSubmitRefinedPrompt}>
+            Generate image
+          </Button>
+        </Modal.Controls>
+      </>
+    )}
+  </Modal>
+);

--- a/apps/hugging-face/src/locations/ConfigScreen.spec.tsx
+++ b/apps/hugging-face/src/locations/ConfigScreen.spec.tsx
@@ -15,6 +15,7 @@ describe('Config Screen component', () => {
     expect(screen.getByText('Hugging Face Integration Configuration')).toBeTruthy();
     expect(screen.getByText('Hugging Face API Key')).toBeTruthy();
     expect(screen.getByText('Text Model ID')).toBeTruthy();
+    expect(screen.getByText('Text Model Inference Provider')).toBeTruthy();
     expect(screen.getByText('Image Model ID')).toBeTruthy();
   });
 

--- a/apps/hugging-face/src/locations/ConfigScreen.spec.tsx
+++ b/apps/hugging-face/src/locations/ConfigScreen.spec.tsx
@@ -17,6 +17,7 @@ describe('Config Screen component', () => {
     expect(screen.getByText('Text Model ID')).toBeTruthy();
     expect(screen.getByText('Text Model Inference Provider')).toBeTruthy();
     expect(screen.getByText('Image Model ID')).toBeTruthy();
+    expect(screen.getByText('Image Model Inference Provider')).toBeTruthy();
   });
 
   it('Updates form values', () => {

--- a/apps/hugging-face/src/locations/ConfigScreen.tsx
+++ b/apps/hugging-face/src/locations/ConfigScreen.tsx
@@ -107,7 +107,7 @@ const ConfigScreen = () => {
               onChange={handleChange('textModelInferenceProvider')}
               placeholder="hf-inference"
             />
-            <FormControl.HelpText>Enter the Inference Provider you wish to use with your text model</FormControl.HelpText>
+            <FormControl.HelpText>Enter the Inference Provider you wish to use with your text model.</FormControl.HelpText>
           </FormControl>
 
           <FormControl isRequired marginBottom="spacingM">
@@ -119,6 +119,17 @@ const ConfigScreen = () => {
               placeholder="black-forest-labs/FLUX.1-dev"
             />
             <FormControl.HelpText>Enter the Hugging Face model ID for image generation. (Must be a Text-to-Image model)</FormControl.HelpText>
+          </FormControl>
+
+          <FormControl isRequired marginBottom="spacingM">
+            <FormControl.Label>Image Model Inference Provider</FormControl.Label>
+            <TextInput
+              name="imageModelInferenceProvider"
+              value={parameters.imageModelInferenceProvider || ''}
+              onChange={handleChange('imageModelInferenceProvider')}
+              placeholder="hf-inference"
+            />
+            <FormControl.HelpText>Enter the Inference Provider you wish to use with your image model.</FormControl.HelpText>
           </FormControl>
         </Form>
       </Box>

--- a/apps/hugging-face/src/locations/ConfigScreen.tsx
+++ b/apps/hugging-face/src/locations/ConfigScreen.tsx
@@ -3,24 +3,20 @@ import { Flex, Form, FormControl, TextInput, Heading, Paragraph, Box, MenuDivide
 import { useSDK } from '@contentful/react-apps-toolkit';
 import css from '@emotion/css';
 import { useCallback, useEffect, useState } from 'react';
-
-export interface AppInstallationParameters {
-  huggingfaceApiKey?: string;
-  textModelId?: string;
-  imageModelId?: string;
-}
+import { AppInstallationParameters } from '../utils/types';
 
 const ConfigScreen = () => {
   const [parameters, setParameters] = useState<AppInstallationParameters>({
     huggingfaceApiKey: '',
     textModelId: 'meta-llama/Llama-3.2-3B-Instruct',
+    textModelInferenceProvider: 'hf-inference',
     imageModelId: 'black-forest-labs/FLUX.1-dev',
   });
   const sdk = useSDK<ConfigAppSDK>();
 
   const onConfigure = useCallback(async () => {
     // Validate the form
-    const valid = Boolean(parameters.huggingfaceApiKey && parameters.textModelId && parameters.imageModelId);
+    const valid = Boolean(parameters.huggingfaceApiKey && parameters.textModelId && parameters.imageModelId && parameters.textModelInferenceProvider);
 
     if (!valid) return false;
 
@@ -101,6 +97,17 @@ const ConfigScreen = () => {
               placeholder="meta-llama/Llama-3.2-3B-Instruct"
             />
             <FormControl.HelpText>Enter the Hugging Face model ID for text processing. (Must be a Text Generation model)</FormControl.HelpText>
+          </FormControl>
+
+          <FormControl isRequired marginBottom="spacingM">
+            <FormControl.Label>Text Model Inference Provider</FormControl.Label>
+            <TextInput
+              name="textModelInferenceProvider"
+              value={parameters.textModelInferenceProvider || ''}
+              onChange={handleChange('textModelInferenceProvider')}
+              placeholder="hf-inference"
+            />
+            <FormControl.HelpText>Enter the Inference Provider you wish to use with your text model</FormControl.HelpText>
           </FormControl>
 
           <FormControl isRequired marginBottom="spacingM">

--- a/apps/hugging-face/src/locations/Page.tsx
+++ b/apps/hugging-face/src/locations/Page.tsx
@@ -187,6 +187,7 @@ const Page = () => {
           setShowGeneratingImageModal(false);
           setGeneratedImage(null);
           setError(null);
+          setRefinedPrompt('');
         }}
       />
     </>

--- a/apps/hugging-face/src/locations/Page.tsx
+++ b/apps/hugging-face/src/locations/Page.tsx
@@ -1,16 +1,27 @@
+import { useState, useEffect, FormEvent } from 'react';
 import { PageAppSDK } from '@contentful/app-sdk';
-import { Grid, Form, FormControl, Textarea, Button, Flex, Heading, Paragraph, Stack, Note } from '@contentful/f36-components';
+import {
+  Form,
+  FormControl,
+  Textarea,
+  Button,
+  Flex,
+  Heading,
+  Paragraph,
+  Modal,
+  Spinner,
+  Text,
+  Skeleton,
+  Box,
+  Subheading,
+  Image,
+} from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { useState, useEffect } from 'react';
-import css from '@emotion/css';
 import { generateImage } from '../services/huggingfaceImage';
 import { refinePrompt } from '../services/huggingfaceText';
-
-interface AppInstallationParameters {
-  huggingfaceApiKey?: string;
-  textModelId?: string;
-  imageModelId?: string;
-}
+import { AppInstallationParameters } from '../utils/types';
+import { ClockIcon } from '@contentful/f36-icons';
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
@@ -20,16 +31,18 @@ const Page = () => {
   const [generatedImage, setGeneratedImage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refinedPrompt, setRefinedPrompt] = useState('');
-  const [isUploading, setIsUploading] = useState(false);
+  // const [isUploading, setIsUploading] = useState(false);
   const [timer, setTimer] = useState(0);
   const [isTimerActive, setIsTimerActive] = useState(false);
+  const [showRefinePromptModal, setShowRefinePromptModal] = useState(false);
+  const [showGeneratingImageModal, setShowGeneratingImageModal] = useState(false);
 
   useEffect(() => {
     let interval: NodeJS.Timeout | null = null;
 
     if (isTimerActive) {
       interval = setInterval(() => {
-        setTimer((prev: number) => prev + 1);
+        setTimer((prev) => prev + 1);
       }, 1000);
     }
 
@@ -89,144 +102,228 @@ const Page = () => {
     }
   };
 
-  const handleUploadAsset = async () => {
-    if (!generatedImage) return;
+  // ADD TIMEOUT FOR REQUESTS
 
-    setIsUploading(true);
+  // const handleUploadAsset = async () => {
+  //   if (!generatedImage) return;
+
+  //   setIsUploading(true);
+  //   setError(null);
+
+  //   try {
+  //     const response = await fetch(generatedImage);
+  //     const blob = await response.blob();
+  //     const file = new File([blob], 'ai-generated-image.png', { type: 'image/png' });
+  //     const buffer = await file.arrayBuffer();
+  //     const upload = await sdk.cma.upload.create({ spaceId: sdk.ids.space }, { file: buffer });
+
+  //     let asset = await sdk.cma.asset.create(
+  //       { spaceId: sdk.ids.space },
+  //       {
+  //         fields: {
+  //           title: {
+  //             'en-US': 'AI Generated Image',
+  //           },
+  //           description: {
+  //             'en-US': `Generated from prompt: ${initialPrompt}`,
+  //           },
+  //           file: {
+  //             'en-US': {
+  //               contentType: 'image/png',
+  //               fileName: 'ai-generated-image.png',
+  //               uploadFrom: {
+  //                 sys: { type: 'Link', linkType: 'Upload', id: upload.sys.id },
+  //               },
+  //             },
+  //           },
+  //         },
+  //       }
+  //     );
+
+  //     asset = await sdk.cma.asset.processForLocale({ spaceId: sdk.ids.space, assetId: asset.sys.id, version: asset.sys.version }, asset, 'en-US');
+  //     asset = await sdk.cma.asset.publish({ spaceId: sdk.ids.space, assetId: asset.sys.id, version: asset.sys.version }, asset);
+
+  //     sdk.notifier.success('Asset successfully uploaded and published');
+  //   } catch (error) {
+  //     console.error('Error uploading asset:', error);
+  //     setError(error instanceof Error ? error.message : 'Failed to upload asset');
+  //     sdk.notifier.error('Failed to upload asset');
+  //   } finally {
+  //     setIsUploading(false);
+  //   }
+  // };
+
+  const onClickRefinePrompt = (event: FormEvent) => {
+    setShowRefinePromptModal(true);
+    handleRefinePrompt(event);
+  };
+
+  const onClickGenerateImage = (event: FormEvent) => {
+    setShowGeneratingImageModal(true);
+    handleGenerateImage(event);
+  };
+
+  const onSubmitRefinedPrompt = (event: FormEvent) => {
+    setShowRefinePromptModal(false);
+    setShowGeneratingImageModal(true);
+    handleGenerateImage(event);
+  };
+
+  const onClickNextAfterImageGeneration = (event: FormEvent) => {
+    setShowGeneratingImageModal(false);
+    // handleUploadAsset();
+  };
+
+  const closeRefinePromptModal = () => {
+    setShowRefinePromptModal(false);
+    setRefinedPrompt('');
     setError(null);
+  };
 
-    try {
-      const response = await fetch(generatedImage);
-      const blob = await response.blob();
-      const file = new File([blob], 'ai-generated-image.png', { type: 'image/png' });
-      const buffer = await file.arrayBuffer();
-      const upload = await sdk.cma.upload.create({ spaceId: sdk.ids.space }, { file: buffer });
-
-      let asset = await sdk.cma.asset.create(
-        { spaceId: sdk.ids.space },
-        {
-          fields: {
-            title: {
-              'en-US': 'AI Generated Image',
-            },
-            description: {
-              'en-US': `Generated from prompt: ${initialPrompt}`,
-            },
-            file: {
-              'en-US': {
-                contentType: 'image/png',
-                fileName: 'ai-generated-image.png',
-                uploadFrom: {
-                  sys: { type: 'Link', linkType: 'Upload', id: upload.sys.id },
-                },
-              },
-            },
-          },
-        }
-      );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      asset = await sdk.cma.asset.processForLocale({ spaceId: sdk.ids.space, assetId: asset.sys.id, version: asset.sys.version } as any, asset, 'en-US');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await sdk.cma.asset.publish({ spaceId: sdk.ids.space, assetId: asset.sys.id, version: asset.sys.version } as any, asset);
-
-      sdk.notifier.success('Asset successfully uploaded and published');
-    } catch (error) {
-      console.error('Error uploading asset:', error);
-      setError(error instanceof Error ? error.message : 'Failed to upload asset');
-      sdk.notifier.error('Failed to upload asset');
-    } finally {
-      setIsUploading(false);
-    }
+  const closeGeneratingImageModal = () => {
+    setShowGeneratingImageModal(false);
+    setGeneratedImage(null);
+    setError(null);
   };
 
   return (
-    <Grid padding="spacingXl" columns="1fr" rowGap="spacingXl" style={{ maxWidth: '1200px', margin: '0 auto' }}>
-      {/* Header Section */}
-      <Grid.Item>
-        <Stack spacing="spacingM">
-          <Heading>AI Image Generation</Heading>
-          <Paragraph>Enter your initial image concept, and we'll help optimize it for the best results.</Paragraph>
-        </Stack>
-      </Grid.Item>
+    <Flex
+      flexDirection="column"
+      style={{
+        backgroundColor: tokens.colorWhite,
+        margin: `0 ${tokens.spacingL}`,
+        borderRadius: tokens.borderRadiusMedium,
+        padding: tokens.spacingXl,
+        alignItems: 'center',
+        height: '100vh',
+      }}>
+      <Flex flexDirection="column" style={{ width: '900px', gap: tokens.spacingL }}>
+        <Flex flexDirection="column">
+          <Heading style={{ marginBottom: tokens.spacing2Xs }}>Hugging Face Image Generator</Heading>
+          <Paragraph style={{ marginBottom: 0 }}>Enter your initial image concept, optimize it for the best results and generate an image.</Paragraph>
+        </Flex>
 
-      {/* Form Section */}
-      <Grid.Item>
-        <Form onSubmit={handleRefinePrompt}>
-          <Stack spacing="spacingM">
-            <FormControl isRequired>
-              <FormControl.Label>Describe your image concept</FormControl.Label>
-              <Textarea
-                name="initialPrompt"
-                value={initialPrompt}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInitialPrompt(e.target.value)}
-                placeholder="e.g., A calm forest with a surreal glow"
-                isDisabled={isRefining || isGenerating}
-                rows={4}
-                resize="vertical"
-              />
-              <FormControl.HelpText>Be descriptive but concise. You can either refine your prompt first or generate an image directly.</FormControl.HelpText>
-            </FormControl>
-
-            {refinedPrompt && (
-              <FormControl>
-                <FormControl.Label>Refined Prompt</FormControl.Label>
-                <Textarea
-                  name="refinedPrompt"
-                  value={refinedPrompt}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setRefinedPrompt(e.target.value)}
-                  isDisabled={isGenerating}
-                  rows={4}
-                  resize="vertical"
-                />
-                <FormControl.HelpText>This is the AI-optimized version of your prompt. You can edit it further if needed.</FormControl.HelpText>
-              </FormControl>
-            )}
-
-            <Flex flexDirection="column" gap="spacingS">
-              <Button variant="secondary" onClick={handleRefinePrompt} isDisabled={!initialPrompt.trim() || isRefining || isGenerating} isLoading={isRefining}>
-                {isRefining ? 'Refining Prompt...' : 'Refine Prompt'}
-              </Button>
-              <Button variant="primary" onClick={handleGenerateImage} isDisabled={!initialPrompt.trim() || isGenerating} isLoading={isGenerating}>
-                {isGenerating ? 'Generating Image...' : 'Generate Image'}
-              </Button>
-            </Flex>
-          </Stack>
+        <Form onSubmit={handleRefinePrompt} style={{ border: `1px solid ${tokens.gray300}`, borderRadius: tokens.borderRadiusSmall, padding: tokens.spacingL }}>
+          <Flex flexDirection="column">
+            <Heading as="h2" style={{ fontSize: tokens.fontSizeL, marginBottom: 0 }}>
+              Describe your image
+            </Heading>
+            <Paragraph>Be descriptive, but concise. You can either refine your prompt first or generate an image directly.</Paragraph>
+          </Flex>
+          <FormControl isRequired style={{ marginBottom: tokens.spacingS }}>
+            <FormControl.Label>Image concept</FormControl.Label>
+            <Textarea
+              name="initialPrompt"
+              value={initialPrompt}
+              onChange={(e) => setInitialPrompt(e.target.value)}
+              placeholder="A sunrise at a farm"
+              isDisabled={isRefining || isGenerating}
+              rows={4}
+              resize="vertical"
+              style={{ height: '64px' }}
+            />
+          </FormControl>
+          <Flex justifyContent="flex-end" gap="spacingM">
+            <Button size="small" onClick={onClickRefinePrompt} isDisabled={initialPrompt.length === 0 || isRefining || isGenerating}>
+              Refine prompt
+            </Button>
+            <Button variant="primary" size="small" onClick={onClickGenerateImage} isDisabled={initialPrompt.length === 0 || isRefining || isGenerating}>
+              Generate image
+            </Button>
+          </Flex>
         </Form>
-      </Grid.Item>
-
-      {/* Results Section */}
-      <Grid.Item>
-        {isTimerActive && (
+      </Flex>
+      <Modal onClose={closeRefinePromptModal} isShown={showRefinePromptModal}>
+        {() => (
           <>
-            <Note variant="primary" className={`${css({ margin: '24px 0' })}`}>
-              Some models take ~60 seconds for image generation.
-            </Note>
-            <Note variant="premium" className={`${css({ margin: '24px 0' })}`}>
-              Timer: {timer} seconds
-            </Note>
+            <Modal.Header title="Refine prompt" onClose={closeRefinePromptModal} />
+            <Modal.Content style={{ paddingBottom: 0 }}>
+              {isRefining && (
+                <Flex>
+                  <Text marginRight="spacingXs">Generating new prompt</Text>
+                  <Spinner />
+                </Flex>
+              )}
+              {!isRefining && error && <Flex style={{ color: tokens.red600 }}>Error: {error}</Flex>}
+              {!isRefining && !error && (
+                <Form onSubmit={onSubmitRefinedPrompt}>
+                  <FormControl style={{ marginBottom: 0 }}>
+                    <Textarea
+                      value={refinedPrompt}
+                      onChange={(e) => {
+                        setRefinedPrompt(e.target.value);
+                      }}
+                      style={{ paddingBottom: 0, height: '140px', maxHeight: '260px', minHeight: '64px' }}
+                    />
+                    <FormControl.HelpText>This is the AI-optimized version of your prompt. You can edit it further if needed.</FormControl.HelpText>
+                  </FormControl>
+                </Form>
+              )}
+            </Modal.Content>
+            <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
+              <Button size="small" onClick={closeRefinePromptModal}>
+                Cancel
+              </Button>
+              <Button size="small" variant="primary" isDisabled={isRefining || refinedPrompt.trim().length === 0} onClick={onSubmitRefinedPrompt}>
+                Generate image
+              </Button>
+            </Modal.Controls>
           </>
         )}
-        {error && <Note variant="negative">{error}</Note>}
+      </Modal>
 
-        {generatedImage && (
-          <Grid columns="2fr 1fr" columnGap="spacingM" style={{ width: '100%' }}>
-            <Grid.Item>
-              <img src={generatedImage} alt="Generated" style={{ maxWidth: '100%', height: 'auto' }} />
-            </Grid.Item>
-            <Grid.Item>
-              <Stack spacing="spacingM">
-                <Button variant="secondary" onClick={handleGenerateImage} isDisabled={isGenerating} isLoading={isGenerating}>
-                  Regenerate Image
-                </Button>
-                <Button variant="positive" onClick={handleUploadAsset} isDisabled={isUploading} isLoading={isUploading}>
-                  Upload to Assets
-                </Button>
-              </Stack>
-            </Grid.Item>
-          </Grid>
+      <Modal onClose={closeGeneratingImageModal} isShown={showGeneratingImageModal} size="fullscreen">
+        {() => (
+          <>
+            <Modal.Header title="Hugging Face image generator" onClose={closeGeneratingImageModal} />
+            <Modal.Content style={{ paddingBottom: 0, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <Flex style={{ width: '1024px', gap: tokens.spacingL, flexDirection: 'column' }}>
+                <Heading style={{ marginBottom: 0 }}>Generating your image</Heading>
+                <Flex justifyContent="space-between">
+                  <Flex flexDirection="column" style={{ width: '600px' }}>
+                    <Subheading as="h2" marginBottom="spacingXs">
+                      Prompt
+                    </Subheading>
+                    <Paragraph style={{ marginBottom: 0 }}>"{refinedPrompt || initialPrompt}"</Paragraph>
+                  </Flex>
+                  <Flex
+                    justifyContent="center"
+                    flexDirection="column"
+                    style={{
+                      border: `1px solid ${tokens.gray300}`,
+                      borderRadius: tokens.borderRadiusSmall,
+                      padding: tokens.spacingM,
+                      height: '112px',
+                      gap: tokens.spacingXs,
+                    }}>
+                    <Flex alignItems="center" gap={tokens.spacing2Xs}>
+                      <ClockIcon style={{ fill: tokens.gray900 }} />
+                      <Subheading style={{ marginBottom: 0 }}>Timer: {timer} seconds</Subheading>
+                    </Flex>
+                    <Text fontColor="gray700">Some models take ~60 seconds for image generation.</Text>
+                  </Flex>
+                </Flex>
+                {error && <Flex style={{ color: tokens.red600 }}>Error: {error}</Flex>}
+                {!error && !generatedImage && (
+                  <Skeleton.Container>
+                    <Skeleton.Image height="100%" width="100%" />
+                  </Skeleton.Container>
+                )}
+                {!error && !!generatedImage && <Image height="100%" width="100%" src={generatedImage} alt="Generated image" />}
+              </Flex>
+            </Modal.Content>
+            <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
+              <Button size="small" onClick={closeGeneratingImageModal}>
+                Cancel
+              </Button>
+              <Button size="small" variant="primary" isDisabled={isGenerating || !generatedImage} onClick={onClickNextAfterImageGeneration}>
+                Next
+              </Button>
+            </Modal.Controls>
+          </>
         )}
-      </Grid.Item>
-    </Grid>
+      </Modal>
+    </Flex>
   );
 };
 

--- a/apps/hugging-face/src/locations/Page.tsx
+++ b/apps/hugging-face/src/locations/Page.tsx
@@ -1,36 +1,21 @@
-import { useState, useEffect, FormEvent } from 'react';
+import { useState, useEffect } from 'react';
 import { PageAppSDK } from '@contentful/app-sdk';
-import {
-  Form,
-  FormControl,
-  Textarea,
-  Button,
-  Flex,
-  Heading,
-  Paragraph,
-  Modal,
-  Spinner,
-  Text,
-  Skeleton,
-  Box,
-  Subheading,
-  Image,
-} from '@contentful/f36-components';
-import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { generateImage } from '../services/huggingfaceImage';
 import { refinePrompt } from '../services/huggingfaceText';
 import { AppInstallationParameters } from '../utils/types';
-import { ClockIcon } from '@contentful/f36-icons';
+import { GenerateImageModal } from '../components/GenerateImageModal';
+import { RefinePromptModal } from '../components/RefinePromptModal';
+import { InitialPrompt } from '../components/InitialPrompt';
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
   const [initialPrompt, setInitialPrompt] = useState('');
   const [isRefining, setIsRefining] = useState(false);
+  const [refinedPrompt, setRefinedPrompt] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedImage, setGeneratedImage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [refinedPrompt, setRefinedPrompt] = useState('');
   // const [isUploading, setIsUploading] = useState(false);
   const [timer, setTimer] = useState(0);
   const [isTimerActive, setIsTimerActive] = useState(false);
@@ -68,7 +53,6 @@ const Page = () => {
       const optimizedPrompt = await refinePrompt(initialPrompt, parameters);
       setRefinedPrompt(optimizedPrompt);
     } catch (error) {
-      console.error('Error refining prompt:', error);
       setError(error instanceof Error ? error.message : 'Failed to refine prompt');
     } finally {
       setIsRefining(false);
@@ -94,15 +78,12 @@ const Page = () => {
       const imageUrl = URL.createObjectURL(imageBlob);
       setGeneratedImage(imageUrl);
     } catch (error) {
-      console.error('Error generating image:', error);
       setError(error instanceof Error ? error.message : 'Failed to generate image');
     } finally {
       setIsGenerating(false);
       setIsTimerActive(false);
     }
   };
-
-  // ADD TIMEOUT FOR REQUESTS
 
   // const handleUploadAsset = async () => {
   //   if (!generatedImage) return;
@@ -153,177 +134,62 @@ const Page = () => {
   //   }
   // };
 
-  const onClickRefinePrompt = (event: FormEvent) => {
-    setShowRefinePromptModal(true);
-    handleRefinePrompt(event);
-  };
-
-  const onClickGenerateImage = (event: FormEvent) => {
-    setShowGeneratingImageModal(true);
-    handleGenerateImage(event);
-  };
-
-  const onSubmitRefinedPrompt = (event: FormEvent) => {
-    setShowRefinePromptModal(false);
-    setShowGeneratingImageModal(true);
-    handleGenerateImage(event);
-  };
-
-  const onClickNextAfterImageGeneration = (event: FormEvent) => {
-    setShowGeneratingImageModal(false);
-    // handleUploadAsset();
-  };
-
-  const closeRefinePromptModal = () => {
-    setShowRefinePromptModal(false);
-    setRefinedPrompt('');
-    setError(null);
-  };
-
-  const closeGeneratingImageModal = () => {
-    setShowGeneratingImageModal(false);
-    setGeneratedImage(null);
-    setError(null);
-  };
-
   return (
-    <Flex
-      flexDirection="column"
-      style={{
-        backgroundColor: tokens.colorWhite,
-        margin: `0 ${tokens.spacingL}`,
-        borderRadius: tokens.borderRadiusMedium,
-        padding: tokens.spacingXl,
-        alignItems: 'center',
-        height: '100vh',
-      }}>
-      <Flex flexDirection="column" style={{ width: '900px', gap: tokens.spacingL }}>
-        <Flex flexDirection="column">
-          <Heading style={{ marginBottom: tokens.spacing2Xs }}>Hugging Face Image Generator</Heading>
-          <Paragraph style={{ marginBottom: 0 }}>Enter your initial image concept, optimize it for the best results and generate an image.</Paragraph>
-        </Flex>
+    <>
+      <InitialPrompt
+        initialPrompt={initialPrompt}
+        setInitialPrompt={setInitialPrompt}
+        isDisabled={isRefining || isGenerating}
+        onClickRefinePrompt={(event) => {
+          setShowRefinePromptModal(true);
+          handleRefinePrompt(event);
+        }}
+        onClickGenerateImage={(event) => {
+          setShowGeneratingImageModal(true);
+          handleGenerateImage(event);
+        }}
+      />
+      <RefinePromptModal
+        showRefinePromptModal={showRefinePromptModal}
+        refinedPrompt={refinedPrompt}
+        isRefining={isRefining}
+        setRefinedPrompt={setRefinedPrompt}
+        error={error}
+        onSubmitRefinedPrompt={(event) => {
+          setShowRefinePromptModal(false);
+          setShowGeneratingImageModal(true);
+          handleGenerateImage(event);
+        }}
+        closeRefinePromptModal={() => {
+          setShowRefinePromptModal(false);
+          setRefinedPrompt('');
+          setError(null);
+        }}
+      />
 
-        <Form onSubmit={handleRefinePrompt} style={{ border: `1px solid ${tokens.gray300}`, borderRadius: tokens.borderRadiusSmall, padding: tokens.spacingL }}>
-          <Flex flexDirection="column">
-            <Heading as="h2" style={{ fontSize: tokens.fontSizeL, marginBottom: 0 }}>
-              Describe your image
-            </Heading>
-            <Paragraph>Be descriptive, but concise. You can either refine your prompt first or generate an image directly.</Paragraph>
-          </Flex>
-          <FormControl isRequired style={{ marginBottom: tokens.spacingS }}>
-            <FormControl.Label>Image concept</FormControl.Label>
-            <Textarea
-              name="initialPrompt"
-              value={initialPrompt}
-              onChange={(e) => setInitialPrompt(e.target.value)}
-              placeholder="A sunrise at a farm"
-              isDisabled={isRefining || isGenerating}
-              rows={4}
-              resize="vertical"
-              style={{ height: '64px' }}
-            />
-          </FormControl>
-          <Flex justifyContent="flex-end" gap="spacingM">
-            <Button size="small" onClick={onClickRefinePrompt} isDisabled={initialPrompt.length === 0 || isRefining || isGenerating}>
-              Refine prompt
-            </Button>
-            <Button variant="primary" size="small" onClick={onClickGenerateImage} isDisabled={initialPrompt.length === 0 || isRefining || isGenerating}>
-              Generate image
-            </Button>
-          </Flex>
-        </Form>
-      </Flex>
-      <Modal onClose={closeRefinePromptModal} isShown={showRefinePromptModal}>
-        {() => (
-          <>
-            <Modal.Header title="Refine prompt" onClose={closeRefinePromptModal} />
-            <Modal.Content style={{ paddingBottom: 0 }}>
-              {isRefining && (
-                <Flex>
-                  <Text marginRight="spacingXs">Generating new prompt</Text>
-                  <Spinner />
-                </Flex>
-              )}
-              {!isRefining && error && <Flex style={{ color: tokens.red600 }}>Error: {error}</Flex>}
-              {!isRefining && !error && (
-                <Form onSubmit={onSubmitRefinedPrompt}>
-                  <FormControl style={{ marginBottom: 0 }}>
-                    <Textarea
-                      value={refinedPrompt}
-                      onChange={(e) => {
-                        setRefinedPrompt(e.target.value);
-                      }}
-                      style={{ paddingBottom: 0, height: '140px', maxHeight: '260px', minHeight: '64px' }}
-                    />
-                    <FormControl.HelpText>This is the AI-optimized version of your prompt. You can edit it further if needed.</FormControl.HelpText>
-                  </FormControl>
-                </Form>
-              )}
-            </Modal.Content>
-            <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
-              <Button size="small" onClick={closeRefinePromptModal}>
-                Cancel
-              </Button>
-              <Button size="small" variant="primary" isDisabled={isRefining || refinedPrompt.trim().length === 0} onClick={onSubmitRefinedPrompt}>
-                Generate image
-              </Button>
-            </Modal.Controls>
-          </>
-        )}
-      </Modal>
-
-      <Modal onClose={closeGeneratingImageModal} isShown={showGeneratingImageModal} size="fullscreen">
-        {() => (
-          <>
-            <Modal.Header title="Hugging Face image generator" onClose={closeGeneratingImageModal} />
-            <Modal.Content style={{ paddingBottom: 0, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <Flex style={{ width: '1024px', gap: tokens.spacingL, flexDirection: 'column' }}>
-                <Heading style={{ marginBottom: 0 }}>Generating your image</Heading>
-                <Flex justifyContent="space-between">
-                  <Flex flexDirection="column" style={{ width: '600px' }}>
-                    <Subheading as="h2" marginBottom="spacingXs">
-                      Prompt
-                    </Subheading>
-                    <Paragraph style={{ marginBottom: 0 }}>"{refinedPrompt || initialPrompt}"</Paragraph>
-                  </Flex>
-                  <Flex
-                    justifyContent="center"
-                    flexDirection="column"
-                    style={{
-                      border: `1px solid ${tokens.gray300}`,
-                      borderRadius: tokens.borderRadiusSmall,
-                      padding: tokens.spacingM,
-                      height: '112px',
-                      gap: tokens.spacingXs,
-                    }}>
-                    <Flex alignItems="center" gap={tokens.spacing2Xs}>
-                      <ClockIcon style={{ fill: tokens.gray900 }} />
-                      <Subheading style={{ marginBottom: 0 }}>Timer: {timer} seconds</Subheading>
-                    </Flex>
-                    <Text fontColor="gray700">Some models take ~60 seconds for image generation.</Text>
-                  </Flex>
-                </Flex>
-                {error && <Flex style={{ color: tokens.red600 }}>Error: {error}</Flex>}
-                {!error && !generatedImage && (
-                  <Skeleton.Container>
-                    <Skeleton.Image height="100%" width="100%" />
-                  </Skeleton.Container>
-                )}
-                {!error && !!generatedImage && <Image height="100%" width="100%" src={generatedImage} alt="Generated image" />}
-              </Flex>
-            </Modal.Content>
-            <Modal.Controls style={{ padding: `${tokens.spacingM} ${tokens.spacingL}` }}>
-              <Button size="small" onClick={closeGeneratingImageModal}>
-                Cancel
-              </Button>
-              <Button size="small" variant="primary" isDisabled={isGenerating || !generatedImage} onClick={onClickNextAfterImageGeneration}>
-                Next
-              </Button>
-            </Modal.Controls>
-          </>
-        )}
-      </Modal>
-    </Flex>
+      <GenerateImageModal
+        showGeneratingImageModal={showGeneratingImageModal}
+        prompt={refinedPrompt || initialPrompt}
+        generatedImage={generatedImage}
+        error={error}
+        timer={timer}
+        isGenerating={isGenerating}
+        onClickNextAfterImageGeneration={(event) => {
+          setShowGeneratingImageModal(false);
+          // handleUploadAsset();
+        }}
+        onRetryImageGeneration={(event) => {
+          setGeneratedImage(null);
+          setError(null);
+          handleGenerateImage(event);
+        }}
+        closeGeneratingImageModal={() => {
+          setShowGeneratingImageModal(false);
+          setGeneratedImage(null);
+          setError(null);
+        }}
+      />
+    </>
   );
 };
 

--- a/apps/hugging-face/src/services/huggingfaceImage.ts
+++ b/apps/hugging-face/src/services/huggingfaceImage.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from '../locations/ConfigScreen';
+import { AppInstallationParameters } from '../utils/types';
 
 export async function generateImage(prompt: string, parameters: AppInstallationParameters, refinedPrompt?: string): Promise<Blob> {
   if (!parameters.huggingfaceApiKey || !parameters.imageModelId) {

--- a/apps/hugging-face/src/services/huggingfaceImage.ts
+++ b/apps/hugging-face/src/services/huggingfaceImage.ts
@@ -1,25 +1,25 @@
+import { InferenceClient } from '@huggingface/inference';
 import { AppInstallationParameters } from '../utils/types';
 
 export async function generateImage(prompt: string, parameters: AppInstallationParameters, refinedPrompt?: string): Promise<Blob> {
-  if (!parameters.huggingfaceApiKey || !parameters.imageModelId) {
-    throw new Error('Missing API key or model ID configuration');
+  if (!parameters.huggingfaceApiKey || !parameters.imageModelId || !parameters.imageModelInferenceProvider) {
+    throw new Error('Missing API key or model ID configuration or inference provider');
   }
+
+  const client = new InferenceClient(parameters.huggingfaceApiKey);
 
   const finalPrompt = refinedPrompt || prompt;
 
-  const response = await fetch(`https://api-inference.huggingface.co/models/${parameters.imageModelId}`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${parameters.huggingfaceApiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ inputs: finalPrompt }),
-  });
+  try {
+    const image = await client.textToImage({
+      provider: parameters.imageModelInferenceProvider,
+      model: parameters.imageModelId,
+      inputs: finalPrompt,
+      parameters: { num_inference_steps: 5 },
+    });
 
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Hugging Face API error: ${error}`);
+    return image;
+  } catch (error) {
+    throw new Error('Failed to generate image with image model');
   }
-
-  return response.blob();
 }

--- a/apps/hugging-face/src/services/huggingfaceText.ts
+++ b/apps/hugging-face/src/services/huggingfaceText.ts
@@ -1,17 +1,18 @@
-import { HfInference } from '@huggingface/inference';
-import { AppInstallationParameters } from '../locations/ConfigScreen';
+import { InferenceClient } from '@huggingface/inference';
+import { AppInstallationParameters } from '../utils/types';
 
 const SYSTEM_PROMPT = `You are an advanced marketing prompt engineer specializing in photorealistic image generation. Transform any user-submitted image prompt into a concise, best-practice prompt that includes realistic details, lighting, composition, environment context, and camera settings. Your final output must be only the refined prompt itself without any additional explanation or formatting.`;
 
 export async function refinePrompt(prompt: string, parameters: AppInstallationParameters): Promise<string> {
-  if (!parameters.huggingfaceApiKey || !parameters.textModelId) {
-    throw new Error('Missing API key or text model ID configuration');
+  if (!parameters.huggingfaceApiKey || !parameters.textModelId || !parameters.textModelInferenceProvider) {
+    throw new Error('Missing API key or text model ID configuration or inference provider');
   }
 
-  const client = new HfInference(parameters.huggingfaceApiKey);
+  const client = new InferenceClient(parameters.huggingfaceApiKey);
 
   try {
     const chatCompletion = await client.chatCompletion({
+      provider: parameters.textModelInferenceProvider,
       model: parameters.textModelId,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },

--- a/apps/hugging-face/src/services/huggingfaceText.ts
+++ b/apps/hugging-face/src/services/huggingfaceText.ts
@@ -29,7 +29,6 @@ export async function refinePrompt(prompt: string, parameters: AppInstallationPa
 
     return chatCompletion.choices[0].message.content;
   } catch (error) {
-    console.error('Error refining prompt:', error);
     throw new Error('Failed to refine prompt with text model');
   }
 }

--- a/apps/hugging-face/src/utils/types.ts
+++ b/apps/hugging-face/src/utils/types.ts
@@ -3,4 +3,5 @@ export interface AppInstallationParameters {
   textModelId?: string;
   imageModelId?: string;
   textModelInferenceProvider?: string;
+  imageModelInferenceProvider?: string;
 }

--- a/apps/hugging-face/src/utils/types.ts
+++ b/apps/hugging-face/src/utils/types.ts
@@ -1,0 +1,6 @@
+export interface AppInstallationParameters {
+  huggingfaceApiKey?: string;
+  textModelId?: string;
+  imageModelId?: string;
+  textModelInferenceProvider?: string;
+}


### PR DESCRIPTION
## Purpose

1) Make hugging face app look like designs 
- initial prompt page
- refine prompt modal
- generate image modal
https://www.figma.com/design/bHX4i2exnrRIyG98J1b6fi/SE-PS-Marketplace-App-Contribution?node-id=57-2687&p=f&m=dev
2) Add inference providers to config because not all inference providers work for all configs

## Approach

- separated Page into three components to separate the UI from the logic and make testing each section easier

## Testing steps

Hold on I need to update the credentials because I used them all up :(

## Dependencies and/or References

https://contentful.atlassian.net/browse/INTEG-2580
https://contentful.atlassian.net/browse/INTEG-2581
https://contentful.atlassian.net/browse/INTEG-2582
