### PR TITLE
fix: Optimize entries fetch for variation entry cards []

### DIFF
--- a/apps/vwo-fme/src/components/CreateContent.js
+++ b/apps/vwo-fme/src/components/CreateContent.js
@@ -41,7 +41,9 @@ function CreateContent(props) {
   const editContent = (vwoVariation) => {
     setSelectContentType(false);
     props.sdk.navigator.openEntry(vwoVariation.variables[0].value, { slideIn: { waitForClose: true } }).then((updatedEntry) => {
-      props.updateContentfulEntries(updatedEntry);
+      if (updatedEntry && props.onRefreshVariationEntries) {
+        props.onRefreshVariationEntries();
+      }
     });
   };
 
@@ -59,7 +61,7 @@ function CreateContent(props) {
       if (vwoVariation) {
         delete meta[vwoVariation.id];
         props.sdk.entry.fields.meta.setValue(meta);
-        props.updateVwoVariationContent(vwoVariation, '', false);
+        props.updateVwoVariationContent(vwoVariation, '');
       }
     },
     [props]

--- a/apps/vwo-fme/src/components/VariationItem.js
+++ b/apps/vwo-fme/src/components/VariationItem.js
@@ -92,7 +92,7 @@ function VariationItem(props) {
           <CreateContent
             sdk={props.sdk}
             variation={props.variation}
-            updateContentfulEntries={props.updateContentfulEntries}
+            onRefreshVariationEntries={props.onRefreshVariationEntries}
             contentTypes={props.contentTypes}
             linkExistingEntry={props.linkExistingEntry}
             updateVwoVariationContent={props.updateVwoVariationContent}

--- a/apps/vwo-fme/src/components/Variations.js
+++ b/apps/vwo-fme/src/components/Variations.js
@@ -78,7 +78,7 @@ function Variations(props) {
           sdk={props.sdk}
           variation={defaultVariation}
           contentTypes={props.contentTypes}
-          updateContentfulEntries={props.updateContentfulEntries}
+          onRefreshVariationEntries={fetchMappedVariations}
           linkExistingEntry={props.linkExistingEntry}
           onCreateVariationEntry={props.onCreateVariationEntry}
           updateVwoVariationContent={props.updateVwoVariationContent}
@@ -117,7 +117,7 @@ function Variations(props) {
                         variation={variation}
                         linkExistingEntry={props.linkExistingEntry}
                         contentTypes={props.contentTypes}
-                        updateContentfulEntries={props.updateContentfulEntries}
+                        onRefreshVariationEntries={fetchMappedVariations}
                         updateVwoVariationName={props.updateVwoVariationName}
                         onCreateVariationEntry={props.onCreateVariationEntry}
                         updateVwoVariationContent={props.updateVwoVariationContent}

--- a/apps/vwo-fme/src/locations/EntryEditor.jsx
+++ b/apps/vwo-fme/src/locations/EntryEditor.jsx
@@ -26,14 +26,12 @@ const initialState = (sdk) => ({
   contentTypes: [],
   meta: sdk.entry.fields.meta?.getValue() || {},
   featureFlag: sdk.entry.fields.featureFlag.getValue() || {},
-  entries: {},
 });
 
 const actionTypes = {
   SET_INITIAL_DATA: 'SET_INITIAL_DATA',
   SET_LOADING: 'SET_LOADING',
   SET_FEATURE_FLAG: 'SET_FEATURE_FLAG',
-  SET_ENTRIES: 'SET_ENTRIES',
   SET_ERROR: 'SET_ERROR',
   SET_META: 'SET_META',
 };
@@ -46,15 +44,12 @@ const reducer = (state, action) => {
         ...state,
         featureFlag: action.payload.featureFlag,
         contentTypes: action.payload.contentTypes,
-        entries: action.payload.entries,
         error: action.payload.error,
       };
     case actionTypes.SET_LOADING:
       return { ...state, loading: action.payload };
     case actionTypes.SET_FEATURE_FLAG:
       return { ...state, featureFlag: action.payload };
-    case actionTypes.SET_ENTRIES:
-      return { ...state, entries: action.payload };
     case actionTypes.SET_ERROR:
       return { ...state, error: action.payload };
     case actionTypes.SET_META:
@@ -79,11 +74,7 @@ const EntryEditor = (props) => {
   const vwoService = useMemo(() => new VwoAppActionService(props.sdk), [props.sdk]);
   
   const fetchInitialData = useCallback(async () => {
-    const space  = props.sdk.space;
-    const [contentTypes, entries] = await Promise.all([
-      space.getContentTypes({ order: 'name', limit: 1000}),
-      space.getEntries({ skip: 0, limit: 1000})
-    ]);
+    const contentTypes = await props.sdk.space.getContentTypes({ order: 'name', limit: 1000 });
     const featureFlag = props.sdk.entry.fields.featureFlag.getValue();
     let error = '';
     if(featureFlag?.id){
@@ -99,7 +90,6 @@ const EntryEditor = (props) => {
     return {
       featureFlag: featureFlag,
       contentTypes: contentTypes.items,
-      entries: entries.items,
       error: error
     }
   }, [props.sdk.entry.fields.featureFlag, props.sdk.notifier, vwoService, props.sdk.space]);
@@ -172,23 +162,7 @@ const EntryEditor = (props) => {
     });
   }
 
-  const updateContentfulEntries = useCallback(async (updatedEntry) => {
-    if(updatedEntry){
-      await props.sdk.space.getEntries({ skip: 0, limit: 1000}).then(resp => {
-          let entries = resp.items.map(entry => {
-            if(updatedEntry.entity.sys.id === entry.sys.id){
-              return updatedEntry.entity;
-            }
-            return entry;
-          });
-          dispatch({ type: actionTypes.SET_ENTRIES, payload: entries });
-      });
-    } else {
-      props.sdk.space.getEntries({ skip: 0, limit: 1000}).then(resp => dispatch({ type: actionTypes.SET_ENTRIES, payload: resp.items }));
-    }
-  }, [props.sdk.space]);
-
-  const updateVwoVariationContent = async (variation, contentId, updateEntries) => {
+  const updateVwoVariationContent = async (variation, contentId) => {
     // Default variation cannot be edited directly. Update variable instead and default variations will be updated
     if(variation.id === 1){
       let featureFlag = state.featureFlag;      
@@ -203,9 +177,6 @@ const EntryEditor = (props) => {
         updatedFeatureFlag.variations.sort((a,b) => b.id-a.id);
         dispatch({ type: actionTypes.SET_FEATURE_FLAG, payload: updatedFeatureFlag });
         props.sdk.entry.fields.featureFlag.setValue(updatedFeatureFlag);
-        if(updateEntries){
-          updateContentfulEntries();
-        }
         props.sdk.notifier.success('VWO Variations updated successfully');
       })
       .catch(err => {
@@ -227,9 +198,6 @@ const EntryEditor = (props) => {
         featureFlag.variations = variations;
         dispatch({ type: actionTypes.SET_FEATURE_FLAG, payload: featureFlag });
         props.sdk.entry.fields.featureFlag.setValue(featureFlag);
-        if(updateEntries){
-          updateContentfulEntries();
-        }
       })
       .catch(err => {
         props.sdk.notifier.error(err);
@@ -271,7 +239,7 @@ const EntryEditor = (props) => {
       [vwoVariation.id]: data.sys.id
     });
 
-    updateVwoVariationContent(vwoVariation, data.sys.id, false);
+    updateVwoVariationContent(vwoVariation, data.sys.id);
   }
 
   const onCreateVariationEntry = async(vwoVariation, contentType) => {
@@ -280,8 +248,6 @@ const EntryEditor = (props) => {
     }).then(async (updatedEntry) => {
       return updatedEntry;
    });
-
-   await updateContentfulEntries(data);
 
     if(!data){
       return;
@@ -294,7 +260,7 @@ const EntryEditor = (props) => {
       [vwoVariation.id]: data.entity.sys.id
     });
 
-    updateVwoVariationContent(vwoVariation, data.entity.sys.id, true);
+    updateVwoVariationContent(vwoVariation, data.entity.sys.id);
   };
 
   useEffect( () => {
@@ -342,9 +308,7 @@ const EntryEditor = (props) => {
             contentTypes={state.contentTypes}
             onCreateVariationEntry={onCreateVariationEntry}
             linkExistingEntry={linkExistingEntry}
-            updateContentfulEntries={updateContentfulEntries}
-            updateVwoVariationContent={updateVwoVariationContent}
-            entries = {state.entries}/>
+            updateVwoVariationContent={updateVwoVariationContent}/>
         }
         <Modal onClose={() => dispatch({ type: actionTypes.SET_ERROR, payload: '' })} isShown={!!state.error && !state.loading}>
           {() => (

--- a/apps/vwo-fme/src/utils.js
+++ b/apps/vwo-fme/src/utils.js
@@ -39,6 +39,31 @@ export const validateCredentials = async (accountId, apiToken) => {
   }
 };
 
+export const buildEntrySelectForContentTypes = (contentTypes) => {
+  const fieldIds = new Set();
+
+  contentTypes.forEach((contentType) => {
+    if (contentType.displayField) {
+      fieldIds.add(contentType.displayField);
+    }
+
+    const descriptionField = contentType.fields?.filter((field) => field.id !== contentType.displayField).find((field) => field.type === 'Text');
+
+    if (descriptionField) {
+      fieldIds.add(descriptionField.id);
+    }
+  });
+
+  return [
+    'sys.id',
+    'sys.contentType',
+    'sys.archivedVersion',
+    'sys.publishedVersion',
+    'sys.version',
+    ...[...fieldIds].map((fieldId) => `fields.${fieldId}`),
+  ].join(',');
+};
+
 export const getRequiredEntryInformation = (entry, contentTypes, defaultLocale) => {
   const contentTypeId = get(entry, ['sys', 'contentType', 'sys', 'id']);
   const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
@@ -65,10 +90,16 @@ export const getRequiredEntryInformation = (entry, contentTypes, defaultLocale) 
 
 export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, defaultLocale, getEntries) => {
   const _vwoVariations = Array.isArray(vwoVariations) ? vwoVariations : [vwoVariations];
-  const entries = await getEntries({
-    'sys.id[in]': Array.from(new Set(_vwoVariations.map((vwoVariation) => vwoVariation?.variables[0]?.value ?? ''))).join(','),
-  });
-  const entryItems = entries.items;
+  const entryIds = [...new Set(_vwoVariations.map((vwoVariation) => vwoVariation?.variables[0]?.value).filter(Boolean))];
+
+  let entryItems = [];
+  if (entryIds.length > 0) {
+    const entries = await getEntries({
+      'sys.id[in]': entryIds.join(','),
+      select: buildEntrySelectForContentTypes(contentTypes),
+    });
+    entryItems = entries.items;
+  }
   return _vwoVariations.map((vwoVariation) => {
     if (vwoVariation.variables.length && vwoVariation.variables[0].value) {
       let contentId = vwoVariation.variables[0].value;


### PR DESCRIPTION
## Purpose

Improve Entry Editor performance and network efficiency when loading and displaying linked Contentful entries on VWO variation cards. The goal is to fetch only the data needed for variation entry cards—title, description, content type, and publication status—while keeping the editor responsive as feature flags and variations are created, linked, and updated.

## Approach

- **Leaner initial load** — Entry Editor initialization now loads content types and feature-flag data only; entry data for variation cards is fetched on demand when variations are mapped, rather than upfront in bulk.
- **Targeted entry queries** — `mapVwoVariationsAndContent` fetches linked entries by ID (`sys.id[in]`) and uses Contentful’s [`select`](https://www.contentful.com/developers/docs/tutorials/general/modifying-api-responses/) via `buildEntrySelectForContentTypes()` to limit the response to fields required for variation cards: `sys` metadata (id, content type, version/status) plus each content type’s display field and description text field.
- **Smarter refresh after edits** — After editing a linked entry in the slide-in, variation cards refresh through `onRefreshVariationEntries` → `fetchMappedVariations`, so titles and status stay in sync without redundant full-space entry syncs.

Field selection is derived from content type definitions (`displayField` and the first `Text` field used for description), so the optimization scales across content types without hard-coding field names like `title` or `name`.

## Testing steps

1. Open a VWO feature-flag entry in the Entry Editor (feature flag already created).
2. Confirm the editor loads and variation blocks render as expected.
3. **Default variation:** Create or link an entry → verify the entry card shows title, content type, and status.
4. **Other variations:** Add a variation, link or create content → verify cards appear with correct metadata.
5. **Edit linked entry:** Open an entry from a variation card (slide-in), change the title, close → confirm the card reflects the update.
6. **Remove content** (non-default variation): Remove linked entry → card should clear.
7. Optional: In devtools network tab, confirm linked-entry requests use `sys.id[in]` and include a `select` query param with a reduced payload.

## Breaking Changes

None. Editor behavior for editors is unchanged; this is an internal fetch and refresh optimization. No schema, installation parameter, or manifest changes.

## Dependencies and/or References

- [Contentful: Modifying REST API responses (`select`)](https://www.contentful.com/developers/docs/tutorials/general/modifying-api-responses/)
- [Contentful App SDK](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/)

## Deployment

Standard `vwo-fme` app bundle deploy. No migration, env var, or manifest changes required.
