### PR TITLE
feat: add workflow_dispatch to release-and-deploy workflow []

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -3,6 +3,7 @@
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR adds `workflow_dispatch` trigger to the release-and-deploy workflow, allowing it to be manually triggered from the GitHub Actions UI.

https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow

## Why?
- The workflow was disabled (by me 😓 ) when the deploy PR was merged

## Usage
After merging, you can manually trigger the workflow by:
1. Going to Actions tab
2. Selecting 'Release and deploy apps' workflow
3. Clicking 'Run workflow' button