### PR TITLE
fix: field-editor package version in docs-to-rich-text []

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -246,6 +246,7 @@ updates:
     directory: '/apps/docs-to-rich-text'
     ignore:
       - dependency-name: '@contentful/app-sdk'
+      - dependency-name: '@contentful/field-editor-rich-text'
       - dependency-name: '@types/node'
         versions:
           - '>18.15.3'

--- a/apps/docs-to-rich-text/package-lock.json
+++ b/apps/docs-to-rich-text/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "^4.29.3",
         "@contentful/f36-components": "^4.81.1",
         "@contentful/f36-tokens": "^4.1.0",
-        "@contentful/field-editor-rich-text": "3.30.0",
+        "@contentful/field-editor-rich-text": "3.16.15",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@emotion/css": "^11.13.5",
         "@types/async-lock": "^1.4.2",
@@ -1244,35 +1244,35 @@
       }
     },
     "node_modules/@contentful/field-editor-rich-text": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.30.0.tgz",
-      "integrity": "sha512-PauR+6/X5o21azXaGdfDNRYMsD3eXkIi5DM8QLO33J/NDbd7l2FWLYFLWqo4pFsHZqXUko7scAzy+0ym0Wr9Cw==",
+      "version": "3.16.15",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/field-editor-rich-text/3.16.15/3b04aeabb140de8fe63523029d9c4c0536dc2259",
+      "integrity": "sha512-bMcUbPPMnQUvwAytTJQ7gEK0g9wyrmLzBF5spjpSs/Zl0m681Vwhm5QrSNqPOPfN94nHj+avqTxuRGToniR3+w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-sdk": "^4.29.0",
+        "@contentful/app-sdk": "^4.21.1",
         "@contentful/contentful-slatejs-adapter": "^15.16.5",
-        "@contentful/f36-components": "^4.70.0",
-        "@contentful/f36-icons": "^4.29.0",
-        "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-utils": "^4.24.3",
-        "@contentful/field-editor-reference": "^5.31.2",
-        "@contentful/field-editor-shared": "^1.8.0",
-        "@contentful/rich-text-plain-text-renderer": "^17.0.0",
-        "@contentful/rich-text-types": "^17.0.0",
+        "@contentful/f36-components": "^4.20.6",
+        "@contentful/f36-icons": "^4.1.1",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-utils": "^4.19.0",
+        "@contentful/field-editor-reference": "^5.22.0",
+        "@contentful/field-editor-shared": "^1.4.5",
+        "@contentful/rich-text-plain-text-renderer": "^16.0.4",
+        "@contentful/rich-text-types": "16.3.0",
         "@popperjs/core": "^2.11.5",
-        "@udecode/plate-basic-marks": "36.0.0",
-        "@udecode/plate-break": "36.0.0",
-        "@udecode/plate-common": "36.5.9",
-        "@udecode/plate-core": "36.5.9",
-        "@udecode/plate-list": "36.0.0",
-        "@udecode/plate-paragraph": "36.0.0",
-        "@udecode/plate-reset-node": "36.0.0",
-        "@udecode/plate-select": "36.0.0",
-        "@udecode/plate-serializer-docx": "36.0.10",
-        "@udecode/plate-serializer-html": "36.0.0",
-        "@udecode/plate-table": "36.5.9",
-        "@udecode/plate-trailing-block": "36.0.0",
-        "constate": "^3.3.2",
+        "@udecode/plate-basic-marks": "23.7.0",
+        "@udecode/plate-break": "23.7.0",
+        "@udecode/plate-common": "23.7.0",
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/plate-list": "23.7.0",
+        "@udecode/plate-paragraph": "23.7.0",
+        "@udecode/plate-reset-node": "23.7.0",
+        "@udecode/plate-select": "23.7.0",
+        "@udecode/plate-serializer-docx": "23.7.0",
+        "@udecode/plate-serializer-html": "23.7.0",
+        "@udecode/plate-table": "23.7.0",
+        "@udecode/plate-trailing-block": "23.7.0",
+        "constate": "3.2.0",
         "fast-deep-equal": "^3.1.3",
         "is-hotkey": "^0.2.0",
         "is-plain-obj": "^3.0.0",
@@ -1280,22 +1280,20 @@
         "slate": "0.94.1",
         "slate-history": "0.100.0",
         "slate-hyperscript": "0.77.0",
