### PR TITLE
fix: add deep-clone to release-please config []

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,9 @@
     "apps/convox": {
       "release-type": "node"
     },
+    "apps/deep-clone": {
+      "release-type": "node"
+    },
     "apps/docs-to-rich-text": {
       "release-type": "node"
     },


### PR DESCRIPTION
## Purpose

Fixed release-please automation for the `deep-clone` app. Release-please was not creating release PRs for `deep-clone` because the app was missing from the `release-please-config.json` file.

## Approach

Added `apps/deep-clone` entry to `release-please-config.json`. The app was already tracked in `.release-please-manifest.json` but missing from the config file that tells release-please which packages to process.

## Testing steps

1. Merge this PR to main
2. Verify release-please creates a release PR for deep-clone after detecting the merged commits
3. Confirm the release PR includes the recent version mismatch fix

## Breaking Changes

None. This enables release automation that was missing.

## Dependencies and/or References

N/A

## Deployment

None. This only affects the release automation workflow.