### PR TITLE
feat: optimize release-and-deploy workflow []

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -10,6 +10,8 @@ permissions:
 
 name: Release and deploy apps
 jobs:
+  # Step 1: Check for apps that need releases
+  # Creates release PRs and tags when conventional commits are detected
   release-please:
     runs-on: ubuntu-latest
     steps:
@@ -21,8 +23,15 @@ jobs:
           default-branch: main
           release-type: node
     outputs:
+      # Boolean: true if any releases were created
       releases_created: ${{ steps.release.outputs.releases_created }}
+      # Comma-separated list of app paths that were released (e.g., "apps/bynder,apps/wix")
+      paths_released: ${{ steps.release.outputs.paths_released }}
 
+  # Step 2: Build and deploy only changed apps
+  # This job has two paths based on whether releases were created:
+  # - Production path: deploys released apps to production
+  # - Staging path: deploys changed apps to staging for testing
   build-and-deploy:
     needs: release-please
     runs-on: ubuntu-latest
@@ -35,19 +44,80 @@ jobs:
       TEST_ORG_ID: ${{ secrets.TEST_ORG_ID }}
       TEST_CMA_TOKEN: ${{ secrets.TEST_CMA_TOKEN }}
     steps:
+      # Checkout with full git history so Lerna can detect which apps have changed
+      # This enables --since flags to work correctly for smart builds
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Setup Node.js with npm caching enabled
+      # The cache speeds up npm ci by reusing node_modules from previous runs
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+
+      # Restore Nx build cache to skip rebuilding unchanged code
+      # Nx caches build outputs (dist/build folders) based on file hashes
+      # This can reduce build time from minutes to seconds for unchanged apps
+      - name: Restore Nx cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/nxcache
+          key: nx-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            nx-${{ runner.os }}-
+
+      # Install root-level dependencies (lerna, nx, etc.)
+      # Required before we can run lerna commands
       - name: Install root-level project
         run: npm ci
-      - name: Install apps
-        run: npm run install-apps:deploy
-      - name: Build apps
-        run: npm run build-apps:deploy
+
+      # PRODUCTION PATH: Only install/build apps that were actually released
+      # This uses release-please's output to determine which apps need deployment
+      # Significantly faster than installing/building all 33+ apps
+      - name: Install released apps
+        if: ${{ needs.release-please.outputs.releases_created }}
+        run: |
+          PATHS="${{ needs.release-please.outputs.paths_released }}"
+          if [ -n "$PATHS" ]; then
+            echo "Released paths: $PATHS"
+            npx lerna run install-ci --scope="{$PATHS}" --concurrency=5
+          fi
+
+      - name: Build released apps
+        if: ${{ needs.release-please.outputs.releases_created }}
+        run: |
+          PATHS="${{ needs.release-please.outputs.paths_released }}"
+          if [ -n "$PATHS" ]; then
+            # Nx cache will skip rebuilding if source files haven't changed
+            npx lerna run build --scope="{$PATHS}" --concurrency=5
+          fi
+
+      # STAGING PATH: Install/build only apps that changed since last commit
+      # Uses Lerna's --since flag to detect changes via git history
+      # This path runs for non-release commits (e.g., dependabot PRs)
+      - name: Install changed apps (staging)
+        if: ${{ !needs.release-please.outputs.releases_created }}
+        run: npm run install-apps  # Uses --since main
+
+      - name: Build changed apps (staging)
+        if: ${{ !needs.release-please.outputs.releases_created }}
+        run: npm run build-apps  # Uses --since main
+
+      # Deploy to staging environment (test deployments)
+      # Only runs when no releases were created (non-release commits)
       - name: Deploy apps (staging)
         if: ${{ !needs.release-please.outputs.releases_created }}
-        run: npm run deploy:staging
+        run: |
+          npx lerna run deploy:staging --since HEAD~1 --concurrency=3
+
+      # Deploy to production environment (live deployments)
+      # Only runs when releases were created by release-please
       - name: Deploy apps (production)
         if: ${{ needs.release-please.outputs.releases_created }}
-        run: npm run deploy:production
+        run: |
+          PATHS="${{ needs.release-please.outputs.paths_released }}"
+          if [ -n "$PATHS" ]; then
+            npx lerna run deploy --scope="{$PATHS}" --concurrency=3
+          fi


### PR DESCRIPTION
## Purpose

Our release workflow currently builds all 33+ apps on every push to main, taking 10-20 minutes regardless of what changed. This PR optimizes the workflow to only build and deploy apps that have actually changed to reduce build times.

## Approach

Uses release-please outputs and Lerna's change detection to selectively build:
- **Production**: Only builds/deploys apps that were released
- **Staging**: Only builds/deploys apps with changes since last commit
- **Caching**: Adds Nx and npm caching to skip rebuilding unchanged code

This is a low-risk optimization using existing tools (Lerna/Nx).

## Testing steps

Monitor first 2-3 releases after merge:
1. Verify builds complete successfully
2. Check logs show only changed apps are built
3. Confirm build times reduced

## Breaking Changes

None. Maintains existing functionality with improved performance.

## Deployment

Takes effect immediately on merge. First run may be slower (cold cache), subsequent runs should show significant improvement. Easy rollback by reverting this commit if issues arise.