### PR TITLE
fix: CircleCI apps-checks []

### DIFF
--- a/apps/lottie-preview/package-lock.json
+++ b/apps/lottie-preview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lottie-preview",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lottie-preview",
-      "version": "1.0.9",
+      "version": "1.0.11",
       "hasInstallScript": true,
       "dependencies": {
         "@contentful/app-components": "file:../../packages/contentful-app-components",
@@ -5560,6 +5560,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -11216,12 +11225,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "prettier": "2.8.8"
   },
   "scripts": {
-    "test-apps": "lerna run test --concurrency=1 --stream --since main",
-    "build-apps": "lerna run build --concurrency=1 --stream --since main",
-    "build-apps:deploy": "lerna run build --concurrency=1 --stream",
-    "install-apps": "lerna run install-ci --concurrency=1 --stream --since main",
-    "install-apps:deploy": "lerna run install-ci --concurrency=1 --stream",
+    "test-apps": "lerna run test --concurrency=1 --stream --since main --sort",
+    "build-apps": "lerna run build --concurrency=1 --stream --since main --sort",
+    "build-apps:deploy": "lerna run build --concurrency=1 --stream --sort",
+    "install-apps": "lerna run install-ci --concurrency=1 --stream --since main --sort",
+    "install-apps:deploy": "lerna run install-ci --concurrency=1 --stream --sort",
     "deploy:staging": "lerna run deploy:staging --concurrency=3",
     "deploy:production": "lerna run deploy --concurrency=3",
     "prepare": "husky install"

--- a/packages/contentful-app-components/package.json
+++ b/packages/contentful-app-components/package.json
@@ -9,7 +9,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "install-ci": "npm install"
+    "install-ci": "npm install && npm run build"
   },
   "peerDependencies": {
     "@contentful/app-sdk": "^4.0.0",


### PR DESCRIPTION
## Purpose

Fixed CircleCI `apps-checks` build errors for apps that depend on the local `@contentful/app-components` package. The build was failing because the shared package wasn't being built before dependent apps (like `lottie-preview`) tried to use it, causing TypeScript to fail with missing module errors.

## Approach

Made two changes to ensure proper build order:

1. **Updated `@contentful/app-components` install-ci script** to include `npm run build`, ensuring the package is built during installation
2. **Added `--sort` flag to lerna commands** in root `package.json` to enforce ordering, so shared packages are processed before their dependents

This ensures `@contentful/app-components` is always built before apps that depend on it.

## Testing steps

1. Push changes to a feature branch
2. Verify CircleCI `apps-checks` job completes successfully
3. Confirm `lottie-preview` and other dependent apps build without module resolution errors

## Breaking Changes

None. This improves build reliability without changing functionality.

## Dependencies and/or References

N/A

## Deployment

None.