### PR TITLE
feat: add variation meta field

### DIFF
--- a/apps/launchdarkly/src/components/ConfigScreen/utils/createLDContentType.ts
+++ b/apps/launchdarkly/src/components/ConfigScreen/utils/createLDContentType.ts
@@ -30,6 +30,14 @@ export async function createOrUpdateLDContentType(
         required: true,
         items: { type: 'Link', linkType: 'Entry' }
       },
+      {
+        id: 'meta',
+        name: 'Variation Metadata',
+        type: 'Object',
+        required: false,
+        localized: false,
+        validations: [],
+      },
       // Optional: editor tolerates if this field is absent
       // { id: 'mode', name: 'Mode', type: 'Symbol', required: false, localized: false }
     ]

--- a/apps/launchdarkly/src/components/EntryEditor/types.ts
+++ b/apps/launchdarkly/src/components/EntryEditor/types.ts
@@ -25,15 +25,16 @@ export interface FlagFormState {
   mode: FlagMode;
   // Change to Reference Array - array index corresponds to variation index
   contentMapping: ContentfulReference[];
+  /**
+   * Lightweight variation → entry mapping for parity with Optimizely's meta field.
+   */
+  meta?: Record<string, string>;
 }
 
 // Extended SDK for flag management capabilities
+// Note: mode field is not in Contentful, it's inferred from data in React state
 export interface ExtendedEditorAppSDK extends EditorAppSDK {
-  entry: EditorAppSDK['entry'] & {
-    fields: EditorAppSDK['entry']['fields'] & {
-      mode: { getValue: () => FlagMode };
-    };
-  };
+  entry: EditorAppSDK['entry'];
   window: {
     startAutoResizer: () => void;
     stopAutoResizer: () => void;

--- a/apps/launchdarkly/src/utils/contentMapping.ts
+++ b/apps/launchdarkly/src/utils/contentMapping.ts
@@ -1,4 +1,6 @@
-import { EnhancedFlagFormState } from '../components/EntryEditor/types';
+import { EnhancedFlagFormState, ContentfulReference } from '../components/EntryEditor/types';
+import { VariationValue } from '../types/launchdarkly';
+import { sanitizeFlagKey } from './validation';
 
 /**
  * Converts enhanced variation content to Reference Array for Contentful storage.
@@ -84,4 +86,81 @@ export const extractSimpleContentMapping = (enhancedState: EnhancedFlagFormState
   }
   
   return result;
+};
+
+type VariationLike = {
+  name?: string;
+  value?: VariationValue;
+  key?: string;
+};
+
+const ensureUniqueKey = (candidate: string, usedKeys: Set<string>, fallback: string) => {
+  let sanitized = sanitizeFlagKey(candidate);
+  if (!sanitized) {
+    sanitized = fallback;
+  }
+  let unique = sanitized;
+  let attempt = 1;
+  while (usedKeys.has(unique)) {
+    unique = `${sanitized}-${attempt++}`;
+  }
+  usedKeys.add(unique);
+  return unique;
+};
+
+/**
+ * Builds a lightweight variation → entry ID map, mirroring the Optimizely meta field.
+ * Can build from either enhancedVariationContent OR contentMapping references.
+ */
+export const buildVariationMetaMapping = (
+  variations: Array<{ value: VariationValue; name?: string; key?: string }> = [],
+  contentSource: ContentfulReference[] | Record<number, EnhancedContentfulEntry> = [],
+): Record<string, string> => {
+  const meta: Record<string, string> = {};
+  const usedKeys = new Set<string>();
+
+  variations.forEach((variation, index) => {
+    // Handle both array (contentMapping) and object (enhancedVariationContent) sources
+    let entryId: string | undefined;
+    if (Array.isArray(contentSource)) {
+      entryId = contentSource[index]?.sys?.id;
+    } else {
+      entryId = contentSource[index]?.sys?.id;
+    }
+
+    if (!entryId) {
+      return;
+    }
+
+    // Use the variation value as the key since that's what LaunchDarkly returns
+    // This enables direct lookup: meta[ldClient.variation('flag', default)]
+    let candidate: string;
+    if (typeof variation?.value === 'object' && variation.value !== null) {
+      // For JSON values, serialize them
+      candidate = JSON.stringify(variation.value);
+    } else {
+      // For primitives (boolean, string, number), convert to string
+      candidate = String(variation?.value ?? `variation-${index}`);
+    }
+
+    const fallback = `variation-${index}`;
+    const metaKey = ensureUniqueKey(candidate, usedKeys, fallback);
+
+    meta[metaKey] = entryId;
+  });
+
+  return meta;
+};
+
+export const isMetaMappingEqual = (
+  a: Record<string, string> | undefined | null,
+  b: Record<string, string>,
+): boolean => {
+  if (!a) {
+    return Object.keys(b).length === 0;
+  }
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
 };


### PR DESCRIPTION
Add optional 'meta' JSON field to LaunchDarkly Feature Flag content type that maps variation keys to Contentful entry IDs. This provides lightweight ID access matching Optimizely's meta field structure, eliminating the need to parse full entry trees.

- Add meta field to content type schema
- Auto-generate meta mapping from variations and contentMapping
- Validate meta field in content model checks

## Purpose

Requested by Block Inc

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