-        "slate-react": "0.102.0"
+        "slate-react": "0.98.3"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/slate": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
-      "integrity": "sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==",
+    "node_modules/@contentful/field-editor-rich-text/node_modules/constate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/constate/-/constate-3.2.0.tgz",
+      "integrity": "sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==",
       "license": "MIT",
-      "dependencies": {
-        "immer": "^9.0.6",
-        "is-plain-object": "^5.0.0",
-        "tiny-warning": "^1.0.3"
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@contentful/field-editor-shared": {
@@ -1340,25 +1338,31 @@
       }
     },
     "node_modules/@contentful/rich-text-plain-text-renderer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-17.1.0.tgz",
-      "integrity": "sha512-WNHTAUj8hXUS7jACNvE8imJJBXqVNCeuwkcgXSG44EPChkJXAfmgjMOT7/iXVFydT12POCC69ls7tUZuJ2rEBQ==",
+      "version": "16.2.10",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-plain-text-renderer/16.2.10/35ceb136fbfa6f377bfcfa3a1b348b203cfbd1e3",
+      "integrity": "sha512-B3VhPtAeriHmlJzwWoNBq8dqzpbkYGT0Bf9MfizAeHK9onOuP9LldW476cUqmoeJwtyEbSNp5/kC9wdr/wzprg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/rich-text-types": "^17.1.0"
+        "@contentful/rich-text-types": "^16.8.5"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@contentful/rich-text-types": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.1.0.tgz",
-      "integrity": "sha512-L0rok1VoMUbtQPJefR0Oxr5z1ow9/ZDIvuNWu16VT4IVVOKkeL4sVsjNj08cCT3ON+HUUzbPWVzyTuyvee2TSg==",
+    "node_modules/@contentful/rich-text-plain-text-renderer/node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
       "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^3.0.0"
-      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.3.0/d44145a43b32d61eb4d6a82d3001cdfddbbda42e",
+      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3541,376 +3545,335 @@
       }
     },
     "node_modules/@udecode/plate-basic-marks": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-36.0.0.tgz",
