### PR TITLE
fix(vwo-fme): replace hardcoded locale with sdk constant [ZEND-7396]

### DIFF
--- a/apps/vwo-fme/src/locations/ConfigScreen.jsx
+++ b/apps/vwo-fme/src/locations/ConfigScreen.jsx
@@ -75,7 +75,7 @@ export default class ConfigScreen extends React.Component {
           "required": false,
           "validations": [],
           "defaultValue": {
-            "en-US": "[VWO] FME Entry"
+            [this.props.sdk.locales.default]: '[VWO] FME Entry',
           },
           "disabled": false,
           "omitted": false
@@ -248,6 +248,9 @@ export default class ConfigScreen extends React.Component {
       return false;
     }
 
+    // Get current state of EditorInterface to avoid version mismatch errors
+    const currentState = await this.props.sdk.app.getCurrentState();
+
     return {
       parameters: {
         accessToken: config.accessToken,
@@ -255,6 +258,7 @@ export default class ConfigScreen extends React.Component {
       },
       targetState: {
         EditorInterface: {
+          ...currentState?.EditorInterface,
           [VARIATION_CONTAINER_ID]: { editor: true, sidebar: { position: 0 } }
         }
       },


### PR DESCRIPTION
## Purpose

Fix app installation failures caused by two issues:
1. **ValidationFailed error**: The app hardcoded `"en-US"` locale when creating the content type, but the customer's space didn't include this locale.
2. **VersionMismatch error**: After fixing the locale issue, a 409 Conflict occurred because EditorInterface was updated without fetching the current state first.

## Approach

- Replaced hardcoded `"en-US"` with `this.props.sdk.locales.default` to use the space's default locale when creating the content type.
- Added `getCurrentState()` call before setting `targetState.EditorInterface` to ensure we use the latest version and preserve existing configurations. This follows the pattern used in other similar apps.