### PR TITLE
feat: Transifex  app handle environment alias [INTEG-001]

### DIFF
--- a/apps/transifex/src/locations/ConfigScreen.jsx
+++ b/apps/transifex/src/locations/ConfigScreen.jsx
@@ -118,7 +118,7 @@ function ConfigScreen() {
     {
       type: 'plain',
       defaults: {
-        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
+        environmentId: sdk.ids.environment,
         spaceId: sdk.ids.space,
       },
     },

--- a/apps/transifex/src/locations/Sidebar.jsx
+++ b/apps/transifex/src/locations/Sidebar.jsx
@@ -43,7 +43,7 @@ function Sidebar() {
     {
       type: 'plain',
       defaults: {
-        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
+        environmentId: sdk.ids.environment,
         spaceId: sdk.ids.space,
       },
     },


### PR DESCRIPTION
## Purpose

To be consistent with transifex contentfull standalone app, use everywhere the actual environment id instead of environment alias

## Approach
When initializing the CMA client, ensure the actual environment.id is used instead of the alias.

## Testing steps

The installation of contentful native app should work as expected

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