-      "integrity": "sha512-fbeD8t5Gkwz/ZKMg9yv75K3e6i5G5N9IIW3pkwmWya3RJ1darvpxDaEREXC19fRcHeF+eav8W0ZYU5ExHkYxtg==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-23.7.0.tgz",
+      "integrity": "sha512-lEtenuSl9EXcMYN9lhe8bPXjLT0PbsQPpo//HvMjDMxIDGDV0YK/zfmPdsBaQQH/MwbdeUrdNaNnikDBA4rjxA==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-break": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-36.0.0.tgz",
-      "integrity": "sha512-c+5yX7HqQQ5lN1Li3tAHEcofi1KMwJ3r0ToTMWyS9Mt/3+/+IX/mlh9m3yvpprN2w7H5iNAArW0upIARsU0UKg==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-23.7.0.tgz",
+      "integrity": "sha512-RL1pYofmQewMbE2M9a91x3DMMdSuSagayvnwgPwlJWalLcE5QivwbD63otvroPZcpky+9ULp+I7TI/TCg3uVZg==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-common": {
-      "version": "36.5.9",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-36.5.9.tgz",
-      "integrity": "sha512-lQaMkd6ZeCiUd6IBUkdDmbTSIpzzfR2rsynU3irRE0PH3/s8kMDI3cvZSeUS1CgvwokwJoRW6dBcRDChhmAXxw==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-common/-/plate-common-23.7.0.tgz",
+      "integrity": "sha512-AgEdfRsFXrYsUWKEY1TcrZt/hy3VeFCKgYWA1ua59/B6dinpiNYev+oPxT3E5OI0Ulu8WqVw/RF/kd090GHaUg==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-core": "36.5.9",
-        "@udecode/plate-utils": "36.5.9",
-        "@udecode/react-utils": "33.0.0",
-        "@udecode/slate": "36.0.6",
-        "@udecode/slate-react": "36.0.6",
-        "@udecode/slate-utils": "36.3.9",
-        "@udecode/utils": "31.0.0"
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/plate-utils": "23.7.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-core": {
-      "version": "36.5.9",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-36.5.9.tgz",
-      "integrity": "sha512-CcJ4ZIoyVtT2oWPlpmwWrAWyOKizwsgUjiYTxSlfV3DMXo2hn9dbQAI68hEuMgMqUoUM+FY/VS3bXZ055FV2Yg==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-23.6.0.tgz",
+      "integrity": "sha512-5nw86q3Om2TLtwo0rmMSzE5phbuoQoE9GlXxBL/oo7BYQwLWFSwqMqSxAO1doysqQ+Z8Yw5ctRtOq3kz587A0w==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/slate": "36.0.6",
-        "@udecode/slate-react": "36.0.6",
-        "@udecode/slate-utils": "36.3.9",
-        "@udecode/utils": "31.0.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/utils": "19.7.1",
+        "@udecode/zustood": "^1.1.3",
         "clsx": "^1.2.1",
-        "is-hotkey": "^0.2.0",
-        "jotai": "^2.7.1",
-        "jotai-optics": "0.3.2",
-        "jotai-x": "^1.2.3",
+        "jotai": "1.7.2",
         "lodash": "^4.17.21",
-        "nanoid": "^3.3.7",
-        "optics-ts": "2.4.1",
-        "react-hotkeys-hook": "^4.5.0",
-        "use-deep-compare": "^1.2.1",
-        "zustand": "^4.5.2",
-        "zustand-x": "^3.0.2"
+        "nanoid": "^3.3.6",
+        "react-hotkeys-hook": "^4.4.1",
+        "use-deep-compare": "^1.1.0",
+        "zustand": "^3.7.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-heading": {
-      "version": "36.0.9",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-36.0.9.tgz",
-      "integrity": "sha512-Bfe3AyKRQrjW+ug9M0FQAK/PUKdTq9My+mJGOp08fXxt7J4263IKJXcySvVJI/k4WcOK0W2/bjp4fPVcNUchfQ==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-23.7.0.tgz",
+      "integrity": "sha512-F1PfmhLtlPUQ6b0vDpmVYajPPf/YNxVrV3ekmd9lUAKt9C/UR5/NUvOFdInni7KRjazC+JWKt6wU+eP7+pW33A==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.6",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-indent": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-36.0.0.tgz",
-      "integrity": "sha512-pbeIqrl+K5vKHvPgKm1NS9cVXUuBr3MxfqO9iZKT7NPtZss6j23O1qYPT2uTqZf15FfeXRttQlG9OuISAiSGWQ==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-23.7.0.tgz",
+      "integrity": "sha512-Bv4lYQHYTJ6U8r/Z56YgLLlcEzkCIyh8TyCRurK7vE8IngTWMRtpcX/95hoJ+BUDroCnvMhhfdaK1W8U7Z09IQ==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-indent-list": {
-      "version": "36.0.1",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-36.0.1.tgz",
-      "integrity": "sha512-ZbFCjs65Kz5X2sb3OShO8W3VpYPbeIXh/wD5FzR9HwfbgJR+Ns4B0brh1j/JoPQ/X+o3zgWsrDH5kht/syVU7g==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-23.7.0.tgz",
+      "integrity": "sha512-iwnf4DMUyKy7K2U6CSKLYzChfiBx2wG2SrYPPTNoe5eT5YMdzwM4OX4BJT55tDgoapFrpLqq1lQzfXiT8hy53g==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-indent": "36.0.0",
-        "@udecode/plate-list": "36.0.0",
-        "clsx": "^1.2.1"
+        "@udecode/plate-common": "23.7.0",
+        "@udecode/plate-indent": "23.7.0",
+        "@udecode/plate-list": "23.7.0"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-list": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-36.0.0.tgz",
-      "integrity": "sha512-6RvRzlwudXxDZIj5993dr9HeprV2qGeVsMnISFWXPqq+2g0D2t4eiy9gZ69XmYUnSKQAtmrTA8E67vTbsgkM8Q==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-23.7.0.tgz",
+      "integrity": "sha512-C4j3PiHg2LtDpAhqp3lR64GAU8CC2qgkot8C6VAKnj+qssa+lgPjUq57nFQTdcH3VFkaiNzIVHDDDh0b1bUGxA==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-reset-node": "36.0.0",
-        "lodash": "^4.17.21"
+        "@udecode/plate-common": "23.7.0",
+        "@udecode/plate-reset-node": "23.7.0"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-media": {
-      "version": "36.0.10",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-36.0.10.tgz",
-      "integrity": "sha512-MNZsYPk+FDVvkRkbf1strNdrmBc0E+/yYOzEAqt70Snjg4V4uUC6MTQ8dF3He7mtk18mYfTZN8p43K0FwSjvEA==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-23.7.0.tgz",
+      "integrity": "sha512-uRWDFZ606qEm/SLmjvciPiYmOXEfRCZQjj/XF2gj1Jjr42kQSbJ9WvDxRG4lHDKTEsdPhf4+t0vuriAxM7PGvw==",
       "license": "MIT",
       "dependencies": {
+        "@udecode/plate-common": "23.7.0",
         "js-video-url-parser": "^0.5.1"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.6",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-paragraph": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-36.0.0.tgz",
-      "integrity": "sha512-Zbm76VygSfj4hkP1kfjwaYZisvmF3XP79f1uVTieQfcx/16s+Ln4BCVasCCbS+PO94yjsujW+ww05bUzGqRxpA==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-23.7.0.tgz",
+      "integrity": "sha512-au8KiBgqouEWnJGofLq9VnDDKgUzgWy+vq048jZ0OCZUQVycY8tXGKQR2hZy8atNmcxSTBN4gRAscoNB7oC+ug==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-reset-node": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-36.0.0.tgz",
-      "integrity": "sha512-gDDc4ak8Gk47TQl6bGoxqy82nzmY94GPtaE9aSVJ5zjNcSTfvqWzPjAU7s2zaNPUJERI7Q01rVMzBJAckbC6Hg==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-23.7.0.tgz",
+      "integrity": "sha512-m+PRF9kusZiE60hw4FRYTQwhbhemiMyHhC4v6G5nN7CGP3Zjmkg3bvuOZ7aqRBk5Vkvjx3wATw2ggisOtG8Fqg==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-resizable": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-resizable/-/plate-resizable-36.0.0.tgz",
-      "integrity": "sha512-q8LDQONh46IAsFaMTiUxOcMNKz4qhKtABwbfi4TvPgTj9r5fDL2UGitvpwxHxMoXPYGfe4l/xvve4ShtutPoyA==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-resizable/-/plate-resizable-23.7.0.tgz",
+      "integrity": "sha512-HvUZmwHuPrs+d1XU0AqDWEzYpEV1lXh0n1DgJnEf5fPrKojzoBRzeARysm9B3KHOxv7VmhTJ7mpHwNt4hjrwJQ==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-select": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-36.0.0.tgz",
-      "integrity": "sha512-cMP+UXYftb/cTJKbrShltk5K1y9z94J7sCUQCqJllOu+VvLKUVkLOokqQC42Vp2zUhGgvIzjCGcL2pPec9Iexg==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-23.7.0.tgz",
+      "integrity": "sha512-ROTbCRNvypRi15BB8FMYxLJJnyXBEVZGDuBKNoee47IJ8shtts9VGmTe81mXYN7sVwTSPp7eQixha3/533m6JQ==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-serializer-docx": {
-      "version": "36.0.10",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-36.0.10.tgz",
-      "integrity": "sha512-v5jaEyz731iisvBQ3KK6FWCOrmV79LVXgIgnOEfm56ubbvnG/oIbIyi+a97k01rCpns4yyXkWqlJZ7Ywf3gM4w==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-23.7.0.tgz",
+      "integrity": "sha512-2OR9PIy5k5/G7W2pQmGHVuHwvqy1zYmYS3xHsIeBryDtMNZhSkGNezo3TgHSGDnXb1FBU4PPRdOZCSrNRaJcUQ==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-heading": "36.0.9",
-        "@udecode/plate-indent": "36.0.0",
-        "@udecode/plate-indent-list": "36.0.1",
-        "@udecode/plate-media": "36.0.10",
-        "@udecode/plate-paragraph": "36.0.0",
-        "@udecode/plate-table": "36.0.0",
-        "validator": "^13.11.0"
+        "@udecode/plate-common": "23.7.0",
+        "@udecode/plate-heading": "23.7.0",
+        "@udecode/plate-indent": "23.7.0",
+        "@udecode/plate-indent-list": "23.7.0",
+        "@udecode/plate-media": "23.7.0",
+        "@udecode/plate-paragraph": "23.7.0",
+        "@udecode/plate-table": "23.7.0",
+        "validator": "^13.9.0"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.6",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
-      }
-    },
-    "node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-table": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-36.0.0.tgz",
-      "integrity": "sha512-5LqUGSP/hasz13w/eztmmqx0t1dQZ6bbfuXB03A2JHIxhjkcNRyrQW8/cZr5WNSVJ7nOhc8zplwU8RYlIkuMKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@udecode/plate-resizable": "36.0.0",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.94.0",
-        "slate-history": ">=0.93.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-serializer-html": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-36.0.0.tgz",
-      "integrity": "sha512-hOIofWtW0DZsfThjRqCw4pECNI1MmxZv8IgbCi/tdu0ROEcac8nwmgdra4DxW0bDEPgu7cEScwX4F6y8nTjm4A==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-23.7.0.tgz",
+      "integrity": "sha512-XlwXvSv4+SkDr3dJAj02OKj5bHY0xDoGs6nLbRtsnSsp5Wf9wJ0wCgjI/AAcsVhO6jE67MQvwWtDFKOANvvLSA==",
       "license": "MIT",
       "dependencies": {
-        "html-entities": "^2.5.2"
+        "@udecode/plate-common": "23.7.0",
+        "html-entities": "^2.4.0"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
         "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-table": {
-      "version": "36.5.9",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-36.5.9.tgz",
-      "integrity": "sha512-PaqveLFKvo0t3I99JVe0fZFn6gGVEtLFj06pikbnTzLZ/RHpz89YjE0F3zDEeNCMoH4lOmgBqsKt3S4ho9HkGQ==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-23.7.0.tgz",
+      "integrity": "sha512-G6OgdQyu/Q2VztSTXSAW2EAYxcuvMSqjscCy4ytR3nQ63R/x2r4k4eb8qBHy/k4T1oqGgqvex6p9tx2dTXx6Tw==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-resizable": "36.0.0",
-        "lodash": "^4.17.21"
+        "@udecode/plate-common": "23.7.0",
+        "@udecode/plate-resizable": "23.7.0"
       },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.5.9",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.98.1"
       }
     },
     "node_modules/@udecode/plate-trailing-block": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-36.0.0.tgz",
-      "integrity": "sha512-fHETw5ylT6Cw5hDf0kyXqm3F4bCXfWg32sj+L0D7u2MJt/g0LYY8LY6J76ht9Vp0NyxYzOqZn/efDzBzlQgFqg==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-23.7.0.tgz",
+      "integrity": "sha512-ea+rAyhdt+A/QnU6d7L0G6kLuygdSDtyFVkPQ47S/hGpzPMEqeDEzgDWmL/XrJY+3JsCBt/mfK/zYmxFyilZZA==",
       "license": "MIT",
+      "dependencies": {
+        "@udecode/plate-common": "23.7.0"
+      },
       "peerDependencies": {
-        "@udecode/plate-common": ">=36.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/plate-utils": {
-      "version": "36.5.9",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-36.5.9.tgz",
-      "integrity": "sha512-cYv7oGNG8ag/Q13Wo9zwSJ4TqiPxfoEc2uEplYvIueFfzNR2fXRy0wO4yJYdwkVass8eew2P9PjvXIWnfYPAeQ==",
+      "version": "23.7.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-utils/-/plate-utils-23.7.0.tgz",
+      "integrity": "sha512-mYma1TnMCbzZI5e9Zn66j4azEkkSHksn8399eyFzneXypSG4CSAglIjYjaR+OKnC67w+da4fZP8UYulQIRHhlA==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/plate-core": "36.5.9",
-        "@udecode/react-utils": "33.0.0",
-        "@udecode/slate": "36.0.6",
-        "@udecode/slate-react": "36.0.6",
-        "@udecode/slate-utils": "36.3.9",
-        "@udecode/utils": "31.0.0",
-        "clsx": "^1.2.1",
-        "lodash": "^4.17.21"
+        "@radix-ui/react-slot": "^1.0.2",
+        "@udecode/plate-core": "23.6.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/slate-react": "22.0.2",
+        "@udecode/slate-utils": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-hyperscript": ">=0.66.0",
-        "slate-react": ">=0.99.0"
-      }
-    },
-    "node_modules/@udecode/react-utils": {
-      "version": "33.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/react-utils/-/react-utils-33.0.0.tgz",
-      "integrity": "sha512-ptFyi2mivkyd/HUVWj1PXCCXLVBecLQ3b6DweNesoabdlf/43aUetL4oHVCXr97TAKck7xi2MZbSUNlMAmLhmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "^1.0.2",
-        "@udecode/utils": "31.0.0",
-        "clsx": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/slate": {
-      "version": "36.0.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-36.0.6.tgz",
-      "integrity": "sha512-b5K/7vOkzHDmjX+Nyz7gk6Z9drC7w+FNKfhKLM3SI991Vvat5KVoew9kGF5Sc4etjwDI5oQVNAehYOS/N7lHxA==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate/-/slate-22.0.2.tgz",
+      "integrity": "sha512-oe4Pi1QMLXwBPuVk64RU0cxmBeXmahg2GWX1iZ3fcshTM8mQyJdTyjIgMu+wmQqe2nk/2mRruGb5INh3Pt8gYQ==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/utils": "31.0.0"
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "slate": ">=0.94.0",
@@ -3918,31 +3881,30 @@
       }
     },
     "node_modules/@udecode/slate-react": {
-      "version": "36.0.6",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-36.0.6.tgz",
-      "integrity": "sha512-kJ9MbUWwlYinroDdDevN5jW/pW3FmxOs6QOSL74vlhxe6wB5SeyvARO2NRF8/MEcE89Il8cjT4rrh+q1RiHc7Q==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-react/-/slate-react-22.0.2.tgz",
+      "integrity": "sha512-8QFuzIEnOgddHdESwtG7/j+Ui0utj6iIAP2zrMxL3V7iWi9nTvpL4nxSJpOzqC/Vvq2WK/+QvQZb+wOZrLiUpQ==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/react-utils": "33.0.0",
-        "@udecode/slate": "36.0.6",
-        "@udecode/utils": "31.0.0"
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "slate": ">=0.94.0",
         "slate-history": ">=0.93.0",
-        "slate-react": ">=0.99.0"
+        "slate-react": ">=0.95.0"
       }
     },
     "node_modules/@udecode/slate-utils": {
-      "version": "36.3.9",
-      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-36.3.9.tgz",
-      "integrity": "sha512-fIlmDf3etL1HdqHLnuxvloL0AiXv2U6nSaWfuZADeE+1ELU0f2tisCT+MGDJBZws6CCyELLDezMxNDCBwAPwtQ==",
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@udecode/slate-utils/-/slate-utils-22.0.2.tgz",
+      "integrity": "sha512-wZ2zbNA/75fRVIynIzpjeyTyt1lfOcRqFCOcCfNSyfVhMzn4RPpOVOoRk7nSrL/89mwZLiUDiSMdhNJrDeQEOw==",
       "license": "MIT",
       "dependencies": {
-        "@udecode/slate": "36.0.6",
-        "@udecode/utils": "31.0.0",
+        "@udecode/slate": "22.0.2",
+        "@udecode/utils": "19.7.1",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
@@ -3951,10 +3913,67 @@
       }
     },
     "node_modules/@udecode/utils": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-31.0.0.tgz",
