### PR TITLE
refactor(vwo-fme): rebrand VWO references to Wingify []

### DIFF
--- a/apps/vwo-fme/contentful-app-manifest.json
+++ b/apps/vwo-fme/contentful-app-manifest.json
@@ -2,12 +2,12 @@
   "functions": [
     {
       "id": "handleVWOCalls",
-      "name": "VWO Calls",
+      "name": "Wingify Calls",
       "description": "Template for creating custom app actions. Add your own code to define how your app should respond when an action is triggered.",
       "path": "functions/handleVWOCalls.js",
       "entryFile": "functions/handleVWOCalls.js",
       "allowNetworks": [
-        "https://*.vwo.com"
+        "https://*.wingify.com"
       ],
       "accepts": [
         "appaction.call"
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "handleVWOActions",
-      "name": "VWO Actions",
+      "name": "Wingify Actions",
       "type": "function-invocation",
       "functionId": "handleVWOCalls",
       "category": "Custom",

--- a/apps/vwo-fme/functions/handleVWOCalls.js
+++ b/apps/vwo-fme/functions/handleVWOCalls.js
@@ -15,14 +15,14 @@ import VwoClient from './vwo-client.js';
  */
 function initVwoClient({ accountId, accessToken }) {
   if (!accountId || !accessToken) {
-    throw new Error('VWO_ACCOUNT_ID and VWO_AUTH_TOKEN environment variables are required. Please configure them in your app settings.');
+    throw new Error('Wingify account ID and access token are required. Please configure them in your app settings.');
   }
 
   return new VwoClient({
     accountId,
     authToken: accessToken,
     onReauth: () => {
-      console.log('VWO authentication failed. Please check your credentials.');
+      console.log('Wingify authentication failed. Please check your credentials.');
     },
   });
 }
@@ -129,7 +129,7 @@ export const handler = async (event, context) => {
 
     return result;
   } catch (error) {
-    console.error('VWO Feature Flag Handler Error:', error);
+    console.error('Wingify Feature Flag Handler Error:', error);
     return {
       success: false,
       error: error.message || 'An unexpected error occurred',

--- a/apps/vwo-fme/functions/vwo-client.js
+++ b/apps/vwo-fme/functions/vwo-client.js
@@ -7,12 +7,12 @@ export default class VwoClient {
     this.accountId = params.accountId;
     this.accessToken = params.authToken;
     this.featureId = '';
-    this.baseUrl = 'https://app.vwo.com/api/v2';
+    this.baseUrl = 'https://app.wingify.com/api/v2';
     this.onReauth = params.onReauth;
   }
 
   createFeatureFlag = async (featureFlag) => {
-    let url = `https://app.vwo.com/api/v2/accounts/${this.accountId}/features`;
+    let url = `https://app.wingify.com/api/v2/accounts/${this.accountId}/features`;
     const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify(featureFlag),
@@ -38,7 +38,7 @@ export default class VwoClient {
     if (!this.featureId) {
       this.featureId = featureId;
     }
-    let url = `https://app.vwo.com/api/v2/accounts/${this.accountId}/features/${this.featureId}`;
+    let url = `https://app.wingify.com/api/v2/accounts/${this.accountId}/features/${this.featureId}`;
     const response = await fetch(url, {
       method: 'GET',
       headers: {
@@ -61,7 +61,7 @@ export default class VwoClient {
   updateFeatureFlag = async (featureFlag) => {
     featureFlag.variations = featureFlag?.variations?.filter((variation) => variation.id !== 1) ?? [];
     this.featureId = this.featureId || featureFlag.id;
-    let url = `https://app.vwo.com/api/v2/accounts/${this.accountId}/features/${this.featureId}`;
+    let url = `https://app.wingify.com/api/v2/accounts/${this.accountId}/features/${this.featureId}`;
     const response = await fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(featureFlag),
@@ -80,7 +80,7 @@ export default class VwoClient {
   };
 
   updateVariations = async (variations, featureId) => {
-    let url = `https://app.vwo.com/api/v2/accounts/${this.accountId}/features/${featureId}`;
+    let url = `https://app.wingify.com/api/v2/accounts/${this.accountId}/features/${featureId}`;
     const response = await fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(variations),

--- a/apps/vwo-fme/src/locations/ConfigScreen.jsx
+++ b/apps/vwo-fme/src/locations/ConfigScreen.jsx
@@ -64,7 +64,7 @@ export default class ConfigScreen extends React.Component {
       sys: {
         id: VARIATION_CONTAINER_ID,
       },
-      name: "VWO FME Wrapper",
+      name: "Wingify FME Wrapper",
       displayField: "title",
       fields: [
         {
@@ -75,7 +75,7 @@ export default class ConfigScreen extends React.Component {
           "required": false,
           "validations": [],
           "defaultValue": {
-            [this.props.sdk.locales.default]: '[VWO] FME Entry',
+            [this.props.sdk.locales.default]: '[Wingify] FME Entry',
           },
           "disabled": false,
           "omitted": false
@@ -201,14 +201,14 @@ export default class ConfigScreen extends React.Component {
   areAllInputsProvided = () => {
     if (!this.state.config.accountId) {
       this.props.sdk.notifier.error(
-        "You must provide a VWO access token to connect to the VWO app!"
+        "You must provide a Wingify access token to connect to the Wingify app!"
       );
       return false;
     }
 
     if (!this.state.config.accessToken) {
       this.props.sdk.notifier.error(
-        "You must provide an api key to connect to the VWO app!"
+        "You must provide an api key to connect to the Wingify app!"
       );
       return false;
     }
@@ -219,7 +219,7 @@ export default class ConfigScreen extends React.Component {
   onConfigure = async () => {
     if (!this.props.accessToken) {
       this.props.sdk.notifier.error(
-        "You must be connect to the VWO in order to configure/install the app!"
+        "You must be connect to the Wingify in order to configure/install the app!"
       );
       return false;
     }
@@ -368,18 +368,18 @@ export default class ConfigScreen extends React.Component {
               <Flex alignItems='center' justifyContent='space-between' marginBottom='spacingL'>
                 <Heading marginBottom='none'>Configuration</Heading>
                 <TextLink
-                  href='https://app.vwo.com/'
+                  href='https://app.wingify.com/'
                   target='_blank'
                   icon={<ExternalLinkIcon />}
                   alignIcon='start'
-                  rel="noopener noreferrer">Open VWO</TextLink>
+                  rel="noopener noreferrer">Open Wingify</TextLink>
               </Flex>
               <FormControl className={styles.formItem}>
                   <FormControl.Label isRequired>Account ID</FormControl.Label>
                   <TextInput
                     value={this.state.config.accountId}
                     onChange={(e) => this.onAccountIdChange(e.target.value)}/>
-                  <Paragraph marginTop='spacingS'>Locate account ID in settings page. See <TextLink href='https://help.vwo.com/hc/en-us/articles/40825355345177-Integrating-VWO-Feature-Flags-with-Contentful-CMS' target='_blank' rel="noopener noreferrer">knowledge base</TextLink> for more details.</Paragraph>
+                  <Paragraph marginTop='spacingS'>Locate account ID in settings page. See <TextLink href='https://help.wingify.com/hc/en-us/articles/40825355345177-Integrating-Wingify-Feature-Flags-with-Contentful-CMS' target='_blank' rel="noopener noreferrer">knowledge base</TextLink> for more details.</Paragraph>
               </FormControl>
               <FormControl className={styles.formItem}>
                   <FormControl.Label isRequired>API Key</FormControl.Label>
@@ -387,17 +387,17 @@ export default class ConfigScreen extends React.Component {
                     type='password'
                     value={this.state.config.accessToken}
                     onChange={(e) => this.onApiKeyChange(e.target.value)}/>
-                  <Paragraph marginTop='spacingS'>View the auth token in Integrations &gt; Contentful &gt; Config section. See <TextLink href='https://help.vwo.com/hc/en-us/articles/40825355345177-Integrating-VWO-Feature-Flags-with-Contentful-CMS' target='_blank' rel="noopener noreferrer">knowledge base</TextLink> for more details.</Paragraph>
+                  <Paragraph marginTop='spacingS'>View the auth token in Integrations &gt; Contentful &gt; Config section. See <TextLink href='https://help.wingify.com/hc/en-us/articles/40825355345177-Integrating-Wingify-Feature-Flags-with-Contentful-CMS' target='_blank' rel="noopener noreferrer">knowledge base</TextLink> for more details.</Paragraph>
               </FormControl>
-              <Note marginBottom='spacingXl'>This token grants read-only access to organization-level information stored in VWO. It is accessible via API by any users within the current Contentful space.</Note>
-              <Button variant='primary' onClick={this.connectToVwo} isLoading={this.state.loading}>Connect with VWO</Button>
+              <Note marginBottom='spacingXl'>This token grants read-only access to organization-level information stored in Wingify. It is accessible via API by any users within the current Contentful space.</Note>
+              <Button variant='primary' onClick={this.connectToVwo} isLoading={this.state.loading}>Connect with Wingify</Button>
             </Flex>}
             {/* After connecting to VWO */}
             {!!this.props.accessToken && !isInstalled
               && <Flex flexDirection='column' alignItems='start' className={styles.body}>
               <Stepper currentStep={2}/>
               <Heading marginBottom='spacingXl'>Just one more step!</Heading>
-              <Note variant='warning' marginBottom='spacingL'>To complete setup, click 'Install' in the top-right corner and start using the VWO FME app.</Note>
+              <Note variant='warning' marginBottom='spacingL'>To complete setup, click 'Install' in the top-right corner and start using the Wingify FME app.</Note>
             </Flex>}
 
             {/* After installing the VWO */}

--- a/apps/vwo-fme/src/locations/EntryEditor.jsx
+++ b/apps/vwo-fme/src/locations/EntryEditor.jsx
@@ -133,7 +133,7 @@ const EntryEditor = (props) => {
     return updateVariationsInVwo(updatedVwoVariations)
     .then(variations => {
       variations.sort((a,b) => b.id-a.id);
-      props.sdk.notifier.success('VWO Variation name updated successfully');
+      props.sdk.notifier.success('Wingify Variation name updated successfully');
       return true;
     })
     .catch(err => {
@@ -153,7 +153,7 @@ const EntryEditor = (props) => {
       featureFlag.variations = variations;
       dispatch({ type: actionTypes.SET_FEATURE_FLAG, payload: featureFlag });
       props.sdk.entry.fields.featureFlag.setValue(featureFlag);
-      props.sdk.notifier.success('VWO Variation added successfully');
+      props.sdk.notifier.success('Wingify Variation added successfully');
       return true;
     })
     .catch(err => {
@@ -177,7 +177,7 @@ const EntryEditor = (props) => {
         updatedFeatureFlag.variations.sort((a,b) => b.id-a.id);
         dispatch({ type: actionTypes.SET_FEATURE_FLAG, payload: updatedFeatureFlag });
         props.sdk.entry.fields.featureFlag.setValue(updatedFeatureFlag);
-        props.sdk.notifier.success('VWO Variations updated successfully');
+        props.sdk.notifier.success('Wingify Variations updated successfully');
       })
       .catch(err => {
         props.sdk.notifier.error(err);
@@ -318,17 +318,17 @@ const EntryEditor = (props) => {
                   Feature flag not found
                 </Heading>
                 <Paragraph fontSize='fontSizeL' marginBottom='spacingXl'>
-                  We couldn't locate the feature flag <strong>{state.featureFlag?.name}</strong>. It may have been removed from the VWO app, or there was an issue retrieving it.
+                  We couldn't locate the feature flag <strong>{state.featureFlag?.name}</strong>. It may have been removed from the Wingify app, or there was an issue retrieving it.
                 </Paragraph>
                 <Button
                   className={styles.button}
                   endIcon={<ExternalLinkIcon />}
                   variant='negative'
                   size='small'
-                  href={`https://app.vwo.com/#/full-stack/feature-flag/${state.featureFlag?.id}/edit/variables/`}
+                  href={`https://app.wingify.com/#/full-stack/feature-flag/${state.featureFlag?.id}/edit/variables/`}
                   as='a'
                   target="_blank">
-                  View this feature flag in VWO
+                  View this feature flag in Wingify
                 </Button>
               </Flex>
             </>

--- a/apps/vwo-fme/src/locations/Sidebar.jsx
+++ b/apps/vwo-fme/src/locations/Sidebar.jsx
@@ -72,7 +72,7 @@ const Sidebar = (props) => {
     .then((featureFlag) => {
       setFeatureFlag(featureFlag);
       props.sdk.entry.fields.title.setValue(featureFlag.name);
-      props.sdk.notifier.success('VWO Feature flag updated successfully');
+      props.sdk.notifier.success('Wingify Feature flag updated successfully');
     })
     .catch((err) => {
       props.sdk.notifier.success(err);
@@ -106,10 +106,10 @@ const Sidebar = (props) => {
           isDisabled={!isFeatureFlagAdded}
           endIcon={<ExternalLinkIcon />}
           size='small'
-          href={`https://app.vwo.com/#/full-stack/feature-flag/${featureFlag?.id}/edit/variables/`}
+          href={`https://app.wingify.com/#/full-stack/feature-flag/${featureFlag?.id}/edit/variables/`}
           as={isFeatureFlagAdded? 'a': 'button'}
           target="_blank">
-          View this feature flag in VWO
+          View this feature flag in Wingify
         </Button>
       <Flex flexDirection='column' marginBottom='spacingM'>
           <Flex alignItems='center' justifyContent='space-between' marginBottom={nameEditing? 'spacing2Xs': 'none'}>

--- a/apps/vwo-fme/src/modalComponents/AddVwoVariationModal.js
+++ b/apps/vwo-fme/src/modalComponents/AddVwoVariationModal.js
@@ -1,76 +1,59 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Modal, Form, FormControl, TextInput, ModalControls } from '@contentful/f36-components';
 
 function AddVwoVariationModal(props) {
+  const [loading, setLoading] = useState(false);
+  const [variationName, setVariationName] = useState(`Variation-${props.vwoVariationsLength}`);
 
-   const [loading, setLoading] = useState(false);
-   const [variationName, setVariationName] = useState(`Variation-${props.vwoVariationsLength}`);
+  const updateVwoVariationsName = (length) => {
+    setVariationName(`Variation-${length}`);
+  };
 
-   const updateVwoVariationsName = (length) => {
-      setVariationName(`Variation-${length}`)
-    }
-
-   const addVwoVariationModal = async (name) => {
-      if(name){
-        setLoading(true);
-        const isVariationAdded = await props.addNewVwoVariation(name);
-        if(isVariationAdded){
-          setVariationName('');
-          props.setNewVariationModal(false);
-        }
-        setLoading(false);
-      }
-      else{
+  const addVwoVariationModal = async (name) => {
+    if (name) {
+      setLoading(true);
+      const isVariationAdded = await props.addNewVwoVariation(name);
+      if (isVariationAdded) {
+        setVariationName('');
         props.setNewVariationModal(false);
       }
+      setLoading(false);
+    } else {
+      props.setNewVariationModal(false);
     }
+  };
 
-    useEffect(() => {
-      updateVwoVariationsName(props.vwoVariationsLength);
-    },[props.vwoVariationsLength]);
+  useEffect(() => {
+    updateVwoVariationsName(props.vwoVariationsLength);
+  }, [props.vwoVariationsLength]);
 
   return (
-      <React.Fragment>
-         <Modal onClose={() => addVwoVariationModal('')} isShown={props.newVariationModal} size='medium'>
-         {() => (
-            <>
-               <Modal.Header
-                  title="Create new VWO Variation"
-                  onClose={() => addVwoVariationModal('')}
-               />
-               <Modal.Content>
-                  <Form onSubmit={() => addVwoVariationModal(variationName)}>
-                     <FormControl>
-                        <FormControl.Label isRequired>Variation name</FormControl.Label>
-                        <TextInput
-                           value={variationName}
-                           onChange={(e) => setVariationName(e.target.value)}/>
-                     </FormControl>
-                  </Form>
-               </Modal.Content>
-               <ModalControls>
-               <Button
-                  size="small"
-                  variant="transparent"
-                  onClick={() => addVwoVariationModal('')}
-               >
-                  Close
-               </Button>
-               <Button
-                  size="small"
-                  variant="positive"
-                  isDisabled={!variationName}
-                  isLoading={loading}
-                  onClick={() => addVwoVariationModal(variationName)}
-               >
-                  Add
-               </Button>
-               </ModalControls>
-            </>
-            )}
-         </Modal>
-      </React.Fragment>
-  )
+    <React.Fragment>
+      <Modal onClose={() => addVwoVariationModal('')} isShown={props.newVariationModal} size="medium">
+        {() => (
+          <>
+            <Modal.Header title="Create new Wingify Variation" onClose={() => addVwoVariationModal('')} />
+            <Modal.Content>
+              <Form onSubmit={() => addVwoVariationModal(variationName)}>
+                <FormControl>
+                  <FormControl.Label isRequired>Variation name</FormControl.Label>
+                  <TextInput value={variationName} onChange={(e) => setVariationName(e.target.value)} />
+                </FormControl>
+              </Form>
+            </Modal.Content>
+            <ModalControls>
+              <Button size="small" variant="transparent" onClick={() => addVwoVariationModal('')}>
+                Close
+              </Button>
+              <Button size="small" variant="positive" isDisabled={!variationName} isLoading={loading} onClick={() => addVwoVariationModal(variationName)}>
+                Add
+              </Button>
+            </ModalControls>
+          </>
+        )}
+      </Modal>
+    </React.Fragment>
+  );
 }
 
 export default AddVwoVariationModal;

--- a/apps/vwo-fme/src/services/vwoAppActionService.js
+++ b/apps/vwo-fme/src/services/vwoAppActionService.js
@@ -25,11 +25,10 @@ class VwoAppActionService {
     try {
       const appActions = await this.cma.appAction.getManyForEnvironment({ appDefinitionId: this.sdk.ids.app });
 
-      const appAction = appActions.items.find((action) => action.name === globalConstants.VWO_APP_ACTION_NAME);
+      const appAction = appActions.items.find((action) => action.name === globalConstants.WINGIFY_APP_ACTION_NAME);
 
       if (!appAction) {
-        console.warn('App action not found');
-        throw new Error('App action not found');
+        throw new Error('Wingify app action not found.');
       }
 
       this.actionId = appAction.sys.id;
@@ -58,7 +57,7 @@ class VwoAppActionService {
         },
         {
           parameters: {
-            action: globalConstants.VWO_GET_FEATURE_FLAG_ACTION,
+            action: globalConstants.WINGIFY_GET_FEATURE_FLAG_ACTION,
             payload: JSON.stringify({ id: featureFlagId }),
           },
         }
@@ -103,7 +102,7 @@ class VwoAppActionService {
         },
         {
           parameters: {
-            action: globalConstants.VWO_CREATE_FEATURE_FLAG_ACTION,
+            action: globalConstants.WINGIFY_CREATE_FEATURE_FLAG_ACTION,
             payload: JSON.stringify(featureFlag),
           },
         }
@@ -148,7 +147,7 @@ class VwoAppActionService {
         },
         {
           parameters: {
-            action: globalConstants.VWO_UPDATE_FEATURE_FLAG_ACTION,
+            action: globalConstants.WINGIFY_UPDATE_FEATURE_FLAG_ACTION,
             payload: JSON.stringify(updatedFeatureFlag),
           },
         }
@@ -196,14 +195,14 @@ class VwoAppActionService {
         },
         {
           parameters: {
-            action: globalConstants.VWO_UPDATE_VARIATIONS_ACTION,
+            action: globalConstants.WINGIFY_UPDATE_VARIATIONS_ACTION,
             payload: JSON.stringify({ variations: filteredVwoVariations, featureId }),
           },
         }
       );
 
       if (response.statusCode !== 200) {
-        throw new Error('Something went wrong while updating VWO Variations. Please try again');
+        throw new Error('Something went wrong while updating Wingify Variations. Please try again');
       }
 
       const { _data, _errors } = JSON.parse(response.body);
@@ -212,7 +211,7 @@ class VwoAppActionService {
       } else if (_errors) {
         throw new Error(_errors[0].message);
       } else {
-        throw new Error('Something went wrong while updating VWO Variations. Please try again');
+        throw new Error('Something went wrong while updating Wingify Variations. Please try again');
       }
     } catch (err) {
       throw new Error(err.message || 'Failed to update variations');

--- a/apps/vwo-fme/src/utils.js
+++ b/apps/vwo-fme/src/utils.js
@@ -19,7 +19,7 @@ export const validateCredentials = async (accountId, apiToken) => {
     return false;
   }
 
-  let url = `https://app.vwo.com/api/v2/accounts/${accountId}/smartcode`;
+  let url = `https://app.wingify.com/api/v2/accounts/${accountId}/smartcode`;
   const response = await fetch(url, {
     method: 'GET',
     headers: {
@@ -31,7 +31,7 @@ export const validateCredentials = async (accountId, apiToken) => {
   if (response.ok) {
     return {
       code: 200,
-      message: 'User autherized with the VWO',
+      message: 'User autherized with the Wingify',
     };
   } else {
     const resp = await response.json();
@@ -92,9 +92,11 @@ export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, de
 };
 
 export const globalConstants = {
-  VWO_APP_ACTION_NAME: 'VWO Actions', // Find it in contentful-app-manifest.json
-  VWO_GET_FEATURE_FLAG_ACTION: 'get',
-  VWO_UPDATE_FEATURE_FLAG_ACTION: 'update',
-  VWO_UPDATE_VARIATIONS_ACTION: 'updateVariations',
-  VWO_CREATE_FEATURE_FLAG_ACTION: 'create',
+  WINGIFY_APP_ACTION_ID: 'handleVWOActions', // Find it in contentful-app-manifest.json
+  WINGIFY_APP_ACTION_NAME: 'Wingify Actions', // Find it in contentful-app-manifest.json
+  WINGIFY_LEGACY_APP_ACTION_NAME: 'VWO Actions',
+  WINGIFY_GET_FEATURE_FLAG_ACTION: 'get',
+  WINGIFY_UPDATE_FEATURE_FLAG_ACTION: 'update',
+  WINGIFY_UPDATE_VARIATIONS_ACTION: 'updateVariations',
+  WINGIFY_CREATE_FEATURE_FLAG_ACTION: 'create',
 };


### PR DESCRIPTION
## Purpose

Rebrand the vwo-fme Contentful app from VWO to Wingify across user-facing copy, API hosts, and app action configuration. This aligns the in-app experience and backend integration with the Wingify product naming after the organizational rebrand, and keeps the frontend app action lookup in sync with the renamed action in `contentful-app-manifest.json`.

## Approach

- Updated user-facing strings in Config Screen, Entry Editor, Sidebar, and variation modals (labels, notifications, help links, and button text).
- Pointed API and app URLs from `app.vwo.com` / `help.vwo.com` to `app.wingify.com` / `help.wingify.com` in:
  - `functions/vwo-client.js` (app function API calls)
  - `src/utils.js` (credential validation)
  - UI deep links in Config Screen, Entry Editor, and Sidebar
- Renamed app function/action display names in `contentful-app-manifest.json` (`Wingify Calls`, `Wingify Actions`) and updated `allowNetworks` to `https://*.wingify.com`.
- Renamed app action constants in `src/utils.js` from `VWO_*` to `WINGIFY_*` and updated `vwoAppActionService.js` to resolve actions by the new `Wingify Actions` name.

**Not renamed (intentionally):**
- Manifest function/action IDs (`handleVWOCalls`, `handleVWOActions`) — registered in Contentful; changing would require re-upserting actions.
- Internal file/class names (`vwo-client.js`, `VwoAppActionService`, etc.) — code identifiers only, no user impact.
- Package/app slug `vwo-fme` — marketplace identity and release-please scope.

## Testing steps

- Install the updated Contentful app in your desired space.
- Trigger the feature flag creation workflow from any content entry.
- Verify that the VWO feature flag is created successfully.
- Use browser developer tools to confirm that no direct API calls to VWO are made from the client side.

## Breaking Changes

- **App action name change**: `"VWO Actions"` to `"Wingify Actions"`. Environments must run `npm run upsert-actions` after deploy or app action lookup will fail until actions are re-registered.
- **API host change**: All outbound API calls now target `app.wingify.com` instead of `app.vwo.com`. Confirm Wingify API endpoints are live at the new host before production deploy.
- **Network allowlist**: Function `allowNetworks` updated to `https://*.wingify.com`; `vwo.com` is no longer allowed from app functions.

No breaking changes to Contentful content model, installation parameters, or stored entry data.