### PR TITLE
fix: cloudinary-search-filter [CLD-1234]

### DIFF
--- a/apps/cloudinary2/src/utils.ts
+++ b/apps/cloudinary2/src/utils.ts
@@ -79,11 +79,15 @@ export function mediaLibraryFilter(type: string, sdk: FieldAppSDK<AppInstallatio
   const binding = {
     entry: sdk.entry,
   };
+  const hasSearchPrefix = !!expression;
+  const searchFilterIsEmpty = !!searchFilterTemplate;
+  const searchFilterStartsWithBooleanOperator = searchFilterTemplate.match(/^\s*(AND|OR).*$/) !== null;
+  const shouldAppendImplicitAndOperator = hasSearchPrefix && searchFilterIsEmpty && !searchFilterStartsWithBooleanOperator;
+  const defaultBooleanOperator = shouldAppendImplicitAndOperator ? ' AND ' : '';
 
-  const shouldAppendImplicitAndOperator = searchFilterTemplate.match(/^\s*(AND|OR).*$/) || !searchFilterTemplate;
-  const defaultBooleanOperator = shouldAppendImplicitAndOperator ? '' : ' AND ';
   const searchFilter = ` ${evaluator(searchFilterTemplate, binding, sdk)}`;
   expression = `${expression}${defaultBooleanOperator}${searchFilter}`;
+
   if (expression.trim() === '') {
     return undefined;
   }


### PR DESCRIPTION
## Purpose

when media type is set to "all" filter was composed incorrectly and resulted in a faulty search expression and empty media library initialization.

## Approach

improved search expression builder
## Testing steps

manual testing for all combinations
## Breaking Changes

none
