### PR TITLE
fix(bynder): Compact View resizing [FSB-11085]

### DIFF
--- a/apps/bynder/src/index.jsx
+++ b/apps/bynder/src/index.jsx
@@ -161,7 +161,7 @@ async function openDialog(sdk, _currentValue, config) {
     shouldCloseOnEscapePress: true,
     parameters,
     width: 'fullWidth',
-    minHeight: '80vh',
+    minHeight: '70vh',
   });
 
   if (!Array.isArray(result)) {


### PR DESCRIPTION
## Purpose

Fix for the disappearance of the Add Asset button when zoomed in. The fix changes the dimensions of the dialog to accomodate for this.

## Approach

Change minHeight from 80vh to 70vh

## Testing steps

Tested against conditions where browser is zoomed in on 150% and 200%

## Breaking Changes

no breaking changes

## Dependencies and/or References

No dependencies

## Deployment

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request addresses a UI issue in the Bynder app where the Add Asset button disappears when the browser is zoomed in at 150% or 200%. The fix reduces the dialog's minimum height from 80vh to 70vh to accommodate zoomed views, ensuring better usability without introducing breaking changes or new dependencies.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changes the minHeight parameter from '80vh' to '70vh' in the openDialog function (openDialog method) in index.jsx to fix Add Asset button visibility issues during browser zoom.</li>

</ul>
</details>

</div>