-      "integrity": "sha512-06JTl1UAm3mzLLAx8hdMUFw4XRQG727z9JoJ9PeBnmFb9q4Cg3DdmbFnhVJMrBPWlyOwoHtPrBjnanTFeiP36Q==",
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/@udecode/utils/-/utils-19.7.1.tgz",
+      "integrity": "sha512-FqPvq/0MOI8qvX3KvQfTKNUkvh8CwHxke9CyoqMck5dxeOmge3vHMkHkCE1BXw2w19EFGkC58Tkw8+RpT8qFSQ==",
       "license": "MIT"
+    },
+    "node_modules/@udecode/zustood": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@udecode/zustood/-/zustood-1.1.3.tgz",
+      "integrity": "sha512-f3mxHDaOF+q2XvDh/mMvLhCNs0LfCLhIBl8jGmvZT/i3WWq7YujzGXgnbK8mxIkun9irfe6wlPhg9sTIB9Gnug==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^9.0.6",
+        "react-tracked": "^1.7.9"
+      },
+      "peerDependencies": {
+        "zustand": ">=3.5.10"
+      }
+    },
+    "node_modules/@udecode/zustood/node_modules/react-tracked": {
+      "version": "1.7.14",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.14.tgz",
+      "integrity": "sha512-6UMlgQeRAGA+uyYzuQGm7kZB6ZQYFhc7sntgP7Oxwwd6M0Ud/POyb4K3QWT1eXvoifSa80nrAWnXWFGpOvbwkw==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "2.6.0",
+        "use-context-selector": "1.4.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@udecode/zustood/node_modules/use-context-selector": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.4.tgz",
+      "integrity": "sha512-pS790zwGxxe59GoBha3QYOwk8AFGp4DN6DOtH+eoqVmgBBRXVx4IlPDhJmmMiNQAgUaLlP+58aqRC3A4rdaSjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -6320,18 +6339,24 @@
       }
     },
     "node_modules/jotai": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.13.1.tgz",
