### PR TITLE
fix: allow all urls for bynder [INTEG-3251]

### DIFF
--- a/apps/bynder/contentful-app-manifest.json
+++ b/apps/bynder/contentful-app-manifest.json
@@ -7,7 +7,7 @@
             "path": "functions/external-ref.js",
             "entryFile": "functions/external-ref.ts",
             "allowNetworks": [
-                "*.bynder.com"
+                "*"
             ],
             "accepts": [
                 "graphql.field.mapping",
@@ -21,7 +21,7 @@
             "path": "functions/asset-tracker.js",
             "entryFile": "functions/asset-tracker.ts",
             "allowNetworks": [
-                "*.bynder.com"
+                "*"
             ],
             "accepts": [
                 "appevent.handler"


### PR DESCRIPTION
some customers have custom paths for bynder so we need to whitelist all
