### PR TITLE
Version 2.0 supporting External References API and Bynder Asset Tracker

### DIFF
--- a/apps/bynder/CHANGELOG.md
+++ b/apps/bynder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.0](https://github.com/contentful/marketplace-partner-apps/compare/bynder-assets-v1.1.18...bynder-assets-v2.0.0) (2025-10-13)
+
+### Features
+
+* **External References**
+The app supports Contentful's External References feature, allowing you to query the latest snapshot of stored Bynder assets via GraphQL. This enables you to retrieve up-to-date asset information directly from Bynder.
+* **Asset Tracker**
+The Asset Tracker feature automatically syncs Bynder asset usage information with Contentful entries. When enabled, it tracks when Bynder assets are used in Contentful entries and maintains this usage data in Bynder's Asset Usage API.
+
+
 ## [1.1.19](https://github.com/contentful/marketplace-partner-apps/compare/bynder-assets-v1.1.18...bynder-assets-v1.1.19) (2025-07-28)
 
 

--- a/apps/bynder/contentful-app-manifest.json
+++ b/apps/bynder/contentful-app-manifest.json
@@ -1,0 +1,31 @@
+{
+    "functions": [
+        {
+            "id": "BynderAPI",
+            "name": "Bynder Function",
+            "description": "This function pulls the asset information from Bynder via APIs",
+            "path": "functions/external-ref.js",
+            "entryFile": "functions/external-ref.ts",
+            "allowNetworks": [
+                "*.bynder.com"
+            ],
+            "accepts": [
+                "graphql.field.mapping",
+                "graphql.query"
+            ]
+        },
+        {
+            "id": "BynderAppEventHandler",
+            "name": "Bynder - App Event Handler",
+            "description": "This function handles the App Events for entries having bynder fields.",
+            "path": "functions/asset-tracker.js",
+            "entryFile": "functions/asset-tracker.ts",
+            "allowNetworks": [
+                "*.bynder.com"
+            ],
+            "accepts": [
+                "appevent.handler"
+            ]
+        }
+    ]
+}

--- a/apps/bynder/functions/Utils/bynderUtils.ts
+++ b/apps/bynder/functions/Utils/bynderUtils.ts
@@ -1,0 +1,399 @@
+import {
+  BynderResponse,
+  BynderAuthConfig,
+  TokenCacheEntry,
+  BynderTokenResponse,
+  Asset,
+  BynderAssetUsageResponse,
+} from "../types";
+
+/**
+ * Bynder base endpoints and other constants.
+ */
+const API_ASSET_BASE = "/api/v4/media";
+const API_ASSET_USAGE_ENDPOINT = "/api/media/usage";
+const BYNDER_CONTENTFUL_INTEGRATION_ID = "ac534173-7ee1-493b-98b7-a6d88ce7a450";
+
+/**
+ * Core Bynder asset fields that must be present to identify a Bynder asset
+ * These are the essential fields that uniquely identify a Bynder asset
+ */
+const CORE_BYNDER_FIELDS = [
+  "id",
+  "name",
+  "dateCreated",
+  "dateModified",
+  "type",
+  "fileSize",
+  "extension",
+  "textMetaproperties",
+  "width",
+  "height",
+  "isPublic",
+];
+
+/**
+ * In-memory cache for Bynder OAuth2 access tokens.
+ *
+ * NOTE: In serverless environments (e.g., AWS Lambda, Vercel, Netlify), this cache
+ * only persists for the lifetime of a single "warm" function instance. There is no
+ * guarantee that the cache will be available across invocations, so the access token
+ * may be fetched on every cold start or new invocation.
+ *
+ * For most use cases, this is acceptable, as the client credentials flow is designed
+ * for frequent token requests.
+ */
+const tokenCache: Record<string, TokenCacheEntry> = {};
+
+/**
+ * Utility function get the API asset base URL for bynder.
+ *
+ * @param {string} base_url
+ *   The client specific endpoint.
+ * @returns {string}
+ *   The Bynder Asset endpoint.
+ */
+const getBynderAssetUrl = (base_url: string): string => {
+  base_url = base_url.endsWith("/") ? base_url.slice(0, -1) : base_url;
+  return `${base_url}${API_ASSET_BASE}`;
+};
+
+/**
+ * Fetch and cache a Bynder access token using client credentials.
+ * Caches per bynderURL+clientId.
+ *
+ * @param {BynderAuthConfig} config
+ *   The Bynder authentication configuration (from installation config).
+ * @returns {Promise<string>}
+ *   The Bynder OAuth2 access token.
+ */
+export const getBynderAccessToken = async (
+  config: BynderAuthConfig,
+): Promise<string> => {
+  const cacheKey = `${config.bynderURL}|${config.clientId}`;
+  const now = Date.now();
+
+  // Check cache (may only persist for warm invocations in serverless)
+  const cached = tokenCache[cacheKey];
+  if (cached && cached.expiresAt > now + 60000) {
+    // 60s buffer
+    return cached.accessToken;
+  }
+
+  // Fetch new token
+  const tokenUrl = `${config.bynderURL.replace(/\/$/, "")}/v6/authentication/oauth2/token`;
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  });
+
+  const resp = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!resp.ok) {
+    throw new Error(
+      `Failed to fetch Bynder access token: ${resp.status} ${await resp.text()}`,
+    );
+  }
+
+  const data = (await resp.json()) as BynderTokenResponse;
+  const accessToken = data.access_token;
+  const expiresIn = data.expires_in || 3600; // seconds
+
+  // Store in cache for future use (if instance is reused)
+  tokenCache[cacheKey] = {
+    accessToken,
+    expiresAt: now + expiresIn * 1000,
+  };
+
+  return accessToken;
+};
+
+/**
+ * Utility function to fetch an asset from Bynder, if exists.
+ * Uses client credentials flow for authentication.
+ *
+ * @param {BynderAuthConfig} config
+ *   The Bynder authentication configuration (from installation config).
+ * @param {string} assetId
+ *   Asset ID which is requested.
+ * @returns {Promise<BynderResponse>}
+ *   The Bynder API response.
+ */
+export const getAsset = async (
+  bynderURL: string,
+  token: string,
+  assetId: string,
+): Promise<BynderResponse> => {
+  const assetUrl = `${getBynderAssetUrl(bynderURL)}/${assetId}?versions=1`;
+
+  try {
+    const apiResponse = await fetch(assetUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      method: "GET",
+    });
+    let response: BynderResponse = {
+      status: apiResponse.status,
+    };
+    if (apiResponse.status === 200) {
+      response.data = (await apiResponse.json()) as Asset;
+    }
+    return response;
+  } catch (error) {
+    const errorResponse: BynderResponse = {
+      status: 500,
+      error: error as Object,
+    };
+    return errorResponse;
+  }
+};
+
+/**
+ * Retrieve existing asset usage from Bynder
+ *
+ * @param {string} bynderURL - The Bynder instance URL
+ * @param {string} token - The Bynder access token
+ * @param {string} uri - URI where the asset is being used
+ * @param {string} [assetId] - Optional Bynder asset ID to filter by specific asset
+ * @returns {Promise<BynderResponse>} - The API response with usage data
+ */
+export const getAssetUsage = async (
+  bynderURL: string,
+  token: string,
+  uri: string,
+  assetId?: string,
+): Promise<BynderResponse> => {
+  const params = new URLSearchParams({
+    integration_id: BYNDER_CONTENTFUL_INTEGRATION_ID,
+    uri: uri,
+  });
+
+  // Add asset_id only if provided
+  if (assetId) {
+    params.append("asset_id", assetId);
+  }
+
+  const usageUrl = `${bynderURL.replace(/\/$/, "")}${API_ASSET_USAGE_ENDPOINT}?${params.toString()}`;
+
+  try {
+    const apiResponse = await fetch(usageUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    let response: BynderResponse = {
+      status: apiResponse.status,
+    };
+
+    if (apiResponse.status === 200) {
+      response.data = (await apiResponse.json()) as BynderAssetUsageResponse;
+    }
+
+    return response;
+  } catch (error) {
+    const errorResponse: BynderResponse = {
+      status: 500,
+      error: error as Object,
+    };
+    return errorResponse;
+  }
+};
+
+/**
+ * Create asset usage in Bynder
+ *
+ * @param {string} bynderURL - The Bynder instance URL
+ * @param {string} token - The Bynder access token
+ * @param {string} assetId - The Bynder asset ID
+ * @param {string} uri - URI where the asset is being used
+ * @param {string} additional - Additional context information
+ * @returns {Promise<BynderResponse>} - The API response
+ */
+export const createAssetUsage = async (
+  bynderURL: string,
+  token: string,
+  assetId: string,
+  uri: string,
+  additional: string,
+): Promise<BynderResponse> => {
+  const usageUrl = `${bynderURL.replace(/\/$/, "")}${API_ASSET_USAGE_ENDPOINT}`;
+
+  const body = new URLSearchParams({
+    asset_id: assetId,
+    integration_id: BYNDER_CONTENTFUL_INTEGRATION_ID,
+    uri,
+    additional,
+    timestamp: new Date().toISOString(),
+  });
+
+  try {
+    const apiResponse = await fetch(usageUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+    });
+
+    let response: BynderResponse = {
+      status: apiResponse.status,
+    };
+
+    if (apiResponse.status === 200 || apiResponse.status === 201) {
+      response.data = await apiResponse.json();
+    }
+
+    return response;
+  } catch (error) {
+    const errorResponse: BynderResponse = {
+      status: 500,
+      error: error as Object,
+    };
+    return errorResponse;
+  }
+};
+
+/**
+ * Delete asset usage from Bynder
+ *
+ * @param {string} bynderURL - The Bynder instance URL
+ * @param {string} token - The Bynder access token
+ * @param {string} assetId - The Bynder asset ID
+ * @param {string} uri - URI where the asset is being used
+ * @returns {Promise<BynderResponse>} - The API response
+ */
+export const deleteAssetUsage = async (
+  bynderURL: string,
+  token: string,
+  assetId: string,
+  uri: string,
+): Promise<BynderResponse> => {
+  const params = new URLSearchParams({
+    integration_id: BYNDER_CONTENTFUL_INTEGRATION_ID,
+    asset_id: assetId,
+    uri: uri,
+  });
+  const usageUrl = `${bynderURL.replace(/\/$/, "")}${API_ASSET_USAGE_ENDPOINT}?${params.toString()}`;
+
+  try {
+    const apiResponse = await fetch(usageUrl, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    let response: BynderResponse = {
+      status: apiResponse.status,
+    };
+
+    if (apiResponse.status === 200 || apiResponse.status === 204) {
+      response.data = {};
+    }
+
+    return response;
+  } catch (error) {
+    const errorResponse: BynderResponse = {
+      status: 500,
+      error: error as Object,
+    };
+    return errorResponse;
+  }
+};
+
+/**
+ * Normalize asset ID to proper UUID format with hyphens
+ * Converts formats like "681d7df7e6e04d219c92f0c5e2ad90e3" to "681d7df7-e6e0-4d21-9c92-f0c5e2ad90e3"
+ *
+ * @param {string} assetId - The asset ID to normalize
+ * @returns {string} - Normalized UUID format
+ */
+const normalizeAssetId = (assetId: string): string => {
+  // Remove any existing hyphens and convert to lowercase
+  const cleanId = assetId.replace(/-/g, "").toLowerCase();
+
+  // Check if it's a valid 32-character hex string (UUID without hyphens)
+  if (cleanId.length === 32 && /^[0-9a-f]{32}$/.test(cleanId)) {
+    // Format as UUID: 8-4-4-4-12
+    return `${cleanId.slice(0, 8)}-${cleanId.slice(8, 12)}-${cleanId.slice(12, 16)}-${cleanId.slice(16, 20)}-${cleanId.slice(20, 32)}`;
+  }
+
+  // If it's already in proper format or not a UUID, return as lowercase
+  return assetId.toLowerCase();
+};
+
+/**
+ * Extract Bynder asset IDs from all JSON object fields in entry
+ * Recursively searches through all fields to find objects with Bynder asset structure
+ *
+ * @param {Record<string, any>} fields - Entry fields object
+ * @returns {string[]} - Array of unique Bynder asset IDs found
+ */
+export const extractBynderAssetIds = (
+  fields: Record<string, any>,
+): string[] => {
+  const assetIds: Set<string> = new Set();
+
+  /**
+   * Check if an object matches the Bynder asset schema
+   * An object is considered a Bynder asset if it has ALL core Bynder fields:
+   * id, name, dateCreated, dateModified, type, fileSize, extension,
+   * textMetaproperties, width, height, isPublic
+   *
+   * @param obj - The object to validate
+   * @returns true if the object has all required Bynder asset fields
+   */
+  const isBynderAsset = (obj: any): boolean => {
+    if (!obj || typeof obj !== "object") {
+      return false;
+    }
+
+    // Check that ALL core Bynder fields are present
+    return CORE_BYNDER_FIELDS.every((field) => obj.hasOwnProperty(field));
+  };
+
+  /**
+   * Recursively search for Bynder assets in any object structure
+   * Traverses arrays and nested objects to find valid Bynder assets
+   *
+   * @param obj - The object/array to search through
+   */
+  const searchForAssets = (obj: any): void => {
+    if (!obj || typeof obj !== "object") return;
+
+    // Check if this object matches the Bynder asset schema strictly
+    if (isBynderAsset(obj)) {
+      assetIds.add(normalizeAssetId(obj.id));
+    }
+
+    // Recursively search arrays and objects
+    if (Array.isArray(obj)) {
+      obj.forEach((item) => searchForAssets(item));
+    } else if (typeof obj === "object") {
+      Object.values(obj).forEach((value) => searchForAssets(value));
+    }
+  };
+
+  // Search through all fields and their locale values
+  Object.values(fields).forEach((fieldValue) => {
+    if (fieldValue && typeof fieldValue === "object") {
+      // Handle locale-specific values (e.g., { "en-US": [...] })
+      Object.values(fieldValue).forEach((localeValue) => {
+        searchForAssets(localeValue);
+      });
+    }
+  });
+
+  return Array.from(assetIds);
+};

--- a/apps/bynder/functions/__tests__/bynderUtils.test.ts
+++ b/apps/bynder/functions/__tests__/bynderUtils.test.ts
@@ -1,0 +1,994 @@
+import { jest } from "@jest/globals";
+
+// Mock fetch globally before importing the module
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+// Import after mocking
+import {
+  getBynderAccessToken,
+  getAsset,
+  getAssetUsage,
+  createAssetUsage,
+  deleteAssetUsage,
+  extractBynderAssetIds,
+} from "../Utils/bynderUtils";
+import {
+  BynderAuthConfig,
+  BynderResponse,
+  BynderAssetUsageResponse,
+} from "../types";
+
+// Helper to clear the internal token cache between tests
+/**
+ * Creates a unique Bynder configuration for testing purposes.
+ * Since the token cache is not exported, each test needs unique configs to avoid cache conflicts.
+ *
+ * @param suffix - Optional suffix to append to the client ID for additional uniqueness
+ * @returns BynderAuthConfig with unique client ID based on timestamp
+ */
+const createUniqueConfig = (suffix: string = ""): BynderAuthConfig => ({
+  bynderURL: process.env.TEST_BYNDER_URL || "https://test-domain.bynder.com",
+  clientId:
+    (process.env.TEST_BYNDER_CLIENT_ID || "test_client_id") +
+    "_" +
+    Date.now() +
+    suffix,
+  clientSecret: process.env.TEST_BYNDER_CLIENT_SECRET || "test_client_secret",
+});
+
+describe("bynderUtils", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe("getBynderAccessToken", () => {
+    test("should fetch new access token successfully", async () => {
+      const testConfig = createUniqueConfig("_fetch_new");
+      const mockTokenResponse = {
+        access_token: "test_access_token_123",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockTokenResponse,
+      } as Response);
+
+      const token = await getBynderAccessToken(testConfig);
+
+      expect(token).toBe("test_access_token_123");
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${testConfig.bynderURL}/v6/authentication/oauth2/token`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: expect.any(URLSearchParams),
+        },
+      );
+
+      // Check the body parameters
+      const callArgs = mockFetch.mock.calls[0];
+      const body = callArgs[1]?.body as URLSearchParams;
+      expect(body.get("grant_type")).toBe("client_credentials");
+      expect(body.get("client_id")).toBe(testConfig.clientId);
+      expect(body.get("client_secret")).toBe(testConfig.clientSecret);
+    });
+
+    test("should return cached token when available and not expired", async () => {
+      const testConfig = createUniqueConfig("_cache_hit");
+      const mockTokenResponse = {
+        access_token: "cached_token_123",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      // First call - should fetch new token
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockTokenResponse,
+      } as Response);
+
+      const firstToken = await getBynderAccessToken(testConfig);
+      expect(firstToken).toBe("cached_token_123");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Second call - should use cached token
+      const secondToken = await getBynderAccessToken(testConfig);
+      expect(secondToken).toBe("cached_token_123");
+      expect(mockFetch).toHaveBeenCalledTimes(1); // No additional fetch call
+    });
+
+    test("should fetch new token when cache is expired", async () => {
+      const testConfig = createUniqueConfig("_cache_expired");
+
+      // First call with short expiry
+      const firstMockResponse = {
+        access_token: "expired_token",
+        expires_in: 1, // 1 second
+        token_type: "Bearer",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => firstMockResponse,
+      } as Response);
+
+      const firstToken = await getBynderAccessToken(testConfig);
+      expect(firstToken).toBe("expired_token");
+
+      // Wait for token to expire (plus buffer)
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // Second call with new token
+      const secondMockResponse = {
+        access_token: "new_token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => secondMockResponse,
+      } as Response);
+
+      const secondToken = await getBynderAccessToken(testConfig);
+      expect(secondToken).toBe("new_token");
+      expect(mockFetch).toHaveBeenCalledTimes(2); // Two separate fetch calls
+    });
+
+    test("should use different cache keys for different configs", async () => {
+      const config1 = createUniqueConfig("_config1");
+      const config2 = createUniqueConfig("_config2");
+
+      const mockResponse1 = {
+        access_token: "token_for_config1",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      const mockResponse2 = {
+        access_token: "token_for_config2",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      // Mock responses for both configs
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockResponse1,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockResponse2,
+        } as Response);
+
+      // Get tokens for both configs
+      const token1 = await getBynderAccessToken(config1);
+      const token2 = await getBynderAccessToken(config2);
+
+      expect(token1).toBe("token_for_config1");
+      expect(token2).toBe("token_for_config2");
+      expect(mockFetch).toHaveBeenCalledTimes(2); // Both should fetch since they're different configs
+
+      // Verify cache isolation - second calls should use cached values
+      const cachedToken1 = await getBynderAccessToken(config1);
+      const cachedToken2 = await getBynderAccessToken(config2);
+
+      expect(cachedToken1).toBe("token_for_config1");
+      expect(cachedToken2).toBe("token_for_config2");
+      expect(mockFetch).toHaveBeenCalledTimes(2); // No additional fetches
+    });
+
+    test("should handle API error responses", async () => {
+      const uniqueConfig = createUniqueConfig("_error_test");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized",
+      } as unknown as Response);
+
+      await expect(getBynderAccessToken(uniqueConfig)).rejects.toThrow(
+        "Failed to fetch Bynder access token: 401 Unauthorized",
+      );
+    });
+
+    test("should handle network errors", async () => {
+      const uniqueConfig = createUniqueConfig("_network_error");
+
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(getBynderAccessToken(uniqueConfig)).rejects.toThrow(
+        "Network error",
+      );
+    });
+
+    test("should handle bynderURL with trailing slash", async () => {
+      const configWithTrailingSlash = {
+        ...createUniqueConfig("_trailing_slash"),
+        bynderURL: "https://test-domain.bynder.com/",
+      };
+
+      const mockTokenResponse = {
+        access_token: "trailing_slash_token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockTokenResponse,
+      } as Response);
+
+      await getBynderAccessToken(configWithTrailingSlash);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-domain.bynder.com/v6/authentication/oauth2/token",
+        expect.any(Object),
+      );
+    });
+
+    test("should handle missing expires_in in response", async () => {
+      const uniqueConfig = createUniqueConfig("_missing_expires");
+
+      const responseWithoutExpiresIn = {
+        access_token: "token_without_expires",
+        token_type: "Bearer",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => responseWithoutExpiresIn,
+      } as Response);
+
+      const token = await getBynderAccessToken(uniqueConfig);
+      expect(token).toBe("token_without_expires");
+    });
+  });
+
+  describe("getAsset", () => {
+    const mockAssetData = {
+      id: "test-asset-id",
+      name: "Test Asset",
+      fileSize: 1024,
+      type: "image",
+      dateCreated: "2023-01-01T00:00:00Z",
+      dateModified: "2023-01-01T00:00:00Z",
+    };
+
+    test("should fetch asset successfully", async () => {
+      const testConfig = createUniqueConfig("_asset_success");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAssetData,
+      } as Response);
+
+      const result: BynderResponse = await getAsset(
+        testConfig.bynderURL,
+        "mock_token",
+        "test-asset-id",
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual(mockAssetData);
+      expect(result.error).toBeUndefined();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${testConfig.bynderURL}/api/v4/media/test-asset-id?versions=1`,
+        {
+          headers: {
+            Authorization: "Bearer mock_token",
+          },
+          method: "GET",
+        },
+      );
+    });
+
+    test("should handle asset not found (404)", async () => {
+      const testConfig = createUniqueConfig("_asset_404");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      } as unknown as Response);
+
+      const result: BynderResponse = await getAsset(
+        testConfig.bynderURL,
+        "mock_token",
+        "non-existent-asset-id",
+      );
+
+      expect(result.status).toBe(404);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeUndefined();
+    });
+
+    test("should handle unauthorized access (401)", async () => {
+      const testConfig = createUniqueConfig("_asset_401");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      } as unknown as Response);
+
+      const result: BynderResponse = await getAsset(
+        testConfig.bynderURL,
+        "invalid_token",
+        "test-asset-id",
+      );
+
+      expect(result.status).toBe(401);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeUndefined();
+    });
+
+    test("should handle network errors", async () => {
+      const testConfig = createUniqueConfig("_asset_network_error");
+      const networkError = new Error("Network connection failed");
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      const result: BynderResponse = await getAsset(
+        testConfig.bynderURL,
+        "mock_token",
+        "test-asset-id",
+      );
+
+      expect(result.status).toBe(500);
+      expect(result.error).toBe(networkError);
+      expect(result.data).toBeUndefined();
+    });
+
+    test("should construct correct URL with trailing slash in bynderURL", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAssetData,
+      } as Response);
+
+      await getAsset(
+        "https://test-domain.bynder.com/",
+        "mock_token",
+        "test-asset-id",
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-domain.bynder.com/api/v4/media/test-asset-id?versions=1",
+        expect.any(Object),
+      );
+    });
+
+    test("should construct correct URL without trailing slash in bynderURL", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAssetData,
+      } as Response);
+
+      await getAsset(
+        "https://test-domain.bynder.com",
+        "mock_token",
+        "test-asset-id",
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test-domain.bynder.com/api/v4/media/test-asset-id?versions=1",
+        expect.any(Object),
+      );
+    });
+
+    test("should include versions=1 query parameter", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAssetData,
+      } as Response);
+
+      const testConfig = createUniqueConfig("_versions_param");
+      await getAsset(testConfig.bynderURL, "mock_token", "test-asset-id");
+
+      const expectedUrl = `${testConfig.bynderURL}/api/v4/media/test-asset-id?versions=1`;
+      expect(mockFetch).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+    });
+
+    test("should handle different asset IDs", async () => {
+      const testConfig = createUniqueConfig("_different_assets");
+      const assetIds = ["asset-1", "asset-2", "asset-3"];
+
+      for (const assetId of assetIds) {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ ...mockAssetData, id: assetId }),
+        } as Response);
+
+        const result = await getAsset(
+          testConfig.bynderURL,
+          "mock_token",
+          assetId,
+        );
+
+        expect(result.status).toBe(200);
+        expect(result.data).toEqual({ ...mockAssetData, id: assetId });
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    test("should handle empty response body for non-200 status", async () => {
+      const testConfig = createUniqueConfig("_empty_response");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error("No JSON body");
+        },
+      } as unknown as Response);
+
+      const result: BynderResponse = await getAsset(
+        testConfig.bynderURL,
+        "mock_token",
+        "test-asset-id",
+      );
+
+      expect(result.status).toBe(500);
+      expect(result.data).toBeUndefined();
+    });
+  });
+
+  describe("Integration tests", () => {
+    test("should work with getBynderAccessToken and getAsset together", async () => {
+      const integrationConfig = createUniqueConfig("_integration");
+
+      const mockTokenResponse = {
+        access_token: "integration_test_token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      };
+
+      const mockAssetData = {
+        id: "integration-asset-id",
+        name: "Integration Test Asset",
+        fileSize: 2048,
+        type: "image",
+        dateCreated: "2023-01-01T00:00:00Z",
+        dateModified: "2023-01-01T00:00:00Z",
+      };
+
+      // Mock token fetch
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockTokenResponse,
+      } as Response);
+
+      // Mock asset fetch
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAssetData,
+      } as Response);
+
+      // Get token first
+      const token = await getBynderAccessToken(integrationConfig);
+      expect(token).toBe("integration_test_token");
+
+      // Use token to get asset
+      const assetResult = await getAsset(
+        integrationConfig.bynderURL,
+        token,
+        "integration-asset-id",
+      );
+
+      expect(assetResult.status).toBe(200);
+      expect(assetResult.data).toEqual(mockAssetData);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    describe("getAssetUsage", () => {
+      const mockUsageResponse: BynderAssetUsageResponse = [
+        {
+          asset_id: "test-asset-id-1",
+          id: "usage-id-1",
+          integration: {
+            id: "ac534173-7ee1-493b-98b7-a6d88ce7a450",
+            description: "Contentful",
+          },
+          timestamp: "2023-01-01T12:00:00Z",
+          uri: "/contentful/entry/123",
+          additional: "Test usage",
+        },
+      ];
+
+      test("should fetch asset usage successfully", async () => {
+        const testConfig = createUniqueConfig("_usage_success");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => mockUsageResponse,
+        } as Response);
+
+        const result = await getAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "/contentful/entry/123",
+          "test-asset-id-1",
+        );
+
+        expect(result.status).toBe(200);
+        expect(result.data).toEqual(mockUsageResponse);
+
+        // Check URL construction with query parameters
+        const expectedUrl = `${testConfig.bynderURL}/api/media/usage?integration_id=ac534173-7ee1-493b-98b7-a6d88ce7a450&uri=%2Fcontentful%2Fentry%2F123&asset_id=test-asset-id-1`;
+        expect(mockFetch).toHaveBeenCalledWith(expectedUrl, {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer mock_token",
+          },
+        });
+      });
+
+      test("should handle empty usage response", async () => {
+        const testConfig = createUniqueConfig("_usage_empty");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => [],
+        } as Response);
+
+        const result = await getAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "test-asset-id",
+          "/contentful/entry/456",
+        );
+
+        expect(result.status).toBe(200);
+        expect(result.data).toEqual([]);
+      });
+
+      test("should handle network errors", async () => {
+        const testConfig = createUniqueConfig("_usage_network_error");
+        const networkError = new Error("Network connection failed");
+        mockFetch.mockRejectedValueOnce(networkError);
+
+        const result = await getAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "test-asset-id",
+          "/contentful/entry/123",
+        );
+
+        expect(result.status).toBe(500);
+        expect(result.error).toBe(networkError);
+      });
+    });
+
+    describe("createAssetUsage", () => {
+      const mockCreateResponse = {
+        id: "new-usage-id",
+        uri: "/contentful/entry/789",
+        additional: "New usage created",
+        asset_id: "test-asset-id-2",
+        timestamp: "2023-01-01T12:30:00Z",
+        integration: {
+          id: "ac534173-7ee1-493b-98b7-a6d88ce7a450",
+          description: "Contentful",
+        },
+      };
+
+      test("should create asset usage successfully", async () => {
+        const testConfig = createUniqueConfig("_create_success");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          json: async () => mockCreateResponse,
+        } as Response);
+
+        const result = await createAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "test-asset-id-2",
+          "/contentful/entry/789",
+          "New usage created",
+        );
+
+        expect(result.status).toBe(201);
+        expect(result.data).toEqual(mockCreateResponse);
+
+        // Check that the request was made with correct parameters
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${testConfig.bynderURL}/api/media/usage`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer mock_token",
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: expect.any(String),
+          },
+        );
+
+        // Check the body content
+        const callArgs = mockFetch.mock.calls[0];
+        const bodyString = callArgs[1]?.body as string;
+        const bodyParams = new URLSearchParams(bodyString);
+
+        expect(bodyParams.get("asset_id")).toBe("test-asset-id-2");
+        expect(bodyParams.get("integration_id")).toBe(
+          "ac534173-7ee1-493b-98b7-a6d88ce7a450",
+        );
+        expect(bodyParams.get("uri")).toBe("/contentful/entry/789");
+        expect(bodyParams.get("additional")).toBe("New usage created");
+        expect(bodyParams.get("timestamp")).toMatch(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+        ); // ISO8601 format
+      });
+
+      test("should handle creation errors", async () => {
+        const testConfig = createUniqueConfig("_create_error");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          json: async () => ({ error: "Bad request" }),
+        } as unknown as Response);
+
+        const result = await createAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "invalid-asset-id",
+          "/contentful/entry/invalid",
+          "Invalid usage",
+        );
+
+        expect(result.status).toBe(400);
+        expect(result.data).toBeUndefined();
+      });
+    });
+
+    describe("deleteAssetUsage", () => {
+      test("should delete asset usage successfully", async () => {
+        const testConfig = createUniqueConfig("_delete_success");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 204,
+          json: async () => ({}),
+        } as Response);
+
+        const result = await deleteAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "test-asset-id-3",
+          "/contentful/entry/delete-test",
+        );
+
+        expect(result.status).toBe(204);
+
+        // Check URL construction with query parameters for DELETE
+        const expectedUrl = `${testConfig.bynderURL}/api/media/usage?integration_id=ac534173-7ee1-493b-98b7-a6d88ce7a450&asset_id=test-asset-id-3&uri=%2Fcontentful%2Fentry%2Fdelete-test`;
+        expect(mockFetch).toHaveBeenCalledWith(expectedUrl, {
+          method: "DELETE",
+          headers: {
+            Authorization: "Bearer mock_token",
+          },
+        });
+      });
+
+      test("should handle delete errors", async () => {
+        const testConfig = createUniqueConfig("_delete_error");
+
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          json: async () => ({ error: "Usage not found" }),
+        } as unknown as Response);
+
+        const result = await deleteAssetUsage(
+          testConfig.bynderURL,
+          "mock_token",
+          "non-existent-asset",
+          "/contentful/entry/not-found",
+        );
+
+        expect(result.status).toBe(404);
+      });
+    });
+
+    describe("extractBynderAssetIds", () => {
+      /**
+       * Helper function to create complete Bynder asset objects with all core required fields.
+       * This ensures test assets pass the strict validation logic that requires all core fields.
+       *
+       * @param id - The asset ID to use
+       * @param overrides - Optional object to override any default field values
+       * @returns Complete Bynder asset object with all core fields populated
+       */
+      const createCompleteAsset = (id: string, overrides: any = {}) => ({
+        id: id,
+        name: `Test Asset ${id}`,
+        dateCreated: "2023-01-01T00:00:00Z",
+        dateModified: "2023-01-01T00:00:00Z",
+        type: "image",
+        fileSize: 1024,
+        extension: ["jpg"],
+        textMetaproperties: [],
+        width: 800,
+        height: 600,
+        isPublic: 0,
+        // Additional fields that might be present
+        brandId: "brand-123",
+        thumbnails: { webimage: "https://test.bynder.com/thumb.jpg" },
+        src: "https://test.bynder.com/original.jpg",
+        ...overrides,
+      });
+
+      test("should extract asset IDs from complete bynder asset objects", () => {
+        const fields = {
+          bynderImages: {
+            "en-US": [
+              createCompleteAsset("asset-1"),
+              createCompleteAsset("asset-2"),
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["asset-1", "asset-2"]);
+      });
+
+      test("should extract asset IDs from multiple locales", () => {
+        const fields = {
+          bynderFiles: {
+            "en-US": [
+              createCompleteAsset("asset-en-1", { name: "English Asset" }),
+            ],
+            "fr-FR": [
+              createCompleteAsset("asset-fr-1", { name: "French Asset" }),
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["asset-en-1", "asset-fr-1"]);
+      });
+
+      test("should extract asset IDs from nested structures", () => {
+        const fields = {
+          richText: {
+            "en-US": {
+              content: [
+                {
+                  data: {
+                    bynderAsset: createCompleteAsset("nested-asset-1"),
+                  },
+                },
+              ],
+            },
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["nested-asset-1"]);
+      });
+
+      test("should handle assets with brandId", () => {
+        const fields = {
+          customField: {
+            "en-US": {
+              assets: [
+                createCompleteAsset("brand-asset-1", { brandId: "brand-456" }),
+              ],
+            },
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["brand-asset-1"]);
+      });
+
+      test("should deduplicate asset IDs", () => {
+        const fields = {
+          field1: {
+            "en-US": [
+              createCompleteAsset("duplicate-asset", {
+                name: "Duplicate Asset 1",
+              }),
+            ],
+          },
+          field2: {
+            "en-US": [
+              createCompleteAsset("duplicate-asset", {
+                name: "Duplicate Asset 2",
+              }),
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["duplicate-asset"]);
+      });
+
+      test("should ignore non-Bynder objects", () => {
+        const fields = {
+          regularField: {
+            "en-US": "Just a string",
+          },
+          objectWithoutBynderStructure: {
+            "en-US": {
+              id: "not-bynder",
+              title: "Regular object",
+              // Missing most Bynder-specific properties
+            },
+          },
+          bynderField: {
+            "en-US": [createCompleteAsset("real-bynder-asset")],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["real-bynder-asset"]);
+      });
+
+      test("should handle empty fields", () => {
+        const assetIds = extractBynderAssetIds({});
+        expect(assetIds).toEqual([]);
+      });
+
+      test("should handle null and undefined values", () => {
+        const fields = {
+          nullField: {
+            "en-US": null,
+          },
+          undefinedField: {
+            "en-US": undefined,
+          },
+          emptyArray: {
+            "en-US": [],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual([]);
+      });
+
+      test("should normalize UUID format with missing hyphens", () => {
+        const fields = {
+          bynderAssets: {
+            "en-US": [
+              createCompleteAsset("681d7df7e6e04d219c92f0c5e2ad90e3"), // Missing hyphens
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["681d7df7-e6e0-4d21-9c92-f0c5e2ad90e3"]); // Properly formatted UUID
+      });
+
+      test("should handle already properly formatted UUIDs", () => {
+        const fields = {
+          bynderAssets: {
+            "en-US": [
+              createCompleteAsset("681d7df7-e6e0-4d21-9c92-f0c5e2ad90e3"), // Already formatted
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["681d7df7-e6e0-4d21-9c92-f0c5e2ad90e3"]); // Should remain the same
+      });
+
+      test("should detect Bynder assets with custom domains and complete schema", () => {
+        const fields = {
+          bynderAssets: {
+            "en-US": [
+              createCompleteAsset("custom-domain-asset-1", {
+                original: "https://my-company.assets.com/media/123",
+                thumbnails: {
+                  webimage: "https://my-company.assets.com/thumb/123",
+                },
+              }),
+              createCompleteAsset("brand-asset-2", {
+                brandId: "brand-456",
+              }),
+            ],
+          },
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["custom-domain-asset-1", "brand-asset-2"]);
+      });
+
+      test("should detect real Bynder asset structure from production", () => {
+        const fields = {
+          "en-US": [
+            {
+              id: "4FA2A955-7106-412F-AF75164286819016",
+              src: "https://appnovation.bynder.com/m/4a54296e1c03af84/webimage-daniel-gzz-ELC0hD4AwB0-unsplash.png",
+              name: "daniel-gzz-ELC0hD4AwB0-unsplash",
+              tags: [],
+              type: "image",
+              width: 6211,
+              height: 4145,
+              archive: 0,
+              brandId: "7EC8B6F7-08AA-474B-AE6F97BA1BFFD82F",
+              limited: 0,
+              fileSize: 998645,
+              isPublic: 0,
+              original: null,
+              copyright: null,
+              extension: ["jpg"],
+              thumbnails: {
+                mini: "https://appnovation.bynder.com/m/4a54296e1c03af84/mini-daniel-gzz-ELC0hD4AwB0-unsplash.png",
+                thul: "https://appnovation.bynder.com/m/4a54296e1c03af84/thul-daniel-gzz-ELC0hD4AwB0-unsplash.png",
+                Banner:
+                  "https://appnovation.bynder.com/m/4a54296e1c03af84/Banner-daniel-gzz-ELC0hD4AwB0-unsplash.jpg",
+                webimage:
+                  "https://appnovation.bynder.com/m/4a54296e1c03af84/webimage-daniel-gzz-ELC0hD4AwB0-unsplash.png",
+                Instagram:
+                  "https://appnovation.bynder.com/m/4a54296e1c03af84/Instagram-daniel-gzz-ELC0hD4AwB0-unsplash.jpg",
+                transformBaseUrl:
+                  "https://appnovation.bynder.com/transform/4fa2a955-7106-412f-af75-164286819016/daniel-gzz-ELC0hD4AwB0-unsplash",
+              },
+              dateCreated: "2024-07-11T23:00:35Z",
+              description: "Daniel description",
+              orientation: "landscape",
+              watermarked: 0,
+              dateModified: "2024-08-29T09:00:01Z",
+              datePublished: "2021-11-09T10:03:44Z",
+              videoPreviewURLs: [],
+              textMetaproperties: [],
+            },
+          ],
+        };
+
+        const assetIds = extractBynderAssetIds(fields);
+        expect(assetIds).toEqual(["4fa2a955-7106-412f-af75-164286819016"]); // Should be normalized to lowercase with hyphens
+      });
+    });
+  });
+
+  describe("URL construction tests", () => {
+    test("getBynderAssetUrl should handle URLs with trailing slash", () => {
+      // Test indirectly by checking the URL construction in getAsset
+      const baseUrl = "https://test-domain.bynder.com/";
+      expect(baseUrl.endsWith("/")).toBe(true);
+
+      // The function should remove trailing slash and add /api/v4/media
+      const expectedBase = "https://test-domain.bynder.com";
+      expect(baseUrl.slice(0, -1)).toBe(expectedBase);
+    });
+
+    test("getBynderAssetUrl should handle URLs without trailing slash", () => {
+      // Test indirectly by checking the URL construction in getAsset
+      const baseUrl = "https://test-domain.bynder.com";
+      expect(baseUrl.endsWith("/")).toBe(false);
+
+      // The function should add /api/v4/media directly
+      const expectedUrl = baseUrl + "/api/v4/media";
+      expect(expectedUrl).toBe("https://test-domain.bynder.com/api/v4/media");
+    });
+  });
+});

--- a/apps/bynder/functions/asset-tracker.ts
+++ b/apps/bynder/functions/asset-tracker.ts
@@ -1,0 +1,192 @@
+import {
+  FunctionEventHandler,
+  FunctionTypeEnum,
+  FunctionEventContext,
+  AppEventRequest,
+} from "@contentful/node-apps-toolkit";
+import {
+  getBynderAccessToken,
+  createAssetUsage,
+  extractBynderAssetIds,
+  getAssetUsage,
+  deleteAssetUsage,
+} from "./Utils/bynderUtils";
+import { BynderAuthConfig, BynderAssetUsageResponse } from "./types";
+
+/**
+ * App Event Handler for Bynder Asset Usage Tracking
+ *
+ * This handler tracks when Bynder assets are used in Contentful entries
+ * and syncs this usage information with Bynder's Asset Usage API.
+ *
+ * Handles the following events:
+ * - Entry.publish: Creates asset usage records
+ * - Entry.unpublish: Removes asset usage records
+ * - Entry.save: Updates asset usage records
+ *
+ * @param event - The app event to be handled
+ * @param context - The execution context
+ * @returns None - App event handlers don't return a response
+ */
+export const handler: FunctionEventHandler<
+  FunctionTypeEnum.AppEventHandler
+> = async (event: AppEventRequest, context: FunctionEventContext) => {
+  try {
+    const topic = event.headers["X-Contentful-Topic"];
+    // Only process Entry events
+    if (!topic?.includes("Entry")) {
+      return;
+    }
+    // Determine action based on event type
+    let shouldRemove = false;
+    if (
+      topic.includes("unpublish") ||
+      topic.includes("delete") ||
+      (topic.includes("archive") && !topic.includes("unarchive"))
+    ) {
+      shouldRemove = true;
+    }
+    // Only create an usage on publish.
+    else if (!topic.includes("publish")) {
+      return;
+    }
+
+    // Extract entry information.
+    const entryData = event.body as any; // Type assertion to handle various event payload types
+    const entryId = entryData?.sys?.id;
+    const spaceId = context.spaceId;
+    const environmentId = context.environmentId;
+
+    if (!entryId) {
+      return;
+    }
+    // Only process in master environment
+    if (environmentId !== "master") {
+      return;
+    }
+
+    // Get Bynder configuration from app installation parameters
+    const { bynderURL, clientId, clientSecret } =
+      context.appInstallationParameters || {};
+
+    if (!bynderURL || !clientId || !clientSecret) {
+      return;
+    }
+
+    // Get Bynder access token
+    const bynderConfig: BynderAuthConfig = {
+      bynderURL,
+      clientId,
+      clientSecret,
+    };
+    const accessToken = await getBynderAccessToken(bynderConfig);
+
+    // Create usage URI and additional context
+    const uri = `https://app.contentful.com/spaces/${spaceId}/environments/${environmentId}/entries/${entryId}`;
+    const additional = JSON.stringify({
+      spaceId,
+      environmentId,
+      entryId,
+      timestamp: new Date().toISOString(),
+    });
+
+    let assetsToProcess: string[] = [];
+
+    // For delete/unpublish/archive events, get assets from Usage API since fields are not available
+    if (shouldRemove) {
+      try {
+        const usageResponse = await getAssetUsage(bynderURL, accessToken, uri);
+
+        if (usageResponse.status === 200 && usageResponse.data) {
+          const usageData = usageResponse.data as BynderAssetUsageResponse;
+          assetsToProcess = usageData.map((entry) =>
+            entry.asset_id.toLowerCase(),
+          );
+        } else {
+          return;
+        }
+      } catch (error) {
+        console.error("Error getting existing usage for delete/unpublish:", error);
+        return;
+      }
+    } else {
+      // For publish events, extract asset IDs from entry fields
+      const assetIds = extractBynderAssetIds(entryData.fields || {});
+      assetsToProcess = assetIds;
+    }
+
+    // For publish events, first check for removed assets and clean them up
+    if (!shouldRemove && topic.includes("publish")) {
+      try {
+        // Get all usage for this URI (without specifying asset_id)
+        const usageResponse = await getAssetUsage(bynderURL, accessToken, uri);
+
+        if (usageResponse.status === 200 && usageResponse.data) {
+          const usageData = usageResponse.data as BynderAssetUsageResponse;
+
+          // Extract all asset IDs that have usage for this URI (normalize to lowercase)
+          const usageAssetIds = usageData.map((entry) =>
+            entry.asset_id.toLowerCase(),
+          );
+
+          // Find assets to remove (exist in usage but not in current entry fields)
+          const assetsToRemove = usageAssetIds.filter(
+            (id) => !assetsToProcess.includes(id),
+          );
+
+          // Find assets to add (exist in current entry but not in usage)
+          const assetsToAdd = assetsToProcess.filter(
+            (id) => !usageAssetIds.includes(id),
+          );
+
+          if (assetsToRemove.length > 0) {
+            // Remove usage for assets no longer in the entry using deleteAssetUsage directly
+            await Promise.allSettled(
+              assetsToRemove.map(async (assetId) => {
+                try {
+                  await deleteAssetUsage(
+                    bynderURL,
+                    accessToken,
+                    assetId,
+                    uri,
+                  );
+                } catch (error) {
+                  console.error(`Failed to remove usage for asset ${assetId}:`, error);
+                }
+              }),
+            );
+          }
+
+          // Only process assets that need to be added (not already tracked)
+          assetsToProcess = assetsToAdd;
+        }
+      } catch (error) {
+        console.error("Error checking for removed assets:", error);
+      }
+    }
+
+    // Sync usage for assets that need processing
+    await Promise.allSettled(
+      assetsToProcess.map(async (assetId) => {
+        try {
+          const result = shouldRemove
+            ? await deleteAssetUsage(bynderURL, accessToken, assetId, uri)
+            : await createAssetUsage(
+                bynderURL,
+                accessToken,
+                assetId,
+                uri,
+                additional,
+              );
+          return { assetId, result };
+        } catch (error) {
+          console.error(`Failed to sync usage for asset ${assetId}:`, error);
+          throw error;
+        }
+      }),
+    );
+  } catch (error) {
+    console.error("Error in Bynder Asset Tracker:", error);
+  }
+  return;
+};

