### PR TITLE
chore: bump release version of bynder app []

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "apps/bynder": "1.1.19",
+  "apps/bynder": "1.2.0",
   "apps/ceros": "1.0.29",
   "apps/cloudinary": "1.0.7",
   "apps/cloudinary2": "1.3.1",


### PR DESCRIPTION
## Purpose

Bynder version was changed in https://github.com/contentful/marketplace-partner-apps/pull/6770 -- it looks like release please didn't auto-release due to the manual version bump

I ran the `npm run deploy` command to release the new version of the Bynder app to prod. This change updates the release please manifest to match the current state so that future changes will release normally.
