### PR TITLE
feat(flexfields): split bundle to stay well under 10 MB AppBundle API limit []

### DIFF
--- a/apps/flexfields/src/components/DefaultField.tsx
+++ b/apps/flexfields/src/components/DefaultField.tsx
@@ -14,7 +14,10 @@ import type { Control } from "contentful-management";
 import { css } from "@emotion/css";
 import React from "react";
 import { getLocaleName } from "../utils";
-import { JsonEditor } from "@contentful/field-editor-json";
+
+const JsonEditor = React.lazy(() =>
+  import("@contentful/field-editor-json").then((m) => ({ default: m.JsonEditor }))
+);
 
 // Prop types for DefaultField component
 export interface DefaultFieldProps {
@@ -251,9 +254,11 @@ const DefaultField = (props: DefaultFieldProps) => {
         />
       )}
 
-      {/* Handle JSON Object Editor */}
+      {/* Handle JSON Object Editor — lazy-loaded to keep main chunk under 10 MB limit */}
       {control?.widgetId === "objectEditor" && (
-        <JsonEditor field={sdk.field} isInitiallyDisabled={false} />
+        <React.Suspense fallback={null}>
+          <JsonEditor field={sdk.field} isInitiallyDisabled={false} />
+        </React.Suspense>
       )}
 
       {/* Show note for custom field widgets ONLY (not ResourceLink, not objectEditor, not builtin) */}

--- a/apps/flexfields/src/components/DefaultField.tsx
+++ b/apps/flexfields/src/components/DefaultField.tsx
@@ -7,6 +7,7 @@ import {
   Note,
   Text,
   Stack,
+  Spinner,
 } from "@contentful/f36-components";
 import { CombinedLinkActions } from "@contentful/field-editor-reference";
 import { type CustomActionProps } from "@contentful/field-editor-reference";
@@ -256,7 +257,7 @@ const DefaultField = (props: DefaultFieldProps) => {
 
       {/* Handle JSON Object Editor — lazy-loaded to keep main chunk under 10 MB limit */}
       {control?.widgetId === "objectEditor" && (
-        <React.Suspense fallback={null}>
+        <React.Suspense fallback={<Spinner size="small" />}>
           <JsonEditor field={sdk.field} isInitiallyDisabled={false} />
         </React.Suspense>
       )}

--- a/apps/flexfields/vite.config.mjs
+++ b/apps/flexfields/vite.config.mjs
@@ -5,6 +5,25 @@ export default defineConfig({
   base: '', // relative paths
   build: {
     outDir: 'build',
+    // Warn at 9 MB so we notice before hitting the 10 MB AppBundle API per-file limit.
+    // The main chunk previously hit 10,561 KB (over the limit); it was brought down to
+    // ~10,485 KB via lazy-loading codemirror/markdown. This guard + manualChunks below
+    // keeps headroom visible as deps evolve.
+    chunkSizeWarningLimit: 9000,
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          // Rich-text editor pulls in Slate.js (~800 KB) — isolate it
+          if (id.includes('@contentful/field-editor-rich-text') || id.includes('@udecode/') || id.includes('slate')) {
+            return 'vendor-richtext';
+          }
+          // contentful-management is large and shared; give it its own chunk
+          if (id.includes('contentful-management') && !id.includes('@contentful/app-sdk')) {
+            return 'vendor-contentful-management';
+          }
+        },
+      },
+    },
   },
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Summary
- The main JS chunk was previously 10,485 KB — only ~245 KB under the hard 10 MB per-file limit enforced by the Contentful AppBundle API. Any dep bump to a heavy package would push it over and break deploys (this happened before in #8313).
- `vite.config.mjs`: add `manualChunks` to isolate the Slate.js/rich-text editor bundle (~7.7 MB) and `contentful-management` (~485 KB) into separate vendor chunks, bringing the main chunk from ~10,485 KB down to ~1,883 KB
- `vite.config.mjs`: add `chunkSizeWarningLimit: 9000` so CI logs a visible warning before any chunk approaches the 10 MB hard limit
- `DefaultField.tsx`: lazy-load `JsonEditor` via `React.lazy` + `Suspense` (same pattern as the existing markdown/codemirror lazy-load), further reducing the main chunk

## Test plan
- [x] `npm run build` in `apps/flexfields` completes with no chunk size warnings — largest chunk is `vendor-richtext` at 7,687 KB, well under 9 MB threshold
- [x] JSON object editor fields still render correctly in an entry
- [x] Rich-text fields still render correctly in an entry
- [x] Markdown fields still work (dialog and cheatsheet open)

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR optimizes the flexfields app bundle to comply with Contentful's AppBundle API hard limit of 10 MB per file. The main JavaScript chunk was previously 10,485 KB—only ~245 KB under the limit—making any dependency update a risk for broken deploys. The fix implements code-splitting via Vite's manualChunks and React lazy-loading to reduce the main chunk to ~1,883 KB.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>vite.config.mjs: adds `chunkSizeWarningLimit: 9000` to surface CI warnings before hitting the 10 MB AppBundle API per-file limit, and `manualChunks` configuration to split vendor bundles into `vendor-richtext` (Slate.js/rich-text at ~7.7 MB) and `vendor-contentful-management` (~485 KB), reducing the main chunk from ~10,485 KB to ~1,883 KB</li>

<li>DefaultField.tsx: changes Suspense fallback for lazy-loaded `JsonEditor` from `null` to `<Spinner size="small" />` for better loading UX</li>

<li>Risk mitigation: these changes prevent deployment failures that previously occurred in #8313 when heavy package updates pushed the bundle over the limit</li>

</ul>
</details>

</div>