### PR TITLE
fix(bynder): remove allowNetworks from manifest [INTEG-3251]

### DIFF
--- a/apps/bynder/contentful-app-manifest.json
+++ b/apps/bynder/contentful-app-manifest.json
@@ -6,9 +6,6 @@
             "description": "This function pulls the asset information from Bynder via APIs",
             "path": "functions/external-ref.js",
             "entryFile": "functions/external-ref.ts",
-            "allowNetworks": [
-                "*"
-            ],
             "accepts": [
                 "graphql.field.mapping",
                 "graphql.query"
@@ -20,9 +17,6 @@
             "description": "This function handles the App Events for entries having bynder fields.",
             "path": "functions/asset-tracker.js",
             "entryFile": "functions/asset-tracker.ts",
-            "allowNetworks": [
-                "*"
-            ],
             "accepts": [
                 "appevent.handler"
             ]


### PR DESCRIPTION
## Purpose

Bynder app was added to the `allowNetworksExclusions` list in functions-api-outbound-worker.

## Approach

I removed the `allowNetworks` setting from the Bynder app manifest to prevent an error in the release workflow.

