### PR TITLE
fix(bynder): thumbnails [ZEND-7453]

### DIFF
--- a/apps/bynder/package-lock.json
+++ b/apps/bynder/package-lock.json
@@ -6770,6 +6770,43 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
@@ -6783,6 +6820,18 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-circus/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {
@@ -8505,9 +8554,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -34,6 +34,7 @@
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $DEFINITIONS_ORG_ID --definition-id 5KySdUzG7OWuCE2V3fgtIa --token $CONTENTFUL_CMA_TOKEN",
     "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $TEST_ORG_ID --definition-id 6weJYfzgz370YDmFVi4B6w --token $TEST_CMA_TOKEN",
+    "deploy:dev": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $TEST_ORG_ID --definition-id 6NxtWWoYQ7toCG1AfGlo82 --token $TEST_CMA_TOKEN",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/apps/bynder/src/index.jsx
+++ b/apps/bynder/src/index.jsx
@@ -69,7 +69,12 @@ const FIELD_SELECTION = `
 const validAssetTypes = ['image', 'audio', 'document', 'video'];
 
 function makeThumbnail(resource) {
-  const thumbnail = (resource.thumbnails && resource.thumbnails.webimage) || resource.src;
+  // Try thumbnail sources in order of preference
+  const thumbnail = 
+    resource.thumbnails?.thul ||
+    resource.thumbnails?.webimage ||
+    resource.src;
+
   const url = typeof thumbnail === 'string' ? thumbnail : undefined;
   const alt = `${resource.name} - ${resource.id}`;
 
@@ -91,7 +96,7 @@ function transformAsset(asset, selected) {
   };
 
   Object.entries(asset.files)
-    .filter(([name]) => !['webImage', 'thumbnail'].includes(name))
+    .filter(([name]) => !['webimage', 'thumbnail'].includes(name.toLowerCase()))
     .forEach(([key, value]) => (thumbnails[key] = value?.url));
 
   return {
@@ -114,7 +119,7 @@ function transformAsset(asset, selected) {
     limited: asset.isLimitedUse ? 1 : 0,
     isPublic: asset.isPublic ? 1 : 0,
     brandId: asset.brandId,
-    thumbnails: thumbnails,
+    thumbnails,
     original: asset.originalUrl,
     videoPreviewURLs: asset.previewUrls || [],
     textMetaproperties: asset.textMetaproperties || [],


### PR DESCRIPTION
## Purpose

Update Bynder app thumbnails to fall back to different images sources based on preference/availability.

## Approach

I noticed we were setting the resource thumbnails to include `thul` (thumbnail) and `webimage` (web-optimized) in `transformAsset`

However, the `makeThumbnail` was only using `webimage` and not the thumbnail.

Now it will use the thumbnail image if available in `makeThumbnail`, and allow the page to load these thumbnail images faster since the files are smaller than using webimage.

<img width="1515" height="1038" alt="Screenshot 2026-01-23 at 4 05 31 PM" src="https://github.com/user-attachments/assets/257c8c61-2019-41ce-9e53-48de66618e34" />
