### PR TITLE
fix(bynder): fallback to original image if thumbnails unavailable [ZEND-7453]

### DIFF
--- a/apps/bynder/src/index.jsx
+++ b/apps/bynder/src/index.jsx
@@ -70,10 +70,8 @@ const validAssetTypes = ['image', 'audio', 'document', 'video'];
 
 function makeThumbnail(resource) {
   // Try thumbnail sources in order of preference
-  const thumbnail = 
-    resource.thumbnails?.thul ||
-    resource.thumbnails?.webimage ||
-    resource.src;
+  // Use the original image if no other thumbnails are avilable
+  const thumbnail = resource.thumbnails?.thul || resource.thumbnails?.webimage || resource.src || resource.original;
 
   const url = typeof thumbnail === 'string' ? thumbnail : undefined;
   const alt = `${resource.name} - ${resource.id}`;
@@ -146,14 +144,11 @@ function renderDialog(sdk) {
   let effectiveMode = compactViewMode ?? 'MultiSelect';
   if (modeOverrideFields && typeof sdk.ids.field === 'string') {
     // Remove all whitespace before splitting
-    const overrideList = modeOverrideFields
-      .replace(/\s+/g, '')
-      .split(',')
-      .filter(Boolean);
+    const overrideList = modeOverrideFields.replace(/\s+/g, '').split(',').filter(Boolean);
     const fieldMachineName = sdk.ids.field;
     if (overrideList.includes(fieldMachineName)) {
       // Switch to the opposite mode
-      effectiveMode = (compactViewMode === 'MultiSelect' ? 'SingleSelectFile' : 'MultiSelect');
+      effectiveMode = compactViewMode === 'MultiSelect' ? 'SingleSelectFile' : 'MultiSelect';
     }
   }
 
@@ -217,7 +212,7 @@ async function openDialog(sdk, _currentValue, config) {
     shouldCloseOnEscapePress: true,
     parameters,
     width: 'fullWidth',
-    minHeight: '80vh'
+    minHeight: '80vh',
   });
 
   if (!Array.isArray(result)) {
@@ -339,7 +334,7 @@ setup({
       name: 'Bynder Client Secret',
       description: 'The OAuth2 client secret for Bynder API access (required for external references and asset tracker).',
       required: false,
-    }
+    },
   ],
   makeThumbnail,
   renderDialog,


### PR DESCRIPTION
## Purpose

Update Bynder app additional fallback to use `resource.original` (original image) if no other thumbnails are available.
