### PR TITLE
fix: release-and-deploy workflow optimization follow-up []

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -91,11 +91,15 @@ jobs:
       # This path runs for non-release commits (e.g., dependabot PRs)
       - name: Install changed apps (staging)
         if: ${{ !needs.release-please.outputs.releases_created }}
-        run: npm run install-apps  # Uses --since main
+        run: |
+          echo "Installing apps that changed since last commit"
+          npx lerna run install-ci --since HEAD~1 --concurrency=5
 
       - name: Build changed apps (staging)
         if: ${{ !needs.release-please.outputs.releases_created }}
-        run: npm run build-apps  # Uses --since main
+        run: |
+          echo "Building apps that changed since last commit"
+          npx lerna run build --since HEAD~1 --concurrency=5
 
       # Deploy to staging environment (test deployments)
       # Only runs when no releases were created (non-release commits)


### PR DESCRIPTION
## Purpose

Fixes staging deployment failures caused by inconsistent change detection between install/build and deploy steps.

## Approach

Changed staging install and build steps to use `--since HEAD~1` instead of `--since main` to match the deploy step. This ensures all three steps detect the same set of changed apps.

## Testing steps

Re-run a failed staging deployment workflow. Verify it completes successfully without missing dependency errors.

## Breaking Changes

None.

## Dependencies and/or References

Fixes issue where re-running workflows on already-merged commits would fail with `contentful-app-scripts: not found` errors.

## Deployment

Takes effect on merge. Staging deployments will be more reliable when workflows are re-run.