--- a/apps/bynder/functions/external-ref.ts
+++ b/apps/bynder/functions/external-ref.ts
@@ -1,0 +1,332 @@
+import type { FunctionEventHandler as EventHandler } from "@contentful/node-apps-toolkit";
+import { getAsset, getBynderAccessToken } from "./Utils/bynderUtils";
+import { createSchema, createYoga } from "graphql-yoga";
+import { GraphQLError } from "graphql";
+import { DateTimeResolver, JSONResolver } from "graphql-scalars";
+import { Asset, BynderFunctionEventContext } from "./types";
+
+/*
+ * We define our GraphQL schema for output here.
+ */
+const typeDefs = `
+"""
+Custom scalar type for DateTime values
+"""
+scalar DateTime
+
+"""
+Custom scalar type for JSON objects
+"""
+scalar JSON
+
+"""
+Represents media items associated with a Bynder asset, including different file formats and transformations
+"""
+type MediaItems {
+  "Unique identifier for the media item"
+  id: ID!
+  "Original filename of the media item"
+  fileName: String!
+  "Date when the media item was created"
+  dateCreated: DateTime!
+  "File size of the media item in bytes"
+  size: Int!
+  "MIME type or format of the media item"
+  type: String!
+  "Version number of the media item"
+  version: Int
+  "Width of the media item in pixels (for images/videos)"
+  width: Int
+  "Height of the media item in pixels (for images/videos)"
+  height: Int
+  "Available thumbnail URLs and transformations for the media item"
+  thumbnails: JSON
+  "Whether the media item is currently active"
+  active: Boolean
+  "Focus point coordinates for cropping and transformations"
+  focusPoint: JSON
+}
+
+"""
+Represents a Bynder asset with all its metadata, properties, and associated media items
+"""
+type Asset {
+  "Unique identifier for the Bynder asset"
+  id: ID!
+  "Display name of the asset"
+  name: String!
+  "File size of the original asset in bytes"
+  fileSize: Int!
+  "Asset type (image, video, document, audio)"
+  type: String!
+  "Description or caption for the asset"
+  description: String
+  "Hash identifier for the asset"
+  idHash: String
+  "Tags associated with the asset for categorization"
+  tags: [String]
+  "Webimage thumbnail URL of an asset"
+  src: String
+  "Width of the asset in pixels (for images/videos)"
+  width: Int
+  "Height of the asset in pixels (for images/videos)"
+  height: Int
+  "Whether the asset is archived"
+  archive: Boolean
+  "Brand identifier associated with the asset"
+  brandId: String
+  "Whether the asset has limited usage rights"
+  limited: Boolean
+  "Whether the asset is publicly accessible"
+  isPublic: Boolean
+  "URL to the original asset file"
+  original: String
+  "Copyright information for the asset"
+  copyright: String
+  "File extensions available for the asset"
+  extension: [String]
+  "Orientation of the asset (landscape, portrait, square)"
+  orientation: String
+  "Whether the asset has a watermark applied"
+  watermarked: Boolean
+  "Available thumbnail URLs and transformations"
+  thumbnails: JSON
+  "Preview URLs for video assets"
+  videoPreviewURLs: [String]
+  "Custom text metadata properties"
+  textMetaproperties: [String]
+  "User who created the asset"
+  userCreated: String
+  "Active focus point for the original asset"
+  activeOriginalFocusPoint: JSON
+  "Date when the asset was created"
+  dateCreated: DateTime!
+  "Date when the asset was last modified"
+  dateModified: DateTime!
+  "Date when the asset was published"
+  datePublished: DateTime
+  "Base URL for asset transformations"
+  transformBaseUrl: String
+  "Available property options for the asset"
+  propertyOptions: [String]
+  "Campaign property values"
+  property_Campaign: [String]
+  "File extension property values"
+  property_File_extension: [String]
+  "Department property values"
+  property_Department: [String]
+  "Industry property values"
+  property_Industry: [String]
+  "Language property values"
+  property_Language: [String]
+  "Usage rights property values"
+  property_Usage_Rights: [String]
+  "Asset type property values"
+  property_Asset_Type: [String]
+  "Asset subtype property values"
+  property_Asset_SubType: [String]
+  "Related assets linked to this asset"
+  relatedAssets: [JSON]
+  "Media items associated with this asset"
+  mediaItems: [MediaItems]
+}
+
+"""
+Root query type for accessing Bynder assets
+"""
+type Query {
+  "Retrieve a Bynder asset by its original asset data"
+  asset(
+    "The original asset object containing the asset ID and metadata"
+    originalAsset: JSON!
+  ): Asset
+}
+`;
+
+/**
+ * Typed Schema for our custom GraphQL server with context.
+ */
+const schema = createSchema({
+  typeDefs,
+  resolvers: {
+    JSON: JSONResolver,
+    DateTime: DateTimeResolver,
+    Query: {
+      asset: async (
+        _parent,
+        { originalAsset },
+        _context: BynderFunctionEventContext,
+      ) => {
+        const { bynderAccessToken } = _context;
+        const { bynderURL } = _context.appInstallationParameters;
+        const assetId = originalAsset.id ?? null;
+        // Preliminary checks on the passed data.
+        if (assetId === null) {
+          throw new GraphQLError(
+            `The Json field has a malformed asset. Please try to add an asset again`,
+          );
+        }
+        if (!bynderURL || !bynderAccessToken) {
+          throw new GraphQLError(
+            `Bynder external references are not configured. Please set a valid Bynder URL, client ID, and client secret in the app config page.`,
+          );
+        }
+        // Call the Bynder API and get the output.
+        const response = await getAsset(
+          bynderURL,
+          _context.bynderAccessToken!,
+          assetId,
+        );
+        if (response.status === 200) {
+          return convertToGraphQLType(response.data);
+        }
+        if (response.status === 404) {
+          throw new GraphQLError(
+            `Asset not found on Bynder. Possibly it was deleted. Try to refresh the asset from the entry.`,
+          );
+        } else if (response.status === 401) {
+          throw new GraphQLError(
+            `Bad Request. Please set a valid Bynder client ID and secret on the app config page.`,
+          );
+        } else {
+          throw new GraphQLError(
+            `Bynder API returned a non-200 status code: Error code: ${response.status}`,
+          );
+        }
+      },
+    },
+  },
+});
+
+/**
+ * Convert API output to GraphQAL output.
+ *
+ * @param rawAsset
+ *  Raw response of an asset received by API.
+ * @returns Asset
+ *  Transformed Asset.
+ */
+const convertToGraphQLType = (rawAsset: any): Asset => {
+  // Fetch the webimage
+  const thumbnails =
+    typeof rawAsset["thumbnails"] === "string"
+      ? JSON.parse(rawAsset["thumbnails"])
+      : (rawAsset["thumbnails"] ?? {});
+
+  // GraphQL schema doesn't accept hyphens (-), hence this basic transformation of this asset key.
+  return {
+    ...rawAsset,
+    src: thumbnails["webimage"] ?? "",
+    property_Asset_SubType: rawAsset["property_Asset_Sub-Type"] ?? null,
+  };
+};
+
+// Create GraphQL Yoga server with introspection enabled for schema documentation
+const yogaGraphQlServer = createYoga({
+  schema,
+  graphiql: false,
+});
+
+/**
+ * Query Event handler to do the actual query to our custom GraphQL server.
+ *
+ * @param event
+ * @param context
+ * @returns
+ */
+const queryHandler: EventHandler<"graphql.query"> = async (
+  event,
+  context: BynderFunctionEventContext,
+) => {
+  const { query, operationName, variables } = event;
+
+  // Fetch Bynder access token once per function request and add to context
+  const { bynderURL, clientId, clientSecret } =
+    context.appInstallationParameters || {};
+  let bynderAccessToken: string = "";
+  if (bynderURL && clientId && clientSecret) {
+    try {
+      bynderAccessToken = await getBynderAccessToken({
+        bynderURL,
+        clientId,
+        clientSecret,
+      });
+    } catch (err) {
+      // Optionally log or handle token fetch error
+      bynderAccessToken = "";
+    }
+  }
+  // Attach token to context for use in resolvers
+  const extendedContext = { ...context, bynderAccessToken };
+
+  const body = JSON.stringify({
+    query,
+    operationName,
+    variables,
+  });
+  const request = {
+    body,
+    method: "post",
+    headers: {
+      accept: "application/graphql-response+json",
+      "content-type": "application/json",
+    },
+  };
+  // Call our custom graphQL server (URL doesn't matter) and wrap the output with GraphQL.
+  const response = await yogaGraphQlServer.fetch(
+    "http://bynderPlugin.com/graphql",
+    request,
+    extendedContext,
+  );
+  if (response.type !== "default") {
+    throw new GraphQLError("Unsupported GraphQL result type");
+  }
+  return response.json();
+};
+
+/**
+ * Field mapping handler to return a typed schema for the bynder field.
+ *
+ * @param event
+ * @param context
+ * @returns
+ */
+const fieldMappingHandler: EventHandler<"graphql.field.mapping"> = (
+  event,
+  context,
+) => {
+  // Define the field mapping to map the external api to
+  // the field in the content type
+  const fields = event.fields.map(({ contentTypeId, field }) => ({
+    contentTypeId,
+    fieldId: field.id,
+    graphQLQueryField: "asset",
+    graphQLOutputType: "[Asset]",
+    graphQLQueryArguments: { originalAsset: "" },
+  }));
+
+  // Return the mapping and the namespace.
+  // The namespace is used to namespace the
+  // GraphQL types from the third party API.
+  return {
+    namespace: "Bynder",
+    fields,
+  };
+};
+
+/**
+ * Event handler to assign handlers on GraphQL Events.
+ *
+ * @param event
+ * @param context
+ * @returns
+ */
+export const handler: EventHandler = (event, context) => {
+  if (event.type === "graphql.field.mapping") {
+    return fieldMappingHandler(event, context);
+  }
+  if (event.type === "graphql.query") {
+    return queryHandler(event, context);
+  }
+  throw new GraphQLError("Unknown Event");
+};

