### PR TITLE
fix: ignore app def not found error []

### DIFF
--- a/apps/abtasty/src/services/createContentType.ts
+++ b/apps/abtasty/src/services/createContentType.ts
@@ -87,6 +87,10 @@ export async function createAbTastyContainerContentType({ sdk }: props) {
 
     await ensureAppInSidebarAndEditor(sdk, CONTENT_TYPE_ID);
   } catch (e: any) {
+    // app throws this error on first install but then it's created so we can ignore it
+    if (e.code === 'NotFound' && e.message.includes('AppDefinition does not exist')) {
+      return;
+    }
     console.log('Error creating content type: ', e.message || e.toString(), e.stack);
     sdk.notifier.error('Error creating content type: ' + (e.message || e.toString()));
   }


### PR DESCRIPTION
on first install we were getting an error notification but everything actually worked fine. On all of our apps we get this app definition not found error on first install (we should try to fix this at some point) but things work fine so I want to ignore it to not create a bad user experience