### PR TITLE
fix(vwo-fme): resolve entries BadRequest and app action NotFound in production []

### DIFF
--- a/apps/vwo-fme/src/services/vwoAppActionService.js
+++ b/apps/vwo-fme/src/services/vwoAppActionService.js
@@ -23,7 +23,7 @@ class VwoAppActionService {
    */
   async initialize() {
     try {
-      const appActions = await this.cma.appAction.getManyForEnvironment({});
+      const appActions = await this.cma.appAction.getManyForEnvironment({ appDefinitionId: this.sdk.ids.app });
 
       const appAction = appActions.items.find((action) => action.name === globalConstants.VWO_APP_ACTION_NAME);
 

--- a/apps/vwo-fme/src/utils.js
+++ b/apps/vwo-fme/src/utils.js
@@ -39,31 +39,6 @@ export const validateCredentials = async (accountId, apiToken) => {
   }
 };
 
-export const buildEntrySelectForContentTypes = (contentTypes) => {
-  const fieldIds = new Set();
-
-  contentTypes.forEach((contentType) => {
-    if (contentType.displayField) {
-      fieldIds.add(contentType.displayField);
-    }
-
-    const descriptionField = contentType.fields?.filter((field) => field.id !== contentType.displayField).find((field) => field.type === 'Text');
-
-    if (descriptionField) {
-      fieldIds.add(descriptionField.id);
-    }
-  });
-
-  return [
-    'sys.id',
-    'sys.contentType',
-    'sys.archivedVersion',
-    'sys.publishedVersion',
-    'sys.version',
-    ...[...fieldIds].map((fieldId) => `fields.${fieldId}`),
-  ].join(',');
-};
-
 export const getRequiredEntryInformation = (entry, contentTypes, defaultLocale) => {
   const contentTypeId = get(entry, ['sys', 'contentType', 'sys', 'id']);
   const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
@@ -96,7 +71,6 @@ export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, de
   if (entryIds.length > 0) {
     const entries = await getEntries({
       'sys.id[in]': entryIds.join(','),
-      select: buildEntrySelectForContentTypes(contentTypes),
     });
     entryItems = entries.items;
   }


### PR DESCRIPTION
## Summary

Two production-only bugs introduced or exposed by #8200 that are blocking the VWO linking feature for customers.

**Bug 1 — Entries BadRequest** (`src/utils.js`)

The `select` parameter added in #8200 causes a `BadRequest` in production:

> A Content Type ID is required. When querying for Entries and involving fields you need to limit your query to a specific Content Type.

The Contentful API requires `content_type` whenever `select` includes `fields.*`. Since variation entries can span any content type, we can't provide one. The fix is to drop `select` — the query is already scoped to a handful of specific IDs via `sys.id[in]`, so the overhead is minimal and this matches the pre-#8200 behavior.

**Bug 2 — App Action NotFound** (`src/services/vwoAppActionService.js`)

`getManyForEnvironment({})` was called without scoping to `appDefinitionId`, so in spaces with multiple apps installed the lookup could resolve to an unrelated app's action. Passing `appDefinitionId: this.sdk.ids.app` scopes it correctly.

## Test plan

- [ ] Open a VWO feature-flag entry in the Entry Editor in a space where the app is installed
- [ ] Confirm variation cards load without a console error or BadRequest in the network tab
- [ ] Link an existing entry to the default variation and confirm the UI updates
- [ ] Add a new variation and link an entry to it
- [ ] Confirm no App Action NotFound error in the network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes two production bugs in the VWO Feature Manager Extension that were blocking the VWO linking feature for customers. The first bug caused a BadRequest error when loading variation entries due to an incompatible `select` parameter in Contentful queries. The second bug caused an App Action NotFound error when multiple apps are installed in the same space.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removed the `select` parameter and `buildEntrySelectForContentTypes` function from entry queries in `utils.js` to fix a BadRequest error caused by the Contentful API requiring `content_type` when `select` includes `fields.*`</li>

<li>Added `appDefinitionId: this.sdk.ids.app` to `getManyForEnvironment({})` in `vwoAppActionService.js` to scope app action lookups to the current app, fixing NotFound errors in spaces with multiple apps installed</li>

</ul>
</details>

</div>