### PR TITLE
fix(cloudinary2): image editor overlays bug fix [ZEND-7047]

### DIFF
--- a/apps/cloudinary2/src/components/FieldWrapper.tsx
+++ b/apps/cloudinary2/src/components/FieldWrapper.tsx
@@ -2,7 +2,7 @@ import { Flex, FormControl } from '@contentful/f36-components';
 import { PropsWithChildren, ReactNode, useId } from 'react';
 
 interface Props {
-  name: string;
+  name?: string;
   description: ReactNode;
   counter?: boolean;
 }
@@ -10,7 +10,7 @@ interface Props {
 export function FieldWrapper({ name, description, counter = false, children }: PropsWithChildren<Props>) {
   return (
     <FormControl id={useId()}>
-      <FormControl.Label>{name}</FormControl.Label>
+      {name && <FormControl.Label>{name}</FormControl.Label>}
       {children}
 
       <Flex justifyContent="space-between">

--- a/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormControl, TextLink } from '@contentful/f36-components';
+import { Checkbox, Form, TextLink } from '@contentful/f36-components';
 import { ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
 import { useCallback } from 'react';
 import { SelectField } from '../../components/SelectField';
@@ -6,6 +6,7 @@ import { TextField } from '../../components/TextField';
 import { DEFAULT_APP_INSTALLATION_PARAMETERS } from '../../constants';
 import { AppInstallationParameters } from '../../types';
 import { BackendConfiguration } from './BackendConfiguration';
+import { FieldWrapper } from '../../components/FieldWrapper';
 
 const MAX_FILES_UPPER_LIMIT = 1000;
 
@@ -136,22 +137,20 @@ export function InstallParamsConfiguration(props: Props) {
         value={parameters.format}
         onChange={(value) => onParameterChange('format', value)}
       />
-      <Checkbox
-        isChecked={parameters.showUploadButton === 'true'}
-        value={'showUploadButton'}
-        onChange={(event) => onParameterChange('showUploadButton', event.currentTarget.checked ? 'true' : 'false')}>
-        Show Upload Button
-      </Checkbox>
 
-      <FormControl.HelpText>
-        Enable or disable the upload functionality. When checked, users will see an Upload button that allows them to add assets directly to your library. When
-        unchecked, the upload option will be hidden, preventing any new assets from being added manually. This setting is useful when you want to restrict asset
-        input to predefined sources only.
-      </FormControl.HelpText>
+      <FieldWrapper description="Enable or disable the upload functionality. When checked, users will see an Upload button that allows them to add assets directly to your library. When unchecked, the upload option will be hidden, preventing any new assets from being added manually. This setting is useful when you want to restrict asset input to predefined sources only.">
+        <Checkbox
+          isChecked={parameters.showUploadButton === 'true'}
+          value={'showUploadButton'}
+          onChange={(event) => onParameterChange('showUploadButton', event.currentTarget.checked ? 'true' : 'false')}>
+          Show Upload Button
+        </Checkbox>
+      </FieldWrapper>
+
       <TextField
         testId="config-imageEditorOverlays"
         name="Image editor overlays"
-        description={`public ids for image editor overlays`}
+        description="Public ids for image editor overlays"
         value={parameters.imageEditorOverlays?.join(',')}
         onChange={(value) => {
           const overlays = value

--- a/apps/cloudinary2/src/locations/ImageEditorDialog.tsx
+++ b/apps/cloudinary2/src/locations/ImageEditorDialog.tsx
@@ -49,14 +49,15 @@ const ImageEditorDialog = () => {
 
         // samples/logo,samples/man-portrait
         const steps = ['resizeAndCrop'];
-        const overlays = installationParams.imageEditorOverlays.map((pid) => {
-          return {
-            publicId: pid,
-            label: pid,
-            transformation: [],
-            placementOptions: ['top_left', 'top_right', 'bottom_left', 'bottom_right'],
-          };
-        });
+        const overlays =
+          installationParams.imageEditorOverlays?.map((pid) => {
+            return {
+              publicId: pid,
+              label: pid,
+              transformation: [],
+              placementOptions: ['top_left', 'top_right', 'bottom_left', 'bottom_right'],
+            };
+          }) || [];
 
         if (overlays.length > 0) {
           steps.push('imageOverlay');


### PR DESCRIPTION
## Purpose

Fixing a bug with the Cloudinary app which happens if the app configuration had not been saved/updated since the app was updated a couple days ago, the `installationParams.imageEditorOverlays` value was `undefined` and throwing a fatal error when rendering the `ImageEditorDialog` component.

|Before|After|
|----|----|
|<img width="1672" height="1145" alt="Screenshot 2025-10-10 at 11 26 53 AM" src="https://github.com/user-attachments/assets/a9b465c3-13ca-41e3-8129-352b62276924" />|<img width="1672" height="1192" alt="Screenshot 2025-10-10 at 12 29 11 PM" src="https://github.com/user-attachments/assets/3b479689-7475-4cfc-a991-deda4639e298" />|

Also fixes a small spacing issue in the Config screen, there was no space above the "Image editor overlays" field label

|Before|After|
|----|----|
|<img width="766" height="578" alt="Screenshot 2025-10-10 at 12 17 20 PM" src="https://github.com/user-attachments/assets/d583f452-d562-47f5-9b43-f862cc764adf" />|<img width="764" height="613" alt="Screenshot 2025-10-10 at 12 15 09 PM" src="https://github.com/user-attachments/assets/cb1d84da-b320-4727-8530-4fd67fd45d14" />|

## Testing steps

Manually tested in our Cloudinary app development environment.

## Breaking Changes

None
