### PR TITLE
chore: Add Extensibility as a CODEOWNER []

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contentful/team-marketplace
+* @contentful/team-extensibility @contentful/team-marketplace


### PR DESCRIPTION
## Summary
Add Extensibility as a default code owner for the repository.

## Changes
- add `@contentful/team-extensibility` to the default `CODEOWNERS` entry
- keep existing owners in place

## Notes
- no product or runtime behavior changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Add Extensibility as a default code owner for the repository. The change adds @contentful/team-extensibility to the default CODEOWNERS entry while keeping existing owners in place. There are no product or runtime behavior changes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds @contentful/team-extensibility as a code owner in the CODEOWNERS file for all repository files, alongside the existing @contentful/team-marketplace.</li>

</ul>
</details>

</div>