### PR TITLE
fix(shopify): server-side environments [ZEND-7254]

### DIFF
--- a/apps/shopify/src/utils/base64.js
+++ b/apps/shopify/src/utils/base64.js
@@ -1,16 +1,46 @@
+/**
+ * Converts a base64 string to a regular string.
+ * Works in both browser and Node.js environments.
+ */
 export const convertBase64ToString = (str) => {
   try {
-    const decodedId = window.atob(str);
-    return decodedId;
+    // Node.js environment
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(str, 'base64').toString('utf-8');
+    }
+    // Browser environment
+    if (typeof window !== 'undefined' && window.atob) {
+      return window.atob(str);
+    }
+    // Fallback: try global atob (available in some environments)
+    if (typeof atob !== 'undefined') {
+      return atob(str);
+    }
+    return null;
   } catch (error) {
     return null;
   }
 };
 
+/**
+ * Converts a regular string to a base64 string.
+ * Works in both browser and Node.js environments.
+ */
 export const convertStringToBase64 = (str) => {
   try {
-    const undecodedId = window.btoa(str);
-    return undecodedId;
+    // Node.js environment
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(str, 'utf-8').toString('base64');
+    }
+    // Browser environment
+    if (typeof window !== 'undefined' && window.btoa) {
+      return window.btoa(str);
+    }
+    // Fallback: try global btoa (available in some environments)
+    if (typeof btoa !== 'undefined') {
+      return btoa(str);
+    }
+    return null;
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
## Purpose

Fix server-side execution failures when Contentful fetches product previews during publishing. The app used browser-only APIs (`window.fetch`, `window.atob`, `window.btoa`) that don't exist in Cloudflare Workers, causing `INTERNAL_SERVER_ERROR` when resolving preview data.

## Approach

Made code environment-agnostic:
- `window.fetch` → `getFetch()` helper (checks global `fetch` first, falls back to `window.fetch`)
- Base64 functions → use Node.js `Buffer` when available, browser APIs as fallback

Maintains browser compatibility while enabling server-side execution.

## Testing steps

1. Browser: Open app in Contentful UI, search/select products - should work as before
2. Server-side: Publish entry with Shopify references - should resolve without errors

## Breaking Changes

None - backward compatible.

## Dependencies and/or References

- Errors occurred in Cloudflare Workers during shopify product resolution
- Related to Contentful orchestration (`isInOrchestrationEAP: true`)

## Deployment

No special considerations - environment detection only, no API changes.