### PR TITLE
chore: increase line width in yaml linter config [INTEG-2829]

### DIFF
--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -14,6 +14,7 @@ jobs:
         uses: karancode/yamllint-github-action@master
         with:
           yamllint_file_or_dir: '.github/workflows/*.yml'
+          yamllint_config_filepath: '.yamllint.yaml'
           yamllint_strict: false
           yamllint_comment: true
         env:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
## Purpose

Changes
- Increase allowed line width in workflow yaml files from 80 to 120 characters
- Throw warnings instead of errors when a workflow has lines wider than 120 characters

I was seeing errors like this in workflow actions ([for example](https://github.com/contentful/marketplace-partner-apps/actions/runs/15857675575/job/44706920017?pr=5236)):
```
lint: error: failed yamllint on .github/workflows/*.yml.

.github/workflows/dependabot-approve-and-request-merge.yml
  Error: 22:81 [line-length] line too long (97 > 80 characters)
  Error: 25:81 [line-length] line too long (82 > 80 characters)
  Error: 31:81 [line-length] line too long (97 > 80 characters)
  Error: 41:81 [line-length] line too long (100 > 80 characters)
  Error: 44:81 [line-length] line too long (97 > 80 characters)
  Error: 59:81 [line-length] line too long (112 > 80 characters)
  Error: 64:81 [line-length] line too long (114 > 80 characters)
  Error: 77:81 [line-length] line too long (97 > 80 characters)
  Error: 110:81 [line-length] line too long (97 > 80 characters)
  Error: 113:81 [line-length] line too long (83 > 80 characters)
  Error: 115:81 [line-length] line too long (88 > 80 characters)
  Error: 117:81 [line-length] line too long (105 > 80 characters)
```