--- a/apps/bynder/functions/types.ts
+++ b/apps/bynder/functions/types.ts
@@ -1,0 +1,154 @@
+import type { FunctionEventContext } from "@contentful/node-apps-toolkit";
+
+export interface BynderResponse {
+  status: number;
+  error?: Object;
+  data?: Asset | BynderAssetUsageResponse | Object;
+}
+export interface BynderAuthConfig {
+  bynderURL: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface TokenCacheEntry {
+  accessToken: string;
+  expiresAt: number; // epoch ms
+}
+
+export interface BynderTokenResponse {
+  access_token: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+export interface Asset {
+  id: string;
+  name: string;
+  fileSize: number;
+  description?: string;
+  type: string;
+  idHash?: string;
+  tags?: string[];
+  src: string;
+  width?: number;
+  height?: number;
+  archive?: boolean;
+  brandId?: string;
+  limited?: boolean;
+  isPublic?: boolean;
+  original?: string;
+  copyright?: string;
+  extension?: string[];
+  orientation?: string;
+  watermarked?: boolean;
+  thumbnails?: any;
+  videoPreviewURLs?: string[];
+  textMetaproperties?: string[];
+  userCreated?: string;
+  activeOriginalFocusPoint?: any;
+  dateCreated: string;
+  dateModified: string;
+  datePublished?: string;
+  transformBaseUrl?: string;
+  propertyOptions?: string[];
+  property_Campaign?: string[];
+  property_File_extension?: string[];
+  property_Department?: string[];
+  property_Industry?: string[];
+  property_Language?: string[];
+  property_Usage_Rights?: string[];
+  property_Asset_Type?: string[];
+  property_Asset_SubType?: string[];
+  relatedAssets?: any[];
+  mediaItems?: any[];
+}
+
+export interface BynderFunctionEventContext extends FunctionEventContext {
+  bynderAccessToken?: string;
+}
+
+// App Event related types
+export interface AppEventPayload {
+  sys: {
+    type: string;
+    id: string;
+    space: {
+      sys: {
+        type: string;
+        linkType: string;
+        id: string;
+      };
+    };
+    environment: {
+      sys: {
+        id: string;
+        type: string;
+        linkType: string;
+      };
+    };
+    contentType?: {
+      sys: {
+        type: string;
+        linkType: string;
+        id: string;
+      };
+    };
+    createdBy?: {
+      sys: {
+        type: string;
+        linkType: string;
+        id: string;
+      };
+    };
+    updatedBy?: {
+      sys: {
+        type: string;
+        linkType: string;
+        id: string;
+      };
+    };
+    revision?: number;
+    createdAt?: string;
+    updatedAt?: string;
+  };
+  fields?: Record<string, any>;
+}
+
+export interface AppEventContext {
+  eventType: string;
+  entityType: string;
+  entityId: string;
+  spaceId: string;
+  environmentId: string;
+  userId?: string;
+  timestamp: string;
+}
+
+export interface BynderAssetUsageEvent {
+  assetId: string;
+  entryId: string;
+  contentTypeId: string;
+  fieldId: string;
+  action: "added" | "removed" | "updated";
+  timestamp: string;
+  spaceId: string;
+  environmentId: string;
+}
+
+// Bynder Asset Usage API types
+export interface BynderIntegration {
+  id: string;
+  description: string;
+}
+
+export interface BynderAssetUsage {
+  asset_id: string;
+  id: string;
+  integration: BynderIntegration;
+  timestamp: string;
+  uri: string | null;
+  additional: string | null;
+}
+
+export type BynderAssetUsageResponse = BynderAssetUsage[];

--- a/apps/bynder/jest.config.js
+++ b/apps/bynder/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/functions'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  collectCoverageFrom: [
+    'functions/**/*.ts',
+    '!functions/**/*.d.ts',
+  ],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      useESM: false,
+      tsconfig: {
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+      },
+    }],
+  },
+  extensionsToTreatAsEsm: [],
+  transformIgnorePatterns: [
+    'node_modules/(?!(node-fetch)/)',
+  ],
+};

