### PR TITLE
chore: clarify cloudinary starting folder syntax [ZEND-7289]

### DIFF
--- a/apps/cloudinary2/src/components/TextField.tsx
+++ b/apps/cloudinary2/src/components/TextField.tsx
@@ -14,9 +14,10 @@ interface Props {
 
   inputProps?: Pick<TextInputProps, 'max' | 'min'>;
   testId: string;
+  placeholder?: string;
 }
 
-export function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId }: Props) {
+export function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId, placeholder }: Props) {
   return (
     <FieldWrapper name={name} description={description} counter>
       <TextInput
@@ -27,6 +28,7 @@ export function TextField({ name, description, value, onChange, isRequired = fal
         isRequired={isRequired}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
         testId={testId}
         {...inputProps}
       />

--- a/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
@@ -79,7 +79,8 @@ export function InstallParamsConfiguration(props: Props) {
       <TextField
         testId="config-startFolder"
         name="Starting folder"
-        description="A path to a folder which the Cloudinary Media Library will automatically browse to on load."
+        description="Relative path to the folder which the Cloudinary Media Library will automatically browse to. Leave blank to open the root folder."
+        placeholder="e.g. images, images/products"
         value={parameters.startFolder}
         onChange={(value) => onParameterChange('startFolder', value)}
         isRequired


### PR DESCRIPTION
## Purpose

Modifying the help and placeholder text in the cloudinary config page to clarify the starting folder syntax

support issue: https://contentful.atlassian.net/browse/ZEND-7289

app was not navigating to the customers expected folder because they added the absolute path in the `Starting Folder` field 

## Approach
Before:
<img width="1709" height="871" alt="Screenshot 2025-12-04 at 9 02 48 AM" src="https://github.com/user-attachments/assets/ab379d2b-a66f-457a-b2ae-a2f6f2b83fbe" />

After:
<img width="1709" height="841" alt="Screenshot 2025-12-04 at 9 02 07 AM" src="https://github.com/user-attachments/assets/721ca4d6-ab3f-43df-afbc-ab1a3fec81d7" />


