### PR TITLE
fix: Fail to map Component -> Reference field [ GC-7555 ]

### DIFF
--- a/apps/bynder-content-workflow/src/hooks/useComponentsMapping.ts
+++ b/apps/bynder-content-workflow/src/hooks/useComponentsMapping.ts
@@ -26,7 +26,7 @@ export default function useComponentsMapping() {
       });
       return existing.sys.id;
     } catch (error: any) {
-      if (error?.code === "NotFound") {
+      if (error?.message === "The resource could not be found.") {
         if (!credentials.current) {
             throw new Error("App cofinguration is missing");
         }


### PR DESCRIPTION
Authored by @timbryandev on behalf of Content Workflow by Bynder.


## Purpose

A customer of Content Workflow reported the following issue.
The client is attempting to create a template mapping. The mapping saves successfully until the client attempts to map a Component → Reference field.

## Approach

This issue is already documented in a different part of out integration, so I have applied the existing fix to this instance, which resolves the issue with a single, non-breaking change.

## Testing steps

You would need a Content Workflow account but simply;
1. Create a Content Workflow project with a template that contains a Component field
2. In the Contentful app, add a Reference field to a Content Type
3. Create a new template mapping:
4. Select the project and template from step 1
5. Set the Content Type Destination to the Content Type from step 2
6. Map the Component field → Reference field
7. Click Create mapping

Before the changes, you would see the mapping fails with "The resource could not be found."
After the changes, the issue should be resolved


## Breaking Changes

None identified, it's improved error detection and handling.

## Dependencies and/or References

The issue was raised during a client feedback call with the Content Workflow product team and actioned off the back of that feedback.


## Deployment

None. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>A customer of Content Workflow reported an issue where creating template mappings fails when attempting to map a Component field to a Reference field, resulting in 'The resource could not be found.' error. This PR applies an existing fix to update error handling logic, resolving the issue with a non-breaking change.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates error condition in useComponentsMapping.ts (getComponentReferenceData function) to check error.message instead of error.code for 'The resource could not be found.' errors.</li>

<li>Enables automatic creation of missing Contentful content types for components when mapping Component to Reference fields.</li>

<li>Improves error detection and handling without introducing breaking changes.</li>

</ul>
</details>

</div>