### PR TITLE
fix: statsig emotion library updates []

### DIFF
--- a/apps/statsig/package-lock.json
+++ b/apps/statsig/package-lock.json
@@ -13,8 +13,8 @@
         "@contentful/f36-tokens": "4.2.0",
         "@contentful/field-editor-reference": "^6.10.1",
         "@contentful/react-apps-toolkit": "1.2.16",
+        "@emotion/css": "^11.11.2",
         "contentful-management": "11.54.4",
-        "emotion": "11.0.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-scripts": "5.0.1"
@@ -3768,6 +3768,87 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -3797,7 +3878,7 @@
         "react": ">=16.3.0"
       }
     },
-    "node_modules/@emotion/css": {
+    "node_modules/@emotion/core/node_modules/@emotion/css": {
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
       "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
@@ -3807,6 +3888,75 @@
         "@emotion/utils": "0.11.3",
         "babel-plugin-emotion": "^10.0.27"
       }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
@@ -10456,12 +10606,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/emotion": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-11.0.0.tgz",
-      "integrity": "sha512-QW3CRqic3aRw1OBOcnvxaHEpCmxtlGwZ5tM9dV5rY3Rn+F41E8EgTPOqJ5VfsqQ5ZXHDs2zSDyUwGI0ZfC2+5A==",
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -21164,6 +21308,12 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/apps/statsig/package.json
+++ b/apps/statsig/package.json
@@ -9,7 +9,7 @@
     "@contentful/field-editor-reference": "^6.10.1",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "11.54.4",
-    "emotion": "11.0.0",
+    "@emotion/css": "^11.11.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-scripts": "5.0.1"

--- a/apps/statsig/src/components/field-editor-reference/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
+++ b/apps/statsig/src/components/field-editor-reference/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import React from 'react';
 
 import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
 
 import { Button } from '@contentful/f36-components';
 import { ContentType } from '../../types';
 import { CreateEntryMenuTrigger } from './CreateEntryMenuTrigger';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import get from 'lodash/get';
 import tokens from '@contentful/f36-tokens';
 
@@ -54,13 +54,7 @@ export const CreateEntryLinkButton = ({
 }: CreateEntryLinkButtonProps) => {
   contentTypes = contentTypes.sort((a, b) => a.name.localeCompare(b.name));
   const suggestedContentType = contentTypes.find((ct) => ct.sys.id === suggestedContentTypeId);
-  const buttonText =
-    text ||
-    `Add ${get(
-      suggestedContentType || (contentTypes.length === 1 ? contentTypes[0] : {}),
-      'name',
-      'entry',
-    )}`;
+  const buttonText = text || `Add ${get(suggestedContentType || (contentTypes.length === 1 ? contentTypes[0] : {}), 'name', 'entry')}`;
   const hasDropdown = contentTypes.length > 1 || customDropdownItems;
 
   // TODO: Introduce `icon: string` and remove `hasPlusIcon` or remove "Plus" if we keep new layout.
@@ -77,8 +71,7 @@ export const CreateEntryLinkButton = ({
       onSelect={onSelect}
       testId={testId}
       dropdownSettings={dropdownSettings}
-      customDropdownItems={customDropdownItems}
-    >
+      customDropdownItems={customDropdownItems}>
       {({ isSelecting }) => (
         <Button
           endIcon={hasDropdown ? <ChevronDownIcon /> : undefined}
@@ -88,8 +81,7 @@ export const CreateEntryLinkButton = ({
           startIcon={isSelecting ? undefined : plusIcon}
           size="small"
           testId="create-entry-link-button"
-          isLoading={isSelecting}
-        >
+          isLoading={isSelecting}>
           {buttonText}
         </Button>
       )}

--- a/apps/statsig/src/components/field-editor-reference/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
+++ b/apps/statsig/src/components/field-editor-reference/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
@@ -5,7 +5,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { TextInput } from '@contentful/f36-components';
 import { SearchIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import get from 'lodash/get';
 
 import { ContentType } from '../../types';
@@ -52,14 +52,8 @@ type CreateEntryMenuTriggerChildProps = {
   isOpen: boolean;
   isSelecting: boolean;
 };
-export type CreateEntryMenuTriggerChild = (
-  props: CreateEntryMenuTriggerChildProps,
-) => React.ReactElement;
-export type CreateCustomEntryMenuItems = ({
-  closeMenu,
-}: {
-  closeMenu: () => void;
-}) => React.ReactElement;
+export type CreateEntryMenuTriggerChild = (props: CreateEntryMenuTriggerChildProps) => React.ReactElement;
+export type CreateCustomEntryMenuItems = ({ closeMenu }: { closeMenu: () => void }) => React.ReactElement;
 
 interface ICreateEntryMenuTrigger {
   contentTypes: ContentType[];
@@ -133,7 +127,7 @@ export const CreateEntryMenuTrigger = ({
       res
         .then(
           () => setSelecting(false),
-          () => setSelecting(false),
+          () => setSelecting(false)
         )
         .catch(console.error);
     }
@@ -163,10 +157,7 @@ export const CreateEntryMenuTrigger = ({
   const isSearchable = contentTypes.length > MAX_ITEMS_WITHOUT_SEARCH;
   const maxDropdownHeight = suggestedContentTypeId ? 300 : 250;
   const suggestedContentType = contentTypes.find((ct) => ct.sys.id === suggestedContentTypeId);
-  const filteredContentTypes = contentTypes.filter(
-    (ct) =>
-      !searchInput || get(ct, 'name', 'Untitled').toLowerCase().includes(searchInput.toLowerCase()),
-  );
+  const filteredContentTypes = contentTypes.filter((ct) => !searchInput || get(ct, 'name', 'Untitled').toLowerCase().includes(searchInput.toLowerCase()));
 
   return (
     <span className={styles.wrapper} ref={wrapper} data-test-id={testId}>
@@ -176,8 +167,7 @@ export const CreateEntryMenuTrigger = ({
         isOpen={isOpen}
         onClose={closeMenu}
         onOpen={handleMenuOpen}
-        {...menuProps}
-      >
+        {...menuProps}>
         <Menu.Trigger>{children({ isOpen, isSelecting })}</Menu.Trigger>
 
         {isOpen && (
@@ -189,8 +179,7 @@ export const CreateEntryMenuTrigger = ({
               maxHeight: `${maxDropdownHeight}px`,
             }}
             ref={menuListRef}
-            testId="add-entry-menu"
-          >
+            testId="add-entry-menu">
             {Boolean(customDropdownItems) && (
               <>
                 {customDropdownItems}
@@ -227,11 +216,7 @@ export const CreateEntryMenuTrigger = ({
             {!searchInput && <Menu.SectionTitle>{contentTypesLabel}</Menu.SectionTitle>}
             {filteredContentTypes.length ? (
               filteredContentTypes.map((contentType, i) => (
-                <Menu.Item
-                  testId="contentType"
-                  key={`${get(contentType, 'name')}-${i}`}
-                  onClick={() => handleSelect(contentType)}
-                >
+                <Menu.Item testId="contentType" key={`${get(contentType, 'name')}-${i}`} onClick={() => handleSelect(contentType)}>
                   {get(contentType, 'name', 'Untitled')}
                 </Menu.Item>
               ))

--- a/apps/statsig/src/components/field-editor-reference/components/LinkActions/redesignStyles.ts
+++ b/apps/statsig/src/components/field-editor-reference/components/LinkActions/redesignStyles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const container = css({
   display: 'flex',

--- a/apps/statsig/src/components/field-editor-reference/components/LinkActions/styles.ts
+++ b/apps/statsig/src/components/field-editor-reference/components/LinkActions/styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const container = css({
   display: 'flex',

--- a/apps/statsig/src/components/field-editor-reference/components/MissingAssetCard/styles.ts
+++ b/apps/statsig/src/components/field-editor-reference/components/MissingAssetCard/styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const card = css({
   position: 'relative',

--- a/apps/statsig/src/components/field-editor-reference/components/SpaceName/SpaceName.tsx
+++ b/apps/statsig/src/components/field-editor-reference/components/SpaceName/SpaceName.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Flex, Text, Tooltip } from '@contentful/f36-components';
 import { FolderOpenTrimmedIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 interface SourceProps {
   spaceName: string;

--- a/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.styles.ts
+++ b/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const getMenuDividerStyles = () =>
   css({

--- a/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
+import * as emotion from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
-import { cx } from 'emotion';
 
 import { getMenuDividerStyles } from './MenuDivider.styles';
+
+const { cx } = emotion;
 
 export type MenuDividerProps = PropsWithHTMLElement<CommonProps, 'hr'>;
 
@@ -12,12 +14,5 @@ export const MenuDivider = (props: ExpandProps<MenuDividerProps>) => {
 
   const styles = getMenuDividerStyles();
 
-  return (
-    <hr
-      aria-orientation="horizontal"
-      data-test-id={testId}
-      className={cx(styles, className)}
-      {...otherProps}
-    />
-  );
+  return <hr aria-orientation="horizontal" data-test-id={testId} className={cx(styles, className)} {...otherProps} />;
 };

--- a/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 
 import { getMenuDividerStyles } from './MenuDivider.styles';
-
-const { cx } = emotion;
 
 export type MenuDividerProps = PropsWithHTMLElement<CommonProps, 'hr'>;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuDivider/MenuDivider.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 
 import * as emotion from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';

--- a/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.styles.ts
+++ b/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.styles.ts
@@ -1,9 +1,10 @@
 import tokens from '@contentful/f36-tokens';
-import { css, ObjectInterpolation } from 'emotion';
+import { css } from '@emotion/css';
 
 import type { MenuItemProps } from './MenuItem';
 
-const activeStyle: ObjectInterpolation<undefined> = {
+// Note: ObjectInterpolation may need to be replaced with a generic object type in Emotion 11
+const activeStyle: Record<string, any> = {
   backgroundColor: tokens.gray200,
   fontWeight: tokens.fontWeightMedium,
   '&:hover': {
@@ -11,7 +12,7 @@ const activeStyle: ObjectInterpolation<undefined> = {
   },
 };
 
-const disabledStyle: ObjectInterpolation<undefined> = {
+const disabledStyle: Record<string, any> = {
   opacity: 0.5,
   cursor: 'auto',
   '&:hover': {
@@ -19,13 +20,7 @@ const disabledStyle: ObjectInterpolation<undefined> = {
   },
 };
 
-export const getMenuItemStyles = ({
-  isActive,
-  isDisabled,
-}: {
-  isActive: MenuItemProps['isActive'];
-  isDisabled: MenuItemProps['isDisabled'];
-}) => {
+export const getMenuItemStyles = ({ isActive, isDisabled }: { isActive: MenuItemProps['isActive']; isDisabled: MenuItemProps['isDisabled'] }) => {
   return {
     root: css(
       [
@@ -77,7 +72,7 @@ export const getMenuItemStyles = ({
         },
       ],
       isActive && activeStyle,
-      isDisabled && disabledStyle,
+      isDisabled && disabledStyle
     ),
   };
 };

--- a/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.tsx
@@ -1,17 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 
-import {
-  CommonProps,
-  ExpandProps,
-  mergeRefs,
-  PolymorphicComponent,
-  PolymorphicProps,
-  useId,
-} from '@contentful/f36-core';
-import { cx } from 'emotion';
-
+import { CommonProps, ExpandProps, mergeRefs, PolymorphicComponent, PolymorphicProps, useId } from '@contentful/f36-core';
+import * as emotion from '@emotion/css';
 import { useMenuContext } from '../MenuContext';
 import { getMenuItemStyles } from './MenuItem.styles';
+
+const { cx } = emotion;
 
 const MENU_ITEM_DEFAULT_TAG = 'button';
 
@@ -37,23 +31,10 @@ interface MenuItemInternalProps extends CommonProps {
   icon?: React.ReactElement;
 }
 
-export type MenuItemProps<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG> =
-  PolymorphicProps<MenuItemInternalProps, E>;
+export type MenuItemProps<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG> = PolymorphicProps<MenuItemInternalProps, E>;
 
-function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
-  props: MenuItemProps<E>,
-  ref: React.Ref<any>,
-) {
-  const {
-    testId,
-    className,
-    as,
-    isActive = false,
-    isDisabled,
-    isInitiallyFocused,
-    icon,
-    ...otherProps
-  } = props;
+function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(props: MenuItemProps<E>, ref: React.Ref<any>) {
+  const { testId, className, as, isActive = false, isDisabled, isInitiallyFocused, icon, ...otherProps } = props;
 
   const id = useId(undefined, 'menu-item');
   const itemTestId = testId || `cf-ui-${id}`;
@@ -79,8 +60,7 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
       className={cx(styles.root, className)}
       data-test-id={itemTestId}
       ref={mergeRefs(itemRef, ref)}
-      tabIndex={-1}
-    >
+      tabIndex={-1}>
       {icon}
       {props.children}
     </Element>
@@ -89,7 +69,4 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
 
 _MenuItem.displayName = 'MenuItem';
 
-export const MenuItem: PolymorphicComponent<
-  ExpandProps<MenuItemInternalProps>,
-  typeof MENU_ITEM_DEFAULT_TAG
-> = React.forwardRef(_MenuItem);
+export const MenuItem: PolymorphicComponent<ExpandProps<MenuItemInternalProps>, typeof MENU_ITEM_DEFAULT_TAG> = React.forwardRef(_MenuItem);

--- a/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuItem/MenuItem.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 
 import { CommonProps, ExpandProps, mergeRefs, PolymorphicComponent, PolymorphicProps, useId } from '@contentful/f36-core';
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import { useMenuContext } from '../MenuContext';
 import { getMenuItemStyles } from './MenuItem.styles';
-
-const { cx } = emotion;
 
 const MENU_ITEM_DEFAULT_TAG = 'button';
 

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.styles.ts
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const getMenuHeaderStyles = () => {
   return css({
@@ -27,10 +27,7 @@ export const getMenuFooterStyles = () => {
   });
 };
 
-export const getMenuListStyles = (props: {
-  hasStickyFooter?: boolean;
-  hasStickyHeader?: boolean;
-}) => ({
+export const getMenuListStyles = (props: { hasStickyFooter?: boolean; hasStickyHeader?: boolean }) => ({
   container: css({
     // To get to our regular border radius for the inner menu items (6px),
     // we need to use 8px on the outer container

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 
 import { useMenuContext } from '../MenuContext';
@@ -9,8 +9,6 @@ import { MenuListFooter } from '../MenuList/MenuListFooter';
 import { MenuListHeader } from '../MenuList/MenuListHeader';
 import { useSubmenuContext } from '../SubmenuContext';
 import { Popover } from '../../forma-36-popover';
-
-const { cx } = emotion;
 
 interface MenuListInternalProps extends CommonProps {
   children?: React.ReactNode;

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import * as emotion from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
-import { cx } from 'emotion';
 
 import { useMenuContext } from '../MenuContext';
 import { getMenuListStyles } from '../MenuList/MenuList.styles';
@@ -9,6 +9,8 @@ import { MenuListFooter } from '../MenuList/MenuListFooter';
 import { MenuListHeader } from '../MenuList/MenuListHeader';
 import { useSubmenuContext } from '../SubmenuContext';
 import { Popover } from '../../forma-36-popover';
+
+const { cx } = emotion;
 
 interface MenuListInternalProps extends CommonProps {
   children?: React.ReactNode;
@@ -51,9 +53,7 @@ const _MenuList = (props: ExpandProps<MenuListProps>, ref: React.Ref<HTMLDivElem
     hasStickyFooter: Boolean(footer),
   });
 
-  const extendedOtherProps = submenuContext
-    ? submenuContext.getSubmenuListProps(otherProps)
-    : otherProps;
+  const extendedOtherProps = submenuContext ? submenuContext.getSubmenuListProps(otherProps) : otherProps;
 
   return (
     <Popover.Content
@@ -61,8 +61,7 @@ const _MenuList = (props: ExpandProps<MenuListProps>, ref: React.Ref<HTMLDivElem
       {...extendedOtherProps}
       {...getMenuListProps(extendedOtherProps, ref)}
       className={cx(styles.container, className)}
-      testId={testId}
-    >
+      testId={testId}>
       {header}
       {items}
       {footer}

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuListFooter.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuListFooter.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import * as emotion from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
-import { cx } from 'emotion';
-
 import { getMenuFooterStyles } from './MenuList.styles';
+
+const { cx } = emotion;
 
 export type MenuListFooterProps = PropsWithHTMLElement<CommonProps, 'div'>;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuListFooter.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuListFooter.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 import { getMenuFooterStyles } from './MenuList.styles';
-
-const { cx } = emotion;
 
 export type MenuListFooterProps = PropsWithHTMLElement<CommonProps, 'div'>;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuListHeader.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuListHeader.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 import { getMenuHeaderStyles } from './MenuList.styles';
-
-const { cx } = emotion;
 
 export type MenuListHeaderProps = PropsWithHTMLElement<CommonProps, 'div'>;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuList/MenuListHeader.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuList/MenuListHeader.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import * as emotion from '@emotion/css';
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
-import { cx } from 'emotion';
-
 import { getMenuHeaderStyles } from './MenuList.styles';
+
+const { cx } = emotion;
 
 export type MenuListHeaderProps = PropsWithHTMLElement<CommonProps, 'div'>;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.styles.ts
+++ b/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const getMenuSectionTitleStyles = () =>
   css({

--- a/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 
 import type { ExpandProps } from '@contentful/f36-core';
 import { Caption, CaptionProps } from '@contentful/f36-typography';
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import { getMenuSectionTitleStyles } from './MenuSectionTitle.styles';
-
-const { cx } = emotion;
 
 export type MenuSectionTitleProps = CaptionProps;
 

--- a/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.tsx
+++ b/apps/statsig/src/components/forma-36-menu/MenuSectionTitle/MenuSectionTitle.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import type { ExpandProps } from '@contentful/f36-core';
 import { Caption, CaptionProps } from '@contentful/f36-typography';
-import { cx } from 'emotion';
-
+import * as emotion from '@emotion/css';
 import { getMenuSectionTitleStyles } from './MenuSectionTitle.styles';
+
+const { cx } = emotion;
 
 export type MenuSectionTitleProps = CaptionProps;
 
@@ -23,8 +24,7 @@ export const MenuSectionTitle = (props: ExpandProps<MenuSectionTitleProps>) => {
       testId={testId}
       className={cx(styles, className)}
       marginBottom="none"
-      {...otherProps}
-    >
+      {...otherProps}>
       {children}
     </Caption>
   );

--- a/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.styles.ts
+++ b/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const getSubmenuTriggerStyles = () => {
   return {

--- a/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
+++ b/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
@@ -1,14 +1,12 @@
 import React, { forwardRef } from 'react';
 
 import { ExpandProps } from '@contentful/f36-core';
-import * as emotion from '@emotion/css';
+import { cx } from '@emotion/css';
 import { ChevronRightIcon } from '@contentful/f36-icons';
 import { MenuItem, MenuItemProps } from '../MenuItem/MenuItem';
 import { MenuTrigger } from '../MenuTrigger/MenuTrigger';
 import { useSubmenuContext } from '../SubmenuContext';
 import { getSubmenuTriggerStyles } from '../SubmenuTrigger/SubmenuTrigger.styles';
-
-const { cx } = emotion;
 
 export type SubmenuTriggerProps = Omit<MenuItemProps<'button'>, 'isInitiallyFocused' | 'as'>;
 

--- a/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
+++ b/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-import type { ExpandProps } from '@contentful/f36-core';
+import { CommonProps } from '@contentful/f36-core';
+import * as emotion from '@emotion/css';
 import { ChevronRightIcon } from '@contentful/f36-icons';
-import { cx } from 'emotion';
+import { getSubmenuTriggerStyles } from '../SubmenuTrigger/SubmenuTrigger.styles';
+
+const { cx } = emotion;
 
 import { MenuItem, MenuItemProps } from '../MenuItem/MenuItem';
 import { MenuTrigger } from '../MenuTrigger/MenuTrigger';
 import { useSubmenuContext } from '../SubmenuContext';
-import { getSubmenuTriggerStyles } from '../SubmenuTrigger/SubmenuTrigger.styles';
 
 export type SubmenuTriggerProps = Omit<MenuItemProps<'button'>, 'isInitiallyFocused' | 'as'>;
 
-const _SubmenuTrigger = (
-  props: ExpandProps<SubmenuTriggerProps>,
-  ref: React.Ref<HTMLButtonElement>,
-) => {
+const _SubmenuTrigger = (props: CommonProps<SubmenuTriggerProps>, ref: React.Ref<HTMLButtonElement>) => {
   const { className, children } = props;
   const { getSubmenuTriggerProps, isOpen } = useSubmenuContext()!;
 
@@ -22,11 +21,7 @@ const _SubmenuTrigger = (
 
   return (
     <MenuTrigger>
-      <MenuItem
-        {...props}
-        {...getSubmenuTriggerProps(props, ref)}
-        className={cx(styles.root({ isActive: isOpen }), className)}
-      >
+      <MenuItem {...props} {...getSubmenuTriggerProps(props, ref)} className={cx(styles.root({ isActive: isOpen }), className)}>
         <span className={styles.content}>{children}</span>
         <ChevronRightIcon className={styles.icon} />
       </MenuItem>
@@ -34,4 +29,4 @@ const _SubmenuTrigger = (
   );
 };
 
-export const SubmenuTrigger = React.forwardRef(_SubmenuTrigger);
+export const SubmenuTrigger = forwardRef(_SubmenuTrigger);

--- a/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
+++ b/apps/statsig/src/components/forma-36-menu/SubmenuTrigger/SubmenuTrigger.tsx
@@ -1,19 +1,18 @@
 import React, { forwardRef } from 'react';
 
-import { CommonProps } from '@contentful/f36-core';
+import { ExpandProps } from '@contentful/f36-core';
 import * as emotion from '@emotion/css';
 import { ChevronRightIcon } from '@contentful/f36-icons';
+import { MenuItem, MenuItemProps } from '../MenuItem/MenuItem';
+import { MenuTrigger } from '../MenuTrigger/MenuTrigger';
+import { useSubmenuContext } from '../SubmenuContext';
 import { getSubmenuTriggerStyles } from '../SubmenuTrigger/SubmenuTrigger.styles';
 
 const { cx } = emotion;
 
-import { MenuItem, MenuItemProps } from '../MenuItem/MenuItem';
-import { MenuTrigger } from '../MenuTrigger/MenuTrigger';
-import { useSubmenuContext } from '../SubmenuContext';
-
 export type SubmenuTriggerProps = Omit<MenuItemProps<'button'>, 'isInitiallyFocused' | 'as'>;
 
-const _SubmenuTrigger = (props: CommonProps<SubmenuTriggerProps>, ref: React.Ref<HTMLButtonElement>) => {
+const _SubmenuTrigger = (props: ExpandProps<SubmenuTriggerProps>, ref: React.Ref<HTMLButtonElement>) => {
   const { className, children } = props;
   const { getSubmenuTriggerProps, isOpen } = useSubmenuContext()!;
 

--- a/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.styles.ts
+++ b/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const getPopoverContentStyles = (isOpen: boolean) => ({
   container: css({

--- a/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
+++ b/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 import { Portal } from '@contentful/f36-utils';

--- a/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
+++ b/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
 import { Portal } from '@contentful/f36-utils';
-import { cx } from 'emotion';
+import * as emotion from '@emotion/css';
 
 import { getPopoverContentStyles } from './PopoverContent.styles';
 import { usePopoverContext } from '../PopoverContext';
+
+const { cx } = emotion;
 
 interface PopoverContentInternalProps extends CommonProps {
   children?: React.ReactNode;
@@ -14,13 +16,7 @@ interface PopoverContentInternalProps extends CommonProps {
 export type PopoverContentProps = PropsWithHTMLElement<PopoverContentInternalProps, 'div'>;
 
 const _PopoverContent = (props: ExpandProps<PopoverContentProps>, ref: any) => {
-  const {
-    children,
-    className,
-    testId = 'cf-ui-popover-content',
-    role = 'dialog',
-    ...otherProps
-  } = props;
+  const { children, className, testId = 'cf-ui-popover-content', role = 'dialog', ...otherProps } = props;
   const { isOpen, renderOnlyWhenOpen, getPopoverProps, usePortal } = usePopoverContext();
 
   const styles = getPopoverContentStyles(isOpen);
@@ -35,8 +31,7 @@ const _PopoverContent = (props: ExpandProps<PopoverContentProps>, ref: any) => {
       role={role}
       // specific attribute to mark that this element is absolute positioned
       // for internal contentful apps usage
-      data-position-absolute
-    >
+      data-position-absolute>
       {children}
     </div>
   );

--- a/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
+++ b/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
-import { Box } from '@contentful/f36-components';
 import { cx } from '@emotion/css';
 import { Portal } from '@contentful/f36-utils';
 import { getPopoverContentStyles } from './PopoverContent.styles';

--- a/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
+++ b/apps/statsig/src/components/forma-36-popover/PopoverContent/PopoverContent.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
 import type { CommonProps, PropsWithHTMLElement, ExpandProps } from '@contentful/f36-core';
+import { Box } from '@contentful/f36-components';
+import { cx } from '@emotion/css';
 import { Portal } from '@contentful/f36-utils';
-import * as emotion from '@emotion/css';
-
 import { getPopoverContentStyles } from './PopoverContent.styles';
 import { usePopoverContext } from '../PopoverContext';
-
-const { cx } = emotion;
 
 interface PopoverContentInternalProps extends CommonProps {
   children?: React.ReactNode;

--- a/apps/statsig/src/locations/EntryEditor/styles.ts
+++ b/apps/statsig/src/locations/EntryEditor/styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const entryEditorStyles = {
   addVariationWrapper: css({


### PR DESCRIPTION
## Purpose

Statsig reported their app won't load, due to dependabot updating their emotion library to version 11. it has breaking changes with how emotion is imported.

I had some difficulties reverting this properly with all of the versioning PRs, other dependabot changes, etc. so I just went ahead and made the updates necessary to support v11. tested on staging and the app is loading now. 