-      "integrity": "sha512-cRsw6kFeGC9Z/D3egVKrTXRweycZ4z/k7i2MrfCzPYsL9SIWcPXTyqv258/+Ay8VUEcihNiE/coBLE6Kic6b8A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.7.2.tgz",
+      "integrity": "sha512-ksvpW1Wu+/HwW1iDYq23PpXLu2df5Vv+eWw70jRAx7IEY4c+qRsORULnqPFurSy/X8LSoPcRhVDJx/cyf8jjMg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12.7.0"
       },
       "peerDependencies": {
-        "@babel/core": ">=7.0.0",
-        "@babel/template": ">=7.0.0",
-        "@types/react": ">=17.0.0",
-        "react": ">=17.0.0"
+        "@babel/core": "*",
+        "@babel/template": "*",
+        "@urql/core": "*",
+        "immer": "*",
+        "optics-ts": "*",
+        "react": ">=16.8",
+        "react-query": "*",
+        "valtio": "*",
+        "wonka": "*",
+        "xstate": "*"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -6340,39 +6365,25 @@
         "@babel/template": {
           "optional": true
         },
-        "@types/react": {
+        "@urql/core": {
           "optional": true
         },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jotai-optics": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/jotai-optics/-/jotai-optics-0.3.2.tgz",
-      "integrity": "sha512-RH6SvqU5hmkVqnHmaqf9zBXvIAs4jLxkDHS4fr5ljuBKHs8+HQ02v+9hX7ahTppxx6dUb0GGUE80jQKJ0kFTLw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "jotai": ">=1.11.0",
-        "optics-ts": "*"
-      }
-    },
-    "node_modules/jotai-x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jotai-x/-/jotai-x-1.2.4.tgz",
-      "integrity": "sha512-FyLrAR/ZDtmaWgif4cNRuJvMam/RSFv+B11/p4T427ws/T+8WhZzwmULwNogG6ZbZq+v1XpH6f9aN1lYqY5dLg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": ">=17.0.0",
-        "jotai": ">=2.0.0",
-        "react": ">=17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
+        "immer": {
           "optional": true
         },