--- a/apps/bynder/jest.setup.js
+++ b/apps/bynder/jest.setup.js
@@ -1,0 +1,9 @@
+// Jest setup file for global test configuration
+// Mock fetch instead of importing node-fetch
+global.fetch = jest.fn();
+
+// Mock console.log to avoid noise in tests
+global.console = {
+  ...console,
+  log: jest.fn(),
+};

--- a/apps/bynder/src/index.jsx
+++ b/apps/bynder/src/index.jsx
@@ -1,0 +1,346 @@
+import pick from 'lodash/pick';
+import { setup } from '@contentful/dam-app-base';
+
+import logo from './logo.svg';
+
+const CTA = 'Select a file on Bynder';
+const BYNDER_BASE_URL = 'https://d8ejoa1fys2rk.cloudfront.net';
+const BYNDER_SDK_URL = `${BYNDER_BASE_URL}/5.0.5/modules/compactview/bynder-compactview-5-latest.js`;
+
+const FIELDS_TO_PERSIST = [
+  'archive',
+  'brandId',
+  'copyright',
+  'dateCreated',
+  'dateModified',
+  'datePublished',
+  'description',
+  'extension',
+  'fileSize',
+  'height',
+  'id',
+  'isPublic',
+  'limited',
+  'name',
+  'orientation',
+  'original',
+  'thumbnails',
+  'type',
+  'watermarked',
+  'width',
+  'videoPreviewURLs',
+  'tags',
+  'selectedFile',
+  'textMetaproperties',
+];
+
+const FIELD_SELECTION = `
+  databaseId
+  type
+  tags
+  orientation
+  description
+  isArchived
+  fileSize
+  height
+  width
+  copyright
+  extensions
+  createdBy
+  isWatermarked
+  isLimitedUse
+  isPublic
+  brandId
+  name
+  publishedAt
+  updatedAt
+  createdAt
+  files
+  originalUrl
+  textMetaproperties {
+    name
+    value
+  }
+  ... on Video {
+    previewUrls
+  }
+`;
+
+const validAssetTypes = ['image', 'audio', 'document', 'video'];
+
+function makeThumbnail(resource) {
+  const thumbnail = (resource.thumbnails && resource.thumbnails.webimage) || resource.src;
+  const url = typeof thumbnail === 'string' ? thumbnail : undefined;
+  const alt = `${resource.name} - ${resource.id}`;
+
+  return [url, alt];
+}
+
+function prepareBynderHTML() {
+  return `
+    <div class="dialog-container">
+      <div id="bynder-compactview" style="overflow-x:auto;width:100%;" />
+    </div>      
+  `;
+}
+
+function transformAsset(asset, selected) {
+  const thumbnails = {
+    webimage: asset.files.webImage?.url,
+    thul: asset.files.thumbnail?.url,
+  };
+
+  Object.entries(asset.files)
+    .filter(([name]) => !['webImage', 'thumbnail'].includes(name))
+    .forEach(([key, value]) => (thumbnails[key] = value?.url));
+
+  return {
+    id: asset.databaseId,
+    orientation: asset.orientation.toLowerCase(),
+    archive: asset.isArchived ? 1 : 0,
+    type: asset.type.toLowerCase(),
+    fileSize: asset.fileSize,
+    description: asset.description,
+    name: asset.name,
+    height: asset.height,
+    width: asset.width,
+    copyright: asset.copyright,
+    extension: asset.extensions,
+    userCreated: asset.createdBy,
+    datePublished: asset.publishedAt,
+    dateCreated: asset.createdAt,
+    dateModified: asset.updatedAt,
+    watermarked: asset.isWatermarked ? 1 : 0,
+    limited: asset.isLimitedUse ? 1 : 0,
+    isPublic: asset.isPublic ? 1 : 0,
+    brandId: asset.brandId,
+    thumbnails: thumbnails,
+    original: asset.originalUrl,
+    videoPreviewURLs: asset.previewUrls || [],
+    textMetaproperties: asset.textMetaproperties || [],
+    tags: asset.tags,
+    selectedFile: selected.selectedFile,
+  };
+}
+
+function checkMessageEvent(e) {
+  if (e.origin !== BYNDER_BASE_URL) {
+    e.stopImmediatePropagation();
+  }
+}
+
+function renderDialog(sdk) {
+  const config = sdk.parameters.invocation;
+  const { assetTypes, bynderURL, compactViewMode, modeOverrideFields } = config;
+
+  // --- Bynder Mode Override Logic ---
+  // 1. Parse override field list (comma-separated, trimmed)
+  // 2. Get current field machine name
+  // 3. If field is in override list, use opposite mode; else use default
+  // 4. Valid modes: 'MultiSelect', 'SingleSelectFile'
+  let effectiveMode = compactViewMode ?? 'MultiSelect';
+  if (modeOverrideFields && typeof sdk.ids.field === 'string') {
+    // Remove all whitespace before splitting
+    const overrideList = modeOverrideFields
+      .replace(/\s+/g, '')
+      .split(',')
+      .filter(Boolean);
+    const fieldMachineName = sdk.ids.field;
+    if (overrideList.includes(fieldMachineName)) {
+      // Switch to the opposite mode
+      effectiveMode = (compactViewMode === 'MultiSelect' ? 'SingleSelectFile' : 'MultiSelect');
+    }
+  }
+
+  let types = [];
+  if (!assetTypes) {
+    // We default to just images in this fallback since this is the behavior the App had in its initial release
+    types = ['IMAGE'];
+  } else {
+    types = assetTypes
+      .trim()
+      .split(',')
+      .map((type) => type.toUpperCase());
+  }
+
+  const script = document.createElement('script');
+  script.src = BYNDER_SDK_URL;
+  script.async = true;
+  document.body.appendChild(script);
+
+  const container = document.createElement('div');
+  container.innerHTML = prepareBynderHTML(config);
+  document.body.appendChild(container);
+
+  sdk.window.startAutoResizer();
+
+  window.addEventListener('message', checkMessageEvent);
+
+  function onSuccess(assets, selected) {
+    sdk.close(Array.isArray(assets) ? assets.map((asset) => transformAsset(asset, selected)) : []);
+    window.removeEventListener('message', checkMessageEvent);
+  }
+
+  script.addEventListener('load', () => {
+    window.BynderCompactView.open({
+      language: 'en_US',
+      mode: effectiveMode,
+      assetTypes: types,
+      portal: { url: bynderURL, editable: true },
+      assetFieldSelection: FIELD_SELECTION,
+      container: document.getElementById('bynder-compactview'),
+      onSuccess,
+      selectedAssets: config.selectedAssets,
+    });
+  });
+}
+
+async function openDialog(sdk, _currentValue, config) {
+  const parameters = { ...config };
+
+  if (config.prefillSelectedAssets === 'Yes') {
+    const assetIds = _currentValue.map((asset) => asset.id);
+    parameters.selectedAssets = assetIds;
+  } else {
+    parameters.selectedAssets = [];
+  }
+
+  const result = await sdk.dialogs.openCurrentApp({
+    position: 'center',
+    title: CTA,
+    shouldCloseOnOverlayClick: true,
+    shouldCloseOnEscapePress: true,
+    parameters,
+    width: 'fullWidth',
+    minHeight: '80vh'
+  });
+
+  if (!Array.isArray(result)) {
+    if (config.prefillSelectedAssets === 'Yes') {
+      return null;
+    } else {
+      return [];
+    }
+  }
+
+  return result.map((item) => ({
+    ...pick(item, FIELDS_TO_PERSIST),
+    src: item.thumbnails && item.thumbnails.webimage,
+  }));
+}
+
+function isDisabled() {
+  return false;
+}
+
+function validateParameters({ bynderURL, assetTypes }) {
+  const hasValidProtocol = bynderURL.startsWith('https://');
+  const isHTMLSafe = ['"', '<', '>'].every((unsafe) => !bynderURL.includes(unsafe));
+
+  if (!hasValidProtocol || !isHTMLSafe) {
+    return 'Provide a valid Bynder URL.';
+  }
+
+  const types = assetTypes
+    .trim()
+    .split(',')
+    .map((type) => type.trim());
+  const isAssetTypesValid = types.every((type) => validAssetTypes.includes(type));
+
+  if (!isAssetTypesValid) {
+    return `Only valid asset types may be selected: ${validAssetTypes.join(',')}`;
+  }
+  return null;
+}
+
+async function customUpdateStateValue({ currentValue, result, config }, updateStateValue) {
+  if (config.prefillSelectedAssets === 'Yes') {
+    if (result) await updateStateValue(result);
+  } else {
+    if (Array.isArray(result) && result.length > 0) {
+      const newValue = [...(currentValue || []), ...result];
+
+      await updateStateValue(newValue);
+    }
+  }
+}
+
+function getAdditionalData(resource) {
+  return {
+    primary: resource.name,
+    secondary: resource.id,
+  };
+}
+
+setup({
+  cta: CTA,
+  name: 'Bynder',
+  logo,
+  color: '#0af',
+  description:
+    'The Bynder app is a widget that allows editors to select media from their Bynder account. Select or upload a file on Bynder and designate the assets that you want your entry to reference.',
+  parameterDefinitions: [
+    {
+      id: 'bynderURL',
+      type: 'Symbol',
+      name: 'Bynder URL',
+      description: 'Provide Bynder URL of your account.',
+      required: true,
+    },
+    {
+      id: 'assetTypes',
+      type: 'Symbol',
+      name: 'Asset types',
+      description: 'Choose which types of assets can be selected.',
+      default: validAssetTypes.join(','),
+      required: true,
+    },
+    {
+      id: 'compactViewMode',
+      name: 'Compact View Mode',
+      type: 'List',
+      value: 'MultiSelect,SingleSelectFile',
+      default: 'MultiSelect',
+      description:
+        'MultiSelect is the best choice for most customers. If you specifically need access to dynamic transformations, use SingleSelectFile mode. (Note that with SingleSelectFile mode, you will likely need to change your frontend to reference the specific transformations chosen by your content editors.)',
+      required: true,
+    },
+    {
+      id: 'modeOverrideFields',
+      name: 'Compact View Mode Override for Fields',
+      type: 'Symbol',
+      description:
+        'Comma-separated list of field machine names to override the default mode. If default is MultiSelect, these fields will use SingleSelectFile, and vice versa.',
+      required: false,
+    },
+    {
+      id: 'prefillSelectedAssets',
+      name: 'Prefill Selected Assets',
+      type: 'List',
+      value: 'No,Yes',
+      default: 'No',
+      description: 'Determines whether the selected assets will be prefilled when opening the asset picker.',
+    },
+    {
+      id: 'clientId',
+      type: 'Symbol',
+      name: 'Bynder Client ID',
+      description: 'The OAuth2 client ID for Bynder API access (required for external references and asset tracker).',
+      required: false,
+    },
+    {
+      id: 'clientSecret',
+      type: 'Symbol',
+      name: 'Bynder Client Secret',
+      description: 'The OAuth2 client secret for Bynder API access (required for external references and asset tracker).',
+      required: false,
+    }
+  ],
+  makeThumbnail,
+  renderDialog,
+  openDialog,
+  isDisabled,
+  validateParameters,
+  customUpdateStateValue,
+  getAdditionalData,
+});

--- a/apps/bynder/tsconfig.json
+++ b/apps/bynder/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "functions/**/*",
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "build",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Purpose

This release was created to provide support of the Contentful External Reference API and Bynder Asset Tracker

## Approach

Rework of the integration was required to keep in sync with Contentful standards

## Testing steps

1. Install in Contentful
2. Connect to Bynder instance
3. Add content field to Content Model
4. Link content field to this integration
5. Pick assets from Bynder

## Breaking Changes

No breaking changes identified

## Dependencies and/or References

No dependencies

## Deployment

N/A
