### PR TITLE
fix: Shopify tag searching and wildcard fixes [ZEND-6490]

### DIFF
--- a/apps/shopify/src/__tests__/pagination.test.js
+++ b/apps/shopify/src/__tests__/pagination.test.js
@@ -87,7 +87,7 @@ describe('Pagination Search Query Generation', () => {
         expect.stringContaining('query getProducts'),
         expect.objectContaining({
           variables: expect.objectContaining({
-            query: 'title:* test-sku* OR sku:* test-sku* OR sku:"test-sku" OR title:"test-sku"',
+            query: 'title:* test-sku* OR sku:* test-sku* OR sku:"test-sku" OR title:"test-sku" OR tag:* test-sku* OR tag:"test-sku"',
           }),
         })
       );
@@ -115,7 +115,65 @@ describe('Pagination Search Query Generation', () => {
         expect.stringContaining('query getProducts'),
         expect.objectContaining({
           variables: expect.objectContaining({
-            query: 'title:* sku-managed-1* OR sku:* sku-managed-1* OR sku:"sku-managed-1" OR title:"sku-managed-1"',
+            query:
+              'title:* sku-managed-1* OR sku:* sku-managed-1* OR sku:"sku-managed-1" OR title:"sku-managed-1" OR tag:* sku-managed-1* OR tag:"sku-managed-1"',
+          }),
+        })
+      );
+    });
+
+    it('should handle tag-based search terms', async () => {
+      const mockResponse = {
+        data: {
+          products: {
+            edges: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+      mockClient.request.mockResolvedValue(mockResponse);
+
+      const makePagination = require('../productPagination').default;
+      const pagination = await makePagination(mockSdk);
+
+      // Test with tag containing special characters
+      await pagination.fetchNext('summer-collection');
+
+      // Verify the query handles tag search properly
+      expect(mockClient.request).toHaveBeenCalledWith(
+        expect.stringContaining('query getProducts'),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            query:
+              'title:* summer-collection* OR sku:* summer-collection* OR sku:"summer-collection" OR title:"summer-collection" OR tag:* summer-collection* OR tag:"summer-collection"',
+          }),
+        })
+      );
+    });
+
+    it('should handle tag-based search with spaces', async () => {
+      const mockResponse = {
+        data: {
+          products: {
+            edges: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+      mockClient.request.mockResolvedValue(mockResponse);
+
+      const makePagination = require('../productPagination').default;
+      const pagination = await makePagination(mockSdk);
+
+      // Test with tag containing spaces
+      await pagination.fetchNext('summer sale');
+
+      // Verify the query handles tag search with spaces properly
+      expect(mockClient.request).toHaveBeenCalledWith(
+        expect.stringContaining('query getProducts'),
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            query: 'title:* summer sale* OR sku:* summer sale* OR sku:"summer sale" OR title:"summer sale" OR tag:* summer sale* OR tag:"summer sale"',
           }),
         })
       );

--- a/apps/shopify/src/productPagination.js
+++ b/apps/shopify/src/productPagination.js
@@ -15,6 +15,8 @@ const makePagination = async (sdk) => {
           `sku:* ${search}*`, // partial SKU match with space
           `sku:"${search}"`, // exact SKU phrase match
           `title:"${search}"`, // exact title phrase match
+          `tag:* ${search}*`, // partial tag match with space
+          `tag:"${search}"`, // exact tag phrase match
         ];
         queryStr = searches.join(' OR ');
       }

--- a/apps/shopify/src/productVariantPagination.js
+++ b/apps/shopify/src/productVariantPagination.js
@@ -95,6 +95,8 @@ class Pagination {
         `sku:* ${search}*`, // partial SKU match with space
         `sku:"${search}"`, // exact SKU phrase match
         `title:"${search}"`, // exact title phrase match
+        `tag:* ${search}*`, // partial tag match with space
+        `tag:"${search}"`, // exact tag phrase match
       ];
       queryStr = searches.join(' OR ');
     }
@@ -208,6 +210,8 @@ class Pagination {
         `sku:* ${search}*`, // partial SKU match with space
         `sku:"${search}"`, // exact SKU phrase match
         `title:"${search}"`, // exact title phrase match
+        `tag:* ${search}*`, // partial tag match with space
+        `tag:"${search}"`, // exact tag phrase match
       ];
       queryStr = searches.join(' OR ');
     }


### PR DESCRIPTION
## Purpose

After updating Shopify app to replace the Buy SDK with the Storefront, customers reported issues searching by SKU and product variants. A fix was deployed for that which restored critical functionality. One of the customers reported that searching by tags was still not working as expected, so I applied the same fix for tags as we did for the sku and product title searches. 