-        "react": {
+        "optics-ts": {
+          "optional": true
+        },
+        "react-query": {
+          "optional": true
+        },
+        "valtio": {
+          "optional": true
+        },
+        "wonka": {
+          "optional": true
+        },
+        "xstate": {
           "optional": true
         }
       }
@@ -6517,12 +6528,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.mapvalues": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6905,12 +6910,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/optics-ts": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/optics-ts/-/optics-ts-2.4.1.tgz",
-      "integrity": "sha512-HaYzMHvC80r7U/LqAd4hQyopDezC60PO2qF5GuIwALut2cl5rK1VWHsqTp0oqoJJWjiv6uXKqsO+Q2OO0C3MmQ==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7733,19 +7732,13 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
-      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
+      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
       "license": "MIT",
       "dependencies": {
-        "compute-scroll-into-view": "^3.0.2"
+        "compute-scroll-into-view": "^1.0.20"
       }
-    },
-    "node_modules/scroll-into-view-if-needed/node_modules/compute-scroll-into-view": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
-      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7867,13 +7860,13 @@
       "license": "ISC"
     },
     "node_modules/slate": {
-      "version": "0.118.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.118.1.tgz",
-      "integrity": "sha512-6H1DNgnSwAFhq/pIgf+tLvjNzH912M5XrKKhP9Frmbds2zFXdSJ6L/uFNyVKxQIkPzGWPD0m+wdDfmEuGFH5Tg==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
+      "integrity": "sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "immer": "^10.0.3",
+        "immer": "^9.0.6",
+        "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
       }
     },
