### PR TITLE
fix(cloudinary2): undefined in video thumbnail URLs [ES-229]

### DIFF
--- a/apps/cloudinary2/src/locations/Field/Thumbnail.tsx
+++ b/apps/cloudinary2/src/locations/Field/Thumbnail.tsx
@@ -273,12 +273,12 @@ function getUrlFromAsset(installationParams: AppInstallationParameters, asset: C
       asset.version != null
         ? {
             type: asset.type,
-            rawTransformation: `/h_149/f_avif,fl_animated,e_loop/${asset.raw_transformation}`,
+            rawTransformation: `/h_149/f_avif,fl_animated,e_loop/${asset.raw_transformation ?? ''}`,
             version: String(asset.version),
           }
         : {
             type: asset.type,
-            rawTransformation: `/h_149/f_avif,fl_animated,e_loop/${asset.raw_transformation}`,
+            rawTransformation: `/h_149/f_avif,fl_animated,e_loop/${asset.raw_transformation ?? ''}`,
           };
 
     return cloudinary.video_url(asset.public_id, videoOptions);


### PR DESCRIPTION
### Purpose
Fix video thumbnail URLs containing the literal string `undefined` when a Cloudinary asset has no transformation applied.

### Approach
Added nullish coalescing (`?? ''`) to the video `rawTransformation` interpolation, matching the existing guard already used for image thumbnails on the same function's earlier line. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes an issue where video thumbnail URLs would contain the literal string 'undefined' when a Cloudinary asset lacks a transformation applied, by adding nullish coalescing to the raw_transformation interpolation in the video handling logic, matching the existing guard used for image thumbnails.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds nullish coalescing (`?? ''`) to `asset.raw_transformation` in video thumbnail URL generation in Thumbnail.tsx to prevent 'undefined' from appearing in URLs when the property is not set.</li>

</ul>
</details>

</div>