### PR TITLE
chore: exclude github-actions bot from PR title check []

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-title:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@077bddd7bdabd0d2b1b25ed0754c7e62e184d7ee # master


### PR DESCRIPTION
## Summary

- release-please PRs are opened by `github-actions[bot]` and use the title pattern `chore: release X Y` with no `[]` ticket reference
- This causes the PR title check to fail every time, requiring a manual title edit before merging
- Excludes `github-actions[bot]` from the check the same way `dependabot[bot]` is already excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)