@@ -7902,37 +7895,32 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.102.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.102.0.tgz",
-      "integrity": "sha512-SAcFsK5qaOxXjm0hr/t2pvIxfRv6HJGzmWkG58TdH4LdJCsgKS1n6hQOakHPlRVCwPgwvngB6R+t3pPjv8MqwA==",
+      "version": "0.98.3",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.3.tgz",
+      "integrity": "sha512-p1BnF9eRyRM0i5hkgOb11KgmpWLQm9Zyp6jVkOAj5fPdIGheKhg48Z7aWKrayeJ4nmRyi/NjRZz/io5hQcphmw==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.8",
-        "@types/lodash": "^4.14.200",
-        "direction": "^1.0.4",
-        "is-hotkey": "^0.2.0",
+        "@types/is-hotkey": "^0.1.1",
+        "@types/lodash": "^4.14.149",
+        "direction": "^1.0.3",
+        "is-hotkey": "^0.1.6",
         "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.21",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "tiny-invariant": "1.3.1"
+        "lodash": "^4.17.4",
+        "scroll-into-view-if-needed": "^2.2.20",
+        "tiny-invariant": "1.0.6"
       },
       "peerDependencies": {
-        "react": ">=18.2.0",
-        "react-dom": ">=18.2.0",
-        "slate": ">=0.99.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "slate": ">=0.65.3"
       }
     },
