### PR TITLE
fix(ci): remove cross-machine Nx cache restoration []

### DIFF
--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -56,17 +56,6 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      # Restore Nx build cache to skip rebuilding unchanged code
-      # Nx caches build outputs (dist/build folders) based on file hashes
-      # This can reduce build time from minutes to seconds for unchanged apps
-      - name: Restore Nx cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: /tmp/nxcache
-          key: nx-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            nx-${{ runner.os }}-
-
       # Install root-level dependencies (lerna, nx, etc.)
       # Required before we can run lerna commands
       - name: Install root-level project


### PR DESCRIPTION
Restoring /tmp/nxcache from a previous runner caused Nx to warn that the cache was not generated on the current machine, breaking the build-and-deploy job. Remove the Restore Nx cache step and the NX_REJECT_UNKNOWN_LOCAL_CACHE workaround that suppressed the error.

https://github.com/contentful/marketplace-partner-apps/actions/runs/27288295462/job/80623124279
<img width="1691" height="675" alt="Screenshot 2026-06-11 at 9 07 56 AM" src="https://github.com/user-attachments/assets/7ad81a6d-99c4-44d5-a4ec-ef0b8aaa56c1" />
