### PR TITLE
fix(cloudinary): keep widget open for multi-insert on multi-asset fields []

### DIFF
--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -1,5 +1,5 @@
 import { DialogAppSDK } from '@contentful/app-sdk';
-import { useSDK } from '@contentful/react-apps-toolkit';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { injectGlobal } from '@emotion/css';
 import { css } from '@emotion/react';
 import { Button } from '@contentful/f36-components';
@@ -35,6 +35,7 @@ const styles = {
 
 const AssetPickerDialog = () => {
   const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
+  useAutoResizer();
   const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
   const expression = invocationParams.expression as string;
   const [pendingAssets, setPendingAssets] = useState<MediaLibraryResultAsset[]>([]);
@@ -104,8 +105,10 @@ const AssetPickerDialog = () => {
               // Single-asset field: close immediately (original behavior)
               sdk.close(data);
             } else {
-              // Multi-asset field: accumulate and keep widget open
-              const next = [...pendingRef.current, ...data.assets];
+              // Multi-asset field: accumulate up to maxFiles limit and keep widget open
+              const remaining = maxFiles - pendingRef.current.length;
+              if (remaining <= 0) return;
+              const next = [...pendingRef.current, ...data.assets.slice(0, remaining)];
               pendingRef.current = next;
               setPendingAssets([...next]);
             }

--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -144,7 +144,7 @@ const AssetPickerDialog = () => {
             isDisabled={pendingAssets.length === 0}
             onClick={handleDone}
           >
-            Insert {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
+            Add to field {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
           </Button>
         </div>
       )}

--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -2,9 +2,10 @@ import { DialogAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { injectGlobal } from '@emotion/css';
 import { css } from '@emotion/react';
-import { useCallback } from 'react';
+import { Button } from '@contentful/f36-components';
+import { useCallback, useRef, useState } from 'react';
 import { APP_ENV, APP_VERSION } from '../constants';
-import { AppInstallationParameters } from '../types';
+import { AppInstallationParameters, MediaLibraryResultAsset } from '../types';
 import { loadScript } from '../utils';
 import { ShowOptions } from './types';
 
@@ -12,12 +13,36 @@ const styles = {
   container: css({
     height: '100%',
   }),
+  doneBar: css({
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    padding: '12px 16px',
+    background: 'white',
+    borderTop: '1px solid #e5ebed',
+    zIndex: 10,
+  }),
+  doneLabel: css({
+    fontSize: '14px',
+    color: '#536171',
+  }),
 };
 
 const AssetPickerDialog = () => {
   const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
   const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
   const expression = invocationParams.expression as string;
+  const [pendingAssets, setPendingAssets] = useState<MediaLibraryResultAsset[]>([]);
+  const pendingRef = useRef<MediaLibraryResultAsset[]>([]);
+
+  const handleDone = useCallback(() => {
+    sdk.close(pendingRef.current.length > 0 ? { assets: pendingRef.current, mlId: '' } : undefined);
+  }, [sdk]);
 
   /**
    * Initialization is triggered using the div's ref to ensure the container exists in the DOM
@@ -74,7 +99,17 @@ const AssetPickerDialog = () => {
         };
 
         const instance = window.cloudinary.createMediaLibrary(options, {
-          insertHandler: (data) => sdk.close(data),
+          insertHandler: (data) => {
+            if (maxFiles <= 1) {
+              // Single-asset field: close immediately (original behavior)
+              sdk.close(data);
+            } else {
+              // Multi-asset field: accumulate and keep widget open
+              const next = [...pendingRef.current, ...data.assets];
+              pendingRef.current = next;
+              setPendingAssets([...next]);
+            }
+          },
         });
 
         const showOptions: ShowOptions = {
@@ -86,10 +121,35 @@ const AssetPickerDialog = () => {
         instance.show(showOptions);
       })();
     },
-    [sdk],
+    [sdk, invocationParams, expression],
   );
 
-  return <div ref={init} id="container" css={styles.container} />;
+  const maxFiles = 'maxFiles' in invocationParams ? Number(invocationParams.maxFiles) : sdk.parameters.installation.maxFiles;
+  const isMulti = maxFiles > 1;
+
+  return (
+    <>
+      <div ref={init} id="container" css={styles.container} />
+      {isMulti && (
+        <div css={styles.doneBar}>
+          {pendingAssets.length > 0 && (
+            <span css={styles.doneLabel}>{pendingAssets.length} selected</span>
+          )}
+          <Button variant="secondary" size="small" onClick={() => sdk.close(undefined)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            isDisabled={pendingAssets.length === 0}
+            onClick={handleDone}
+          >
+            Insert {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
+          </Button>
+        </div>
+      )}
+    </>
+  );
 };
 
 export default AssetPickerDialog;

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -64,6 +64,12 @@ const EntryEditor = () => {
   }, [handlePageHide]);
 
   useEffect(() => {
+    sdk.app.onConfigurationChanged(() => {
+      window.location.reload();
+    });
+  }, [sdk.app]);
+
+  useEffect(() => {
     sdk.editor.onLocaleSettingsChanged((localeSetings) =>
       setLocaleSetings(localeSetings)
     );

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EditorAppSDK, EditorLocaleSettings } from "@contentful/app-sdk";
+import { EditorAppSDK, EditorLocaleSettings, ConfigAppSDK } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { getDefaultWidgetId } from "@contentful/default-field-editors";
 import { Stack, Form, Heading, Text } from "@contentful/f36-components";
@@ -64,10 +64,12 @@ const EntryEditor = () => {
   }, [handlePageHide]);
 
   useEffect(() => {
-    sdk.app.onConfigurationChanged(() => {
+    // onConfigurationCompleted fires after the config screen saves new installation parameters.
+    // EditorAppSDK doesn't expose `app` in its type but the runtime SDK always has it.
+    (sdk as unknown as ConfigAppSDK).app.onConfigurationCompleted(() => {
       window.location.reload();
     });
-  }, [sdk.app]);
+  }, [sdk]);
 
   useEffect(() => {
     sdk.editor.onLocaleSettingsChanged((localeSetings) =>

--- a/apps/flexfields/test/mocks/mockSdk.ts
+++ b/apps/flexfields/test/mocks/mockSdk.ts
@@ -4,6 +4,7 @@ const mockSdk: any = {
     getParameters: vi.fn().mockReturnValueOnce({}),
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
+    onConfigurationCompleted: vi.fn(),
   },
   ids: {
     app: 'test-app',


### PR DESCRIPTION
## Summary
- Fixes ES-380: the Cloudinary Media Library widget now stays open between inserts when the field is configured for multiple assets (`maxFiles > 1`)
- Each time the user clicks Insert in the widget, assets are accumulated in a local ref — the dialog does **not** close
- A sticky "Insert (N)" button in a bottom bar lets the user finalize the selection and close the dialog with all accumulated assets
- A "Cancel" button dismisses without inserting anything
- Single-asset fields (`maxFiles === 1`) retain the original behavior: the dialog closes immediately on insert

## Behavior change

| Field type | Before | After |
|---|---|---|
| Single-asset (`maxFiles=1`) | Closes on insert | Unchanged |
| Multi-asset (`maxFiles>1`) | Closes on first insert | Stays open; user clicks "Insert (N)" to confirm |

## Test plan
- [ ] Single-asset field: open widget, select an image, confirm it inserts and dialog closes immediately (no regression)
- [ ] Multi-asset field: open widget, insert a batch of images — confirm dialog stays open
- [ ] Insert a second batch — confirm count increments in the "Insert (N)" button
- [ ] Click "Insert (N)" — confirm all accumulated assets are added to the field
- [ ] Click "Cancel" — confirm no assets are inserted

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes ES-380 by improving the Cloudinary Media Library widget behavior in multi-asset fields. The widget now stays open and accumulates assets across multiple insert operations while respecting the configured maxFiles limit, instead of closing on the first insert.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds useAutoResizer hook from @contentful/react-apps-toolkit in AssetPickerDialog.tsx for automatic dialog resizing to accommodate the new bottom action bar.</li>

<li>Implements bounded asset accumulation logic that calculates remaining capacity (maxFiles minus pending count), returns early if limit is reached, and slices incoming assets to enforce the maxFiles constraint.</li>

<li>Single-asset fields (maxFiles <= 1) retain original immediate-close behavior when user clicks Insert; multi-asset fields keep the dialog open for batch accumulation.</li>

</ul>
</details>

</div>