-    "node_modules/slate/node_modules/immer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
-      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
+    "node_modules/slate-react/node_modules/is-hotkey": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
+      "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8159,9 +8147,9 @@
       }
     },
     "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
       "license": "MIT"
     },
     "node_modules/tiny-warning": {
@@ -9941,97 +9929,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
         "node": ">=12.7.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
         "react": ">=16.8"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
         "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zustand-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/zustand-x/-/zustand-x-3.0.4.tgz",
-      "integrity": "sha512-dVD8WUEpR/0mMdLah9j8i+r6PMAq9Ii2u+BX/9Bn4MHRt8sSnRQ90YMUlTVonZYAHGb2UHZwPpE2gMb8GtYDDw==",
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^10.0.3",
-        "lodash.mapvalues": "^4.6.0",
-        "react-tracked": "^1.7.11"
-      },
-      "peerDependencies": {
-        "zustand": ">=4.3.9"
-      }
-    },
-    "node_modules/zustand-x/node_modules/immer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
-      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/zustand-x/node_modules/react-tracked": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.14.tgz",
-      "integrity": "sha512-6UMlgQeRAGA+uyYzuQGm7kZB6ZQYFhc7sntgP7Oxwwd6M0Ud/POyb4K3QWT1eXvoifSa80nrAWnXWFGpOvbwkw==",
-      "license": "MIT",
-      "dependencies": {
-        "proxy-compare": "2.6.0",
-        "use-context-selector": "1.4.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": "*",
-        "react-native": "*",
-        "scheduler": ">=0.19.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zustand-x/node_modules/use-context-selector": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.4.tgz",
-      "integrity": "sha512-pS790zwGxxe59GoBha3QYOwk8AFGp4DN6DOtH+eoqVmgBBRXVx4IlPDhJmmMiNQAgUaLlP+58aqRC3A4rdaSjg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": "*",
-        "react-native": "*",
-        "scheduler": ">=0.19.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         }
       }

--- a/apps/docs-to-rich-text/package.json
+++ b/apps/docs-to-rich-text/package.json
@@ -6,7 +6,7 @@
     "@contentful/app-sdk": "^4.29.3",
     "@contentful/f36-components": "^4.81.1",
     "@contentful/f36-tokens": "^4.1.0",
-    "@contentful/field-editor-rich-text": "3.30.0",
+    "@contentful/field-editor-rich-text": "3.16.15",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@emotion/css": "^11.13.5",
     "@types/async-lock": "^1.4.2",


### PR DESCRIPTION
every time the '@contentful/field-editor-rich-text' package version changes, rich text breaks. We will need to actually fix the usage soon but for now this PR changes the version and tells dependabot to ignore the package and not try to update it 
