### PR TITLE
Revert: clarify cloudinary starting folder syntax [ZEND-7289]

### DIFF
--- a/apps/cloudinary2/src/components/TextField.tsx
+++ b/apps/cloudinary2/src/components/TextField.tsx
@@ -14,10 +14,9 @@ interface Props {
 
   inputProps?: Pick<TextInputProps, 'max' | 'min'>;
   testId: string;
-  placeholder?: string;
 }
 
-export function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId, placeholder }: Props) {
+export function TextField({ name, description, value, onChange, isRequired = false, type, inputProps, testId }: Props) {
   return (
     <FieldWrapper name={name} description={description} counter>
       <TextInput
@@ -28,7 +27,6 @@ export function TextField({ name, description, value, onChange, isRequired = fal
         isRequired={isRequired}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
         testId={testId}
         {...inputProps}
       />

--- a/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
+++ b/apps/cloudinary2/src/locations/ConfigScreen/InstallParamsConfiguration.tsx
@@ -79,8 +79,7 @@ export function InstallParamsConfiguration(props: Props) {
       <TextField
         testId="config-startFolder"
         name="Starting folder"
-        description="Relative path to the folder which the Cloudinary Media Library will automatically browse to. Leave blank to open the root folder."
-        placeholder="e.g. images, images/products"
+        description="A path to a folder which the Cloudinary Media Library will automatically browse to on load."
         value={parameters.startFolder}
         onChange={(value) => onParameterChange('startFolder', value)}
         isRequired


### PR DESCRIPTION
…(#7431)"

This reverts commit e1b96670948bcb630c1e9b108b2e473473b7fd05.

## Purpose

used the wrong commit message, didn't trigger release please pr
