### PR TITLE
fix - handle regex metacharacters in query strings []

### DIFF
--- a/apps/global-find-replace/package-lock.json
+++ b/apps/global-find-replace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "global-find-replace",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "global-find-replace",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@contentful/app-sdk": "4.51.4",
         "@contentful/f36-components": "^4.81.1",

--- a/apps/global-find-replace/package.json
+++ b/apps/global-find-replace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-find-replace",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "4.51.4",

--- a/apps/global-find-replace/src/components/SummaryView.tsx
+++ b/apps/global-find-replace/src/components/SummaryView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Heading, Paragraph, Table, TableBody, TableCell, TableHead, TableRow, Button } from '@contentful/f36-components';
+import { Flex, Heading, Table, TableBody, TableCell, TableHead, TableRow, Button } from '@contentful/f36-components';
 import { MatchField } from '../types';
 
 interface SummaryViewProps {

--- a/apps/global-find-replace/src/utils/fieldProcessors.ts
+++ b/apps/global-find-replace/src/utils/fieldProcessors.ts
@@ -10,7 +10,7 @@ function replaceSimpleValue(value: any, find: string, replace: string, caseSensi
   if (!strVal.toLowerCase().includes(find.toLowerCase())) return null;
 
   if (!caseSensitive) {
-    const updated = strVal.replace(new RegExp(find, 'gi'), replace);
+    const updated = strVal.replace(new RegExp(escapeRegex(find), 'gi'), replace);
     return {
       original: strVal,
       updated,
@@ -18,14 +18,16 @@ function replaceSimpleValue(value: any, find: string, replace: string, caseSensi
     };
   }
 
-  if (!strVal.includes(find)) return null;
-
   const result = strVal.replaceAll(find, replace);
   return {
     original: strVal,
     updated: result,
     diffLines: getRelevantDiff(value, find, replace, caseSensitive),
   };
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -176,7 +178,7 @@ const getRelevantDiff = (value: any, find: string, replace: string, caseSensitiv
   const diffLines: DiffLine[] = [];
   for (const snippet of originalSnippets) {
     const originalText = snippet;
-    const updatedText = caseSensitive ? snippet.replaceAll(find, replace) : snippet.replace(new RegExp(find, 'gi'), replace);
+    const updatedText = caseSensitive ? snippet.replaceAll(find, replace) : snippet.replace(new RegExp(escapeRegex(find), 'gi'), replace);
     diffLines.push({ diffOriginal: originalText, diffUpdated: updatedText });
   }
 


### PR DESCRIPTION
## Purpose

To properly handle query strings that include regex metacharacters.

## Approach

The search query string is escaped before the regex matching happens to handle special characters that previously would break the replacement.

## Testing steps

1. Install the application
2. Open a content item
3. Change any field to contain the text "[[test]]"
4. Open the page app
6. Enter "[[test]]" as the search term and anything as the replacement term
7. Press search
8. Verify results are shown and that the replacement is visually correct
9. Select any number of field changes to apply
10. Press apply
11. Verify completion results are shown
12. Open content items and verify changes were applied correctly

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A
