### PR TITLE
fix: deploy script for sfmc-studio []

### DIFF
--- a/apps/sfmc-studio/next-env.d.ts
+++ b/apps/sfmc-studio/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/sfmc-studio/package.json
+++ b/apps/sfmc-studio/package.json
@@ -10,7 +10,7 @@
     "fix-paths": "node fix-paths.js",
     "clean-paths": "LC_ALL=C.UTF-8 find out -type f -exec sed -i '' -e 's|/_next|./_next|g' {} +",
     "start": "next start",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./next --organization-id ${DEFINITIONS_ORG_ID} --definition-id 4kk0CWKMz2hDS2amuVelsV --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./out --organization-id ${DEFINITIONS_ORG_ID} --definition-id 4kk0CWKMz2hDS2amuVelsV --token ${CONTENTFUL_CMA_TOKEN}",
     "export": "npx serve out -p 3005",
     "lint": "next lint",
     "test": "jest --ci",


### PR DESCRIPTION
## Purpose

Fixed deployment error in sfmc-studio app caused by incorrect bundle directory path in the deploy script. The error `ENOENT: no such file or directory, scandir 'next'` was occurring because the deploy command was looking for a non-existent `next` directory.

## Approach

Updated the `--bundle-dir` parameter in the deploy script from `./next` to `./out`. Next.js is configured with `output: 'export'` which outputs the static build to the `out` directory by default, which is also where the `fix-paths.js` script processes files.

## Testing steps

1. Run `npm run build` to build the app
2. Verify the `out` directory is created and populated
3. Run `npm run deploy` and confirm it successfully uploads without the `ENOENT` error

## Breaking Changes

None. This only fixes the deploy script to point to the correct output directory.