### PR TITLE
feat: document Shopify app migration to Storefront API [INTEG-2706]

### DIFF
--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@contentful/shopify-sku",
   "version": "2.0.12",
+  "description": "Contentful app for importing Shopify products using the Storefront API",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.23.0",


### PR DESCRIPTION
## Purpose

- the previous PR https://github.com/contentful/marketplace-partner-apps/pull/5130 was tagged as a `refactor` and therefore didn't trigger a release 🤦 
- This adds a feat flag that will and some actual changes so it doesn't get ignored by lerna
