### PR TITLE
fix(cloudinary2): restore saved crop transformation on image editor reopen [ES-282]

### DIFF
--- a/apps/cloudinary2/src/locations/ImageEditorDialog.tsx
+++ b/apps/cloudinary2/src/locations/ImageEditorDialog.tsx
@@ -69,7 +69,7 @@ const ImageEditorDialog = () => {
           layoutStyle: 'single',
           layout: 'tabs',
           image: {
-            transformation: [{ rawTransformation: asset.original_raw_transformation }],
+            transformation: [{ rawTransformation: asset.raw_transformation || asset.original_raw_transformation }],
             steps,
             resizeAndCrop: {
               toggleAspectRatio: true,


### PR DESCRIPTION
## Summary

- The Cloudinary image editor dialog was always initializing from `original_raw_transformation`, ignoring any crop that had been previously saved
- After cropping and saving, reopening the dialog would show the full original image instead of the saved crop state
- Fix: prefer `raw_transformation` (the user's last saved crop) over `original_raw_transformation` on init, keeping the original as fallback for assets that have never been cropped

Before crop
<img width="432" height="540" alt="image" src="https://github.com/user-attachments/assets/178b4d8f-b4a8-4371-b31d-dd3790e265d9" />

After crop
<img width="386" height="497" alt="image" src="https://github.com/user-attachments/assets/31e2bd44-434d-4f14-af95-6e398b1d8f74" />

Crop preserved in editor
<img width="1389" height="1038" alt="image" src="https://github.com/user-attachments/assets/e240bb5c-2f17-4336-a540-d3ef6ce3f1ed" />


## Test plan

- [ ] Install Cloudinary app locally (`localhost:3001`)
- [ ] Open an entry with a Cloudinary image field
- [ ] Crop an image in the editor and hit Update
- [ ] Close and reopen the dialog — should open at the previously cropped state, not full image
- [ ] For an asset that has never been cropped, confirm editor still opens at the original transformation

Fixes: [ES-282](https://contentful.atlassian.net/browse/ES-282)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ES-282]: https://contentful.atlassian.net/browse/ES-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bug in the Cloudinary2 app where the image editor dialog would always initialize from the original image state, ignoring any crop that had been previously saved. When a user crops an image, saves it, and reopens the dialog, it now correctly displays the saved crop state instead of resetting to the full original image. For assets that have never been cropped, the editor still opens at the original transformation as expected.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Modified ImageEditorDialog.tsx to prioritize asset.raw_transformation (saved crop) over asset.original_raw_transformation when initializing the Cloudinary media editor, ensuring previously cropped images reopen at their saved state</li>

<li>Added fallback to original_raw_transformation for assets that have never been cropped, maintaining backward compatibility</li>

</ul>
</details>

</div>