### PR TITLE
fix(shopify): resolver functions return fallback data for errors [ZEND-7254]

### DIFF
--- a/apps/shopify/src/__tests__/skuResolvers.test.js
+++ b/apps/shopify/src/__tests__/skuResolvers.test.js
@@ -249,7 +249,13 @@ describe('fetchProductPreviews', () => {
     const validProductId = Buffer.from('gid://shopify/Product/1').toString('base64');
     const mockSkus = [validProductId];
 
-    await expect(fetchProductPreviews(mockSkus, mockConfig)).rejects.toThrow('GraphQL errors');
+    const result = await fetchProductPreviews(mockSkus, mockConfig);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      isMissing: true,
+      name: '',
+      image: '',
+    });
   });
 
   it('should transform images from GraphQL format to Buy SDK format', async () => {

--- a/apps/shopify/src/utils/fallback.js
+++ b/apps/shopify/src/utils/fallback.js
@@ -1,0 +1,13 @@
+/**
+ * Creates a fallback preview object for when Shopify data cannot be fetched.
+ * 
+ * @param {string} sku - The SKU identifier
+ * @returns {Object} A fallback preview object marked as missing
+ */
+export const createFallbackPreview = (sku) => ({
+  id: sku,
+  image: '',
+  isMissing: true,
+  name: '',
+  sku,
+});


### PR DESCRIPTION
## Purpose

Prevents build failures when Shopify's API is temporarily unavailable. Currently, Shopify API errors cause `INTERNAL_SERVER_ERROR` responses that can break customer builds and block content publishing.

## Approach

Updated SKU resolver functions (`fetchProductPreviews`, `fetchProductVariantPreviews`, `fetchCollectionPreviews`) to return fallback data with `isMissing: true` instead of throwing errors when Shopify requests fail. Created `createFallbackPreview()` utility to centralize fallback object structure.

## Testing steps

1. Configure Shopify app with valid credentials and create an entry with Shopify product references
2. Change Storefront Access Token to invalid value in app settings
3. Publish the entry - should succeed with products marked as "missing"
4. Restore credentials and verify normal operation

## Dependencies and/or References

- Internal ticket: `ZEND-7254`