### PR TITLE
Deep clone: config screen [INTEG-2830]

### DIFF
--- a/apps/deep-clone-main/package-lock.json
+++ b/apps/deep-clone-main/package-lock.json
@@ -12,7 +12,10 @@
         "@contentful/app-components": "file:../../packages/contentful-app-components",
         "@contentful/app-sdk": "^4.29.7",
         "@contentful/f36-components": "4.80.5",
+        "@contentful/f36-multiselect": "^4.81.0",
         "@contentful/react-apps-toolkit": "1.2.16",
+        "@emotion/css": "^11.13.5",
+        "@testing-library/user-event": "^14.6.1",
         "contentful-management": "11.54.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -344,13 +347,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -466,16 +466,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-accordion/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-asset": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.80.5.tgz",
@@ -492,16 +482,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-asset/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
@@ -527,16 +507,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-autocomplete/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-avatar": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.80.5.tgz",
@@ -555,16 +525,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-avatar/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-badge": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.80.5.tgz",
@@ -581,42 +541,22 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-badge/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-button": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.80.5.tgz",
-      "integrity": "sha512-s9OzWbIqVa6+wEhrIGac/dlnwqobi/I4P7LppCVMk2UM2zCPE8g9TxgyCAKxcBJWVLeMUrChzoDk1NTKgv7qfw==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.81.0.tgz",
+      "integrity": "sha512-LJ5+TjpHixGV1wPP0OXsInGad3Wv5n64SrfJIfEXNHoesw877LH7FRF6A3lPOQ+jBDjO/FJRJJOhOdYNW/OPgQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
-        "@contentful/f36-spinner": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
+        "@contentful/f36-spinner": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.80.5",
+        "@contentful/f36-tooltip": "^4.81.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-button/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-card": {
@@ -645,16 +585,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-card/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-collapse": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.80.5.tgz",
@@ -668,16 +598,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-collapse/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-components": {
@@ -758,20 +678,10 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-copybutton/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-core": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.80.5.tgz",
-      "integrity": "sha512-obtfunEH5mpgFCIZdJaSZibh8ZmI00DWAOBBtl/fYyp/jZNoiOpF8pCT/kfVkAVejMQI8f/v8RwtK+fX9zUsLA==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.81.0.tgz",
+      "integrity": "sha512-NVay2xYmxg30fRnV15oD9Szfi7VGO0M+9FCfimGXqC2/50yjJJ/rsswgzsAtamY6GO5oiLYJO+7eM4XqOF5gJw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.2.0",
@@ -783,16 +693,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-core/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-datepicker": {
@@ -818,16 +718,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-datepicker/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-datetime": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.80.5.tgz",
@@ -842,16 +732,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-datetime/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
@@ -871,16 +751,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-drag-handle/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-empty-state": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.80.5.tgz",
@@ -894,16 +764,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-empty-state/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-entity-list": {
@@ -929,42 +789,22 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-entity-list/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.80.5.tgz",
-      "integrity": "sha512-ppZ11MtmAW4xYl7eTjFx621PByytZcM/UwLUa3Ehgnkk9ca0Oito8/JInmjRLo/BZ3KfKMQCOTlrY+qsvBRqwA==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.81.0.tgz",
+      "integrity": "sha512-I9u81MrgeG+Q2CIQmhPjIQQijTBs9cNrT1yOu7kgeD0daZEvBO29CHJjMFHxJeVv5whfsStqp+Noe+MydiUfNA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-icons": "^4.29.1",
         "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.80.5",
+        "@contentful/f36-typography": "^4.81.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-forms/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-header": {
@@ -985,16 +825,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-header/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-icon": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.80.5.tgz",
@@ -1008,16 +838,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-icons": {
@@ -1036,16 +856,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-image": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.80.5.tgz",
@@ -1062,16 +872,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-image/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-list": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.80.5.tgz",
@@ -1085,16 +885,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-list/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-menu": {
@@ -1114,16 +904,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-menu/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-modal": {
@@ -1146,14 +926,29 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-modal/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+    "node_modules/@contentful/f36-multiselect": {
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.81.0.tgz",
+      "integrity": "sha512-PQosCAtjKWCrzEfueX4dcPEgF6SrKWcMcy6pczdsMGkBp7Wx7ZJ8Mt360kN2N0rUmcAE6SBFYe9ykil0RzDGkQ==",
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
+        "@babel/runtime": "^7.27.1",
+        "@contentful/f36-button": "^4.81.0",
+        "@contentful/f36-core": "^4.81.0",
+        "@contentful/f36-forms": "^4.81.0",
+        "@contentful/f36-icons": "^4.20.8",
+        "@contentful/f36-popover": "^4.81.0",
+        "@contentful/f36-skeleton": "^4.81.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.81.0",
+        "@contentful/f36-typography": "^4.81.0",
+        "@contentful/f36-utils": "^4.20.8",
+        "emotion": "^10.0.17",
+        "react-focus-lock": "^2.9.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-navbar": {
@@ -1177,16 +972,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-navbar/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-note": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.80.5.tgz",
@@ -1204,16 +989,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-note/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-notification": {
@@ -1236,16 +1011,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-notification/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-pagination": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.80.5.tgz",
@@ -1263,16 +1028,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-pagination/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-pill": {
@@ -1294,23 +1049,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-pill/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.80.5.tgz",
-      "integrity": "sha512-oOodBeyB4bs64jWV4GOqmzwNawUghqfJMR6IMiEsGlnuD7kksPAjt4rhdnVGE7KxraUjal9Wa21p5xUkAnglnw==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.81.0.tgz",
+      "integrity": "sha512-NN8HeRQYWAF1Ra/LR6HmaEoIRa/2B/vJYUske+yOsR5b4BMe6wrZhlRVCPbOrKv2RhK9IAyZUpDYWmRGf6sl0g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1322,49 +1067,29 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-popover/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.80.5.tgz",
-      "integrity": "sha512-NJCXonyDecgxAluUZAwuQi0VKNUOjyrRW7gMp3ZB41uTOg0tpUd7oVQBxDJVR0yr633OVobOPr9dsOb5b2hWQQ==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.81.0.tgz",
+      "integrity": "sha512-L5xgE38koX47fffnM24a7YRs1MsYFm3LtUZyOQ/P5nyPeQtA9jLp7yNbHHWpX14ykFgIen6vQQkDffNGko45BA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
-        "@contentful/f36-table": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
+        "@contentful/f36-table": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-skeleton/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.80.5.tgz",
-      "integrity": "sha512-dyD+/DJQf/nL/Fk7Ba4HVAXXIG6B8gyu6FWaMDBo8U2c4USC+GqvS7UMeQm21PcNqewy+Yf2m/J/SZX+1LHULg==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.81.0.tgz",
+      "integrity": "sha512-Z6jsevuGFG/Oo+3qPTRv5QI9WdhlJ3dGlNFgthWdSp2pZxP/cAlBHAxI3hBk7c6/IQMrymY5ATDEd0qYHp8X5A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
         "emotion": "^10.0.17"
       },
@@ -1373,42 +1098,22 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-spinner/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-table": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.80.5.tgz",
-      "integrity": "sha512-ZAyxPq1H46VfT5oggtVQ9Xpk2SnGNB8vxuTVC/gWR+mXGyT39Zehypd5N3f/pwDjlX0Jb+Ki0Vd82CIeTWqdWg==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.81.0.tgz",
+      "integrity": "sha512-9s7Bwd4U2V7rI+XAUMSVmgjaSyj+Q/GGWoeKN1xvZbns8w1qiGBpYxGO/R5Nq+VAXH6L5GCGAbrmYfO6lmvzgg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-icons": "^4.29.1",
         "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.80.5",
+        "@contentful/f36-typography": "^4.81.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-table/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-tabs": {
@@ -1427,16 +1132,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-tabs/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-text-link": {
       "version": "4.80.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.80.5.tgz",
@@ -1452,16 +1147,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-text-link/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-tokens": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
@@ -1469,12 +1154,12 @@
       "license": "MIT"
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.80.5.tgz",
-      "integrity": "sha512-Z0xqko7UiV1tnWutqKBmYmJuFzKNoUX/41voLBh9Ge8O0gMHkmQkxVvvcCdOYyP1PQyc5/I6uXGuPBLAfuKBxQ==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.81.0.tgz",
+      "integrity": "sha512-Rdc1c5MNDTv0Nw/fc5MrJ810Md0vz3+xdNKd9t37n/bgCuHPdVkLa5EkRRNpNIohjIzdrnSFd+0lW008G501rA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1487,23 +1172,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-tooltip/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.80.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.80.5.tgz",
-      "integrity": "sha512-4rpTgyoNTi+mQQY1XsIQLNERHBonyR71ZhN+8iFYStZDf03qG9sJCOsSWOfXr4eqkpgmeLybKjnPkIBrHGJQZA==",
+      "version": "4.81.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.81.0.tgz",
+      "integrity": "sha512-b1zfdIfMtGdcMsZMyzFAZB2twajqc5B2juVzh81fTs9DE5IR9Ursf3X6olSzOZzqycB8neqda90HFRT2dhl58A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.5",
+        "@contentful/f36-core": "^4.81.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -1511,16 +1186,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-typography/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/f36-utils": {
@@ -1534,16 +1199,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-utils/node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
       }
     },
     "node_modules/@contentful/react-apps-toolkit": {
@@ -1683,6 +1338,108 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -1712,7 +1469,7 @@
         "react": ">=16.3.0"
       }
     },
-    "node_modules/@emotion/css": {
+    "node_modules/@emotion/core/node_modules/@emotion/css": {
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
       "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
@@ -1722,6 +1479,75 @@
         "@emotion/utils": "0.11.3",
         "babel-plugin-emotion": "^10.0.27"
       }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
@@ -3265,7 +3091,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3285,7 +3110,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -3361,11 +3185,23 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3983,7 +3819,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3993,7 +3828,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4516,7 +4350,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4606,7 +4439,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4619,7 +4451,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5014,7 +4845,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5043,7 +4873,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dotenv": {
@@ -5105,6 +4934,16 @@
       "integrity": "sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -5940,14 +5779,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -6281,7 +6121,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7342,7 +7181,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -8043,7 +7881,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -8058,7 +7895,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8342,12 +8178,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -9106,11 +8936,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/apps/deep-clone-main/package.json
+++ b/apps/deep-clone-main/package.json
@@ -7,7 +7,10 @@
     "@contentful/app-components": "file:../../packages/contentful-app-components",
     "@contentful/app-sdk": "^4.29.7",
     "@contentful/f36-components": "4.80.5",
+    "@contentful/f36-multiselect": "^4.81.0",
     "@contentful/react-apps-toolkit": "1.2.16",
+    "@emotion/css": "^11.13.5",
+    "@testing-library/user-event": "^14.6.1",
     "contentful-management": "11.54.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/apps/deep-clone-main/src/components/ContentTypeMultiSelect.tsx
+++ b/apps/deep-clone-main/src/components/ContentTypeMultiSelect.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Stack, Pill } from '@contentful/f36-components';
+import { Multiselect } from '@contentful/f36-multiselect';
+import { ContentTypeProps } from 'contentful-management';
+import { CMAClient, ConfigAppSDK } from '@contentful/app-sdk';
+
+export interface ContentType {
+  id: string;
+  name: string;
+}
+
+interface ContentTypeMultiSelectProps {
+  selectedContentTypes: ContentType[];
+  setSelectedContentTypes: (contentTypes: ContentType[]) => void;
+  sdk: ConfigAppSDK;
+  cma: CMAClient;
+}
+
+const ContentTypeMultiSelect: React.FC<ContentTypeMultiSelectProps> = ({ selectedContentTypes, setSelectedContentTypes, sdk, cma }) => {
+  const [availableContentTypes, setAvailableContentTypes] = useState<ContentType[]>([]);
+  const getPlaceholderText = (): string => {
+    if (selectedContentTypes.length === 0) return 'Select one or more';
+    if (selectedContentTypes.length === 1) return selectedContentTypes[0]?.name || '';
+    return `${selectedContentTypes[0]?.name || ''} and ${selectedContentTypes.length - 1} more`;
+  };
+  const [filteredItems, setFilteredItems] = React.useState<ContentType[]>([]);
+
+  const handleSearchValueChange = (event: { target: { value: any } }) => {
+    const value = event.target.value;
+    const newFilteredItems = availableContentTypes.filter((contentType) => contentType.name.toLowerCase().includes(value.toLowerCase()));
+    setFilteredItems(newFilteredItems);
+  };
+
+  const fetchAllContentTypes = async (): Promise<ContentTypeProps[]> => {
+    let allContentTypes: ContentTypeProps[] = [];
+    let skip = 0;
+    const limit = 1000;
+    let areMoreContentTypes = true;
+
+    while (areMoreContentTypes) {
+      const response = await cma.contentType.getMany({
+        spaceId: sdk.ids.space,
+        environmentId: sdk.ids.environment,
+        query: { skip, limit },
+      });
+      if (response.items) {
+        allContentTypes = allContentTypes.concat(response.items as ContentTypeProps[]);
+        areMoreContentTypes = response.items.length === limit;
+      } else {
+        areMoreContentTypes = false;
+      }
+      skip += limit;
+    }
+
+    return allContentTypes;
+  };
+
+  useEffect(() => {
+    (async () => {
+      const currentState = await sdk.app.getCurrentState();
+      const currentContentTypesIds = Object.keys(currentState?.EditorInterface || {});
+
+      const allContentTypes = await fetchAllContentTypes();
+
+      const newAvailableContentTypes = allContentTypes
+        .map((ct) => ({
+          id: ct.sys.id,
+          name: ct.name,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      setAvailableContentTypes(newAvailableContentTypes);
+      setFilteredItems(newAvailableContentTypes);
+
+      // If we have current content types, set them as selected
+      if (currentContentTypesIds.length > 0) {
+        const currentContentTypes = allContentTypes.filter((ct) => currentContentTypesIds.includes(ct.sys.id)).map((ct) => ({ id: ct.sys.id, name: ct.name }));
+        setSelectedContentTypes(currentContentTypes);
+      }
+    })();
+  }, []);
+
+  return (
+    <>
+      <Stack marginTop="spacingXs" flexDirection="column" alignItems="start">
+        <Multiselect
+          searchProps={{
+            searchPlaceholder: 'Search content types',
+            onSearchValueChange: handleSearchValueChange,
+          }}
+          placeholder={getPlaceholderText()}>
+          {filteredItems.map((item) => (
+            <Multiselect.Option
+              key={item.id}
+              value={item.id}
+              itemId={item.id}
+              isChecked={selectedContentTypes.some((ct) => ct.id === item.id)}
+              onSelectItem={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const checked = e.target.checked;
+                if (checked) {
+                  setSelectedContentTypes([...selectedContentTypes, item]);
+                } else {
+                  setSelectedContentTypes(selectedContentTypes.filter((ct) => ct.id !== item.id));
+                }
+              }}>
+              {item.name}
+            </Multiselect.Option>
+          ))}
+        </Multiselect>
+
+        {selectedContentTypes.length > 0 && (
+          <Box width="full" overflow="auto">
+            <Stack flexDirection="row" spacing="spacing2Xs" flexWrap="wrap">
+              {selectedContentTypes.map((contentType, index) => (
+                <Pill
+                  key={index}
+                  label={contentType.name}
+                  isDraggable={false}
+                  onClose={() => setSelectedContentTypes(selectedContentTypes.filter((ct) => ct.id !== contentType.id))}
+                />
+              ))}
+            </Stack>
+          </Box>
+        )}
+      </Stack>
+    </>
+  );
+};
+
+export default ContentTypeMultiSelect;

--- a/apps/deep-clone-main/src/locations/ConfigScreen.styles.ts
+++ b/apps/deep-clone-main/src/locations/ConfigScreen.styles.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/css';
+
+export const styles = {
+  textInputLabel: css({
+    fontWeight: 'fontWeightMedium',
+  }),
+};

--- a/apps/deep-clone-main/test/locations/ConfigScreen.spec.tsx
+++ b/apps/deep-clone-main/test/locations/ConfigScreen.spec.tsx
@@ -1,21 +1,63 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import ConfigScreen from '../../src/locations/ConfigScreen';
-import { render } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { mockCma, mockSdk } from '../mocks';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));
 
+vi.mock('../../src/components/ContentTypeMultiSelect', () => ({
+  default: () => {
+    return <div>Content type selector mock</div>;
+  },
+}));
+
+async function saveAppInstallation() {
+  return await mockSdk.app.onConfigure.mock.calls.at(-1)?.[0]?.();
+}
+
 describe('Config Screen component', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
   it('Component text exists', async () => {
-    const { getByText } = render(<ConfigScreen />);
+    render(<ConfigScreen />);
+    expect(await screen.findByRole('heading', { name: /Set up Deep Clone/i })).toBeTruthy();
+    expect(await screen.findByText(/Assign content types/i)).toBeTruthy();
+    expect(await screen.findByText(/Naming/i)).toBeTruthy();
+    expect(await screen.findByText(/Getting started/i)).toBeTruthy();
+  });
 
-    // simulate the user clicking the install button
-    await mockSdk.app.onConfigure.mock.calls[0]?.[0]?.();
+  it('saves with default parameters', async () => {
+    render(<ConfigScreen />);
+    expect(await screen.findByLabelText(/Clone text/i)).toBeTruthy();
 
-    expect(getByText('Clone Text')).toBeDefined();
+    await act(async () => {
+      const result = await saveAppInstallation();
+      expect(result).toEqual({
+        parameters: { cloneText: 'Copy', cloneTextBefore: true, automaticRedirect: true },
+        targetState: { EditorInterface: {} },
+      });
+    });
+  });
+
+  it('shows a toast error if the clone text is not set', async () => {
+    const user = userEvent.setup();
+    render(<ConfigScreen />);
+    expect(await screen.findByLabelText(/Clone text/i)).toBeTruthy();
+
+    const input = screen.getByLabelText(/Clone text/i);
+    user.clear(input);
+    await act(async () => {
+      await saveAppInstallation();
+    });
+
+    expect(mockSdk.notifier.error).toHaveBeenCalledWith('The app configuration was not saved. Please try again.');
   });
 });

--- a/apps/deep-clone-main/test/mocks/mockCma.ts
+++ b/apps/deep-clone-main/test/mocks/mockCma.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 const mockCma = {
   contentType: {
     get: vi.fn(),
+    getMany: vi.fn(),
   },
   entry: {
     get: vi.fn(),

--- a/apps/deep-clone-main/test/mocks/mockSdk.ts
+++ b/apps/deep-clone-main/test/mocks/mockSdk.ts
@@ -1,10 +1,13 @@
 import { vi } from 'vitest';
+import { mockCma } from './mockCma';
 
 const mockSdk = {
+  cma: mockCma,
   app: {
     onConfigure: vi.fn(),
     getParameters: vi.fn().mockReturnValue({}),
     setReady: vi.fn(),
+    getCurrentState: vi.fn(),
   },
   ids: {
     entry: 'test-entry',
@@ -21,6 +24,7 @@ const mockSdk = {
   },
   notifier: {
     success: vi.fn(),
+    error: vi.fn(),
   },
   navigator: {
     openEntry: vi.fn(),


### PR DESCRIPTION
## Purpose

Adjust the deep clone config screen

## Approach

Applied the styles from the design.
Right now for selecting content types I'm adding a component that handles that. In a future PR I'll replace it with the one in the packages folder.

## Testing steps

Install the app, try different configurations and clone an entry.

<img width="1461" height="730" alt="image" src="https://github.com/user-attachments/assets/45d6dd17-1b01-494e-9bf2-605555bfa5e8" />