### PR TITLE
fix: performance issues on lottie viewer config page [ZEND-6496]

### DIFF
--- a/apps/lottie-preview/package-lock.json
+++ b/apps/lottie-preview/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lottie-viewer",
+  "name": "lottie-preview",
   "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lottie-viewer",
+      "name": "lottie-preview",
       "version": "1.0.4",
       "dependencies": {
         "@contentful/app-sdk": "^4.29.5",


### PR DESCRIPTION
## Purpose

A customer reported being unable to install the Lottie Preview app. Impersonating them, I see they have a lot of Content Types. I reviewed the logic for the config page knowing how it fetches many content types and deals with their editor interfaces to apply the Lottie app to JSON fields within Content Types. 

There were a few critical issues that I believe will resolve this for the customer. 


