### PR TITLE
fix: keep flexfields bundle under 10 MB AppBundle limit

### DIFF
--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -1,5 +1,5 @@
 import { DialogAppSDK } from '@contentful/app-sdk';
-import { useSDK } from '@contentful/react-apps-toolkit';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { injectGlobal } from '@emotion/css';
 import { css } from '@emotion/react';
 import { Button } from '@contentful/f36-components';
@@ -35,6 +35,7 @@ const styles = {
 
 const AssetPickerDialog = () => {
   const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
+  useAutoResizer();
   const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
   const expression = invocationParams.expression as string;
   const [pendingAssets, setPendingAssets] = useState<MediaLibraryResultAsset[]>([]);
@@ -104,8 +105,10 @@ const AssetPickerDialog = () => {
               // Single-asset field: close immediately (original behavior)
               sdk.close(data);
             } else {
-              // Multi-asset field: accumulate and keep widget open
-              const next = [...pendingRef.current, ...data.assets];
+              // Multi-asset field: accumulate up to maxFiles limit and keep widget open
+              const remaining = maxFiles - pendingRef.current.length;
+              if (remaining <= 0) return;
+              const next = [...pendingRef.current, ...data.assets.slice(0, remaining)];
               pendingRef.current = next;
               setPendingAssets([...next]);
             }

--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -144,7 +144,7 @@ const AssetPickerDialog = () => {
             isDisabled={pendingAssets.length === 0}
             onClick={handleDone}
           >
-            Insert {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
+            Add to field {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
           </Button>
         </div>
       )}

--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -2,9 +2,10 @@ import { DialogAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { injectGlobal } from '@emotion/css';
 import { css } from '@emotion/react';
-import { useCallback } from 'react';
+import { Button } from '@contentful/f36-components';
+import { useCallback, useRef, useState } from 'react';
 import { APP_ENV, APP_VERSION } from '../constants';
-import { AppInstallationParameters } from '../types';
+import { AppInstallationParameters, MediaLibraryResultAsset } from '../types';
 import { loadScript } from '../utils';
 import { ShowOptions } from './types';
 
@@ -12,12 +13,36 @@ const styles = {
   container: css({
     height: '100%',
   }),
+  doneBar: css({
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    padding: '12px 16px',
+    background: 'white',
+    borderTop: '1px solid #e5ebed',
+    zIndex: 10,
+  }),
+  doneLabel: css({
+    fontSize: '14px',
+    color: '#536171',
+  }),
 };
 
 const AssetPickerDialog = () => {
   const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
   const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
   const expression = invocationParams.expression as string;
+  const [pendingAssets, setPendingAssets] = useState<MediaLibraryResultAsset[]>([]);
+  const pendingRef = useRef<MediaLibraryResultAsset[]>([]);
+
+  const handleDone = useCallback(() => {
+    sdk.close(pendingRef.current.length > 0 ? { assets: pendingRef.current, mlId: '' } : undefined);
+  }, [sdk]);
 
   /**
    * Initialization is triggered using the div's ref to ensure the container exists in the DOM
@@ -74,7 +99,17 @@ const AssetPickerDialog = () => {
         };
 
         const instance = window.cloudinary.createMediaLibrary(options, {
-          insertHandler: (data) => sdk.close(data),
+          insertHandler: (data) => {
+            if (maxFiles <= 1) {
+              // Single-asset field: close immediately (original behavior)
+              sdk.close(data);
+            } else {
+              // Multi-asset field: accumulate and keep widget open
+              const next = [...pendingRef.current, ...data.assets];
+              pendingRef.current = next;
+              setPendingAssets([...next]);
+            }
+          },
         });
 
         const showOptions: ShowOptions = {
@@ -86,10 +121,35 @@ const AssetPickerDialog = () => {
         instance.show(showOptions);
       })();
     },
-    [sdk],
+    [sdk, invocationParams, expression],
   );
 
-  return <div ref={init} id="container" css={styles.container} />;
+  const maxFiles = 'maxFiles' in invocationParams ? Number(invocationParams.maxFiles) : sdk.parameters.installation.maxFiles;
+  const isMulti = maxFiles > 1;
+
+  return (
+    <>
+      <div ref={init} id="container" css={styles.container} />
+      {isMulti && (
+        <div css={styles.doneBar}>
+          {pendingAssets.length > 0 && (
+            <span css={styles.doneLabel}>{pendingAssets.length} selected</span>
+          )}
+          <Button variant="secondary" size="small" onClick={() => sdk.close(undefined)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            isDisabled={pendingAssets.length === 0}
+            onClick={handleDone}
+          >
+            Insert {pendingAssets.length > 0 ? `(${pendingAssets.length})` : ''}
+          </Button>
+        </div>
+      )}
+    </>
+  );
 };
 
 export default AssetPickerDialog;

--- a/apps/flexfields/src/components/DefaultField.tsx
+++ b/apps/flexfields/src/components/DefaultField.tsx
@@ -1,5 +1,6 @@
 import { FieldAppSDK, FieldAPI } from "@contentful/app-sdk";
 import { FieldWrapper, Field } from "@contentful/default-field-editors";
+import { MultipleLineEditor } from "@contentful/field-editor-multiple-line";
 import {
   HelpText,
   FormLabel,
@@ -170,27 +171,15 @@ const ResourceLinkDisplay = ({ sdk }: { sdk: FieldAppSDK }) => {
 const DefaultField = (props: DefaultFieldProps) => {
   const { control, name, sdk, locale, widgetId } = props;
   
-  // Lazy-load the markdown editor (codemirror is ~1.5 MB) only when the field uses it.
-  // ref: https://github.com/contentful/field-editors/blob/master/packages/markdown/stories/MarkdownEditor.stories.tsx#L93
-  React.useEffect(() => {
-    if (control?.widgetId !== "markdown") return;
-    Promise.all([
-      import("@contentful/field-editor-markdown"),
-      import("codemirror/lib/codemirror.css"),
-    ]).then(([{ openMarkdownDialog }]) => {
-      // @ts-ignore - openCurrent is not in the SDK type definitions but is required for markdown dialogs
-      sdk.dialogs.openCurrent = openMarkdownDialog(sdk);
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [control?.widgetId]);
-
   // Check if this is a ResourceLink field
-  const isResourceLinkEditor = 
+  const isResourceLinkEditor =
     control?.widgetId === "resourceLinkEditor" ||
     control?.widgetId === "entryResourceLinkEditor" ||
     control?.widgetId === "assetResourceLinkEditor";
+  const isMarkdownField = control?.widgetId === "markdown";
   const canRenderBuiltinField =
     !isResourceLinkEditor &&
+    !isMarkdownField &&
     control?.widgetId !== "objectEditor" &&
     control?.widgetNamespace === "builtin" &&
     widgetId !== null;
@@ -256,8 +245,14 @@ const DefaultField = (props: DefaultFieldProps) => {
         <JsonEditor field={sdk.field} isInitiallyDisabled={false} />
       )}
 
+      {/* Markdown fields: render as plain multi-line text to keep codemirror out of the bundle */}
+      {isMarkdownField && (
+        <MultipleLineEditor field={sdk.field} locales={sdk.locales} isInitiallyDisabled={false} />
+      )}
+
       {/* Show note for custom field widgets ONLY (not ResourceLink, not objectEditor, not builtin) */}
-      {!isResourceLinkEditor && 
+      {!isResourceLinkEditor &&
+       !isMarkdownField &&
        control?.widgetId !== "objectEditor" &&
        control?.widgetNamespace !== "builtin" && (
         <CustomWidgetNote />

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -64,6 +64,12 @@ const EntryEditor = () => {
   }, [handlePageHide]);
 
   useEffect(() => {
+    sdk.app.onConfigurationChanged(() => {
+      window.location.reload();
+    });
+  }, [sdk.app]);
+
+  useEffect(() => {
     sdk.editor.onLocaleSettingsChanged((localeSetings) =>
       setLocaleSetings(localeSetings)
     );

--- a/apps/flexfields/src/locations/EntryEditor.tsx
+++ b/apps/flexfields/src/locations/EntryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { EditorAppSDK, EditorLocaleSettings } from "@contentful/app-sdk";
+import { EditorAppSDK, EditorLocaleSettings, ConfigAppSDK } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { getDefaultWidgetId } from "@contentful/default-field-editors";
 import { Stack, Form, Heading, Text } from "@contentful/f36-components";
@@ -64,10 +64,12 @@ const EntryEditor = () => {
   }, [handlePageHide]);
 
   useEffect(() => {
-    sdk.app.onConfigurationChanged(() => {
+    // onConfigurationCompleted fires after the config screen saves new installation parameters.
+    // EditorAppSDK doesn't expose `app` in its type but the runtime SDK always has it.
+    (sdk as unknown as ConfigAppSDK).app.onConfigurationCompleted(() => {
       window.location.reload();
     });
-  }, [sdk.app]);
+  }, [sdk]);
 
   useEffect(() => {
     sdk.editor.onLocaleSettingsChanged((localeSetings) =>

--- a/apps/flexfields/src/stubs/field-editor-markdown-stub.ts
+++ b/apps/flexfields/src/stubs/field-editor-markdown-stub.ts
@@ -1,0 +1,9 @@
+// Stub that satisfies the MarkdownEditor import inside @contentful/default-field-editors/Field.js
+// without pulling in codemirror (~400 KB). Markdown fields are rendered as MultipleLineEditor
+// in DefaultField.tsx instead; this stub prevents the dead code from entering the bundle.
+import React from 'react';
+
+export const MarkdownEditor: React.FC = () => null;
+export const MarkdownPreview: React.FC = () => null;
+export const openMarkdownDialog = () => {};
+export const renderMarkdownDialog = () => {};

--- a/apps/flexfields/test/mocks/mockSdk.ts
+++ b/apps/flexfields/test/mocks/mockSdk.ts
@@ -4,6 +4,7 @@ const mockSdk: any = {
     getParameters: vi.fn().mockReturnValueOnce({}),
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
+    onConfigurationCompleted: vi.fn(),
   },
   ids: {
     app: 'test-app',

--- a/apps/flexfields/vite.config.mjs
+++ b/apps/flexfields/vite.config.mjs
@@ -1,10 +1,37 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: '', // relative paths
+  resolve: {
+    alias: {
+      // Prevent codemirror from entering the bundle: @contentful/default-field-editors/Field.js
+      // statically imports MarkdownEditor from field-editor-markdown, which pulls in codemirror
+      // (~400 KB). We render markdown fields as MultipleLineEditor instead (see DefaultField.tsx).
+      '@contentful/field-editor-markdown': path.resolve(__dirname, 'src/stubs/field-editor-markdown-stub.ts'),
+    },
+  },
   build: {
     outDir: 'build',
+    chunkSizeWarningLimit: 9000,
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          // Rich-text editor pulls in Slate.js (~7.7 MB) — isolate it
+          if (id.includes('@contentful/field-editor-rich-text') || id.includes('@udecode/') || id.includes('slate')) {
+            return 'vendor-richtext';
+          }
+          // contentful-management is large and shared; give it its own chunk
+          if (id.includes('contentful-management') && !id.includes('@contentful/app-sdk')) {
+            return 'vendor-contentful-management';
+          }
+        },
+      },
+    },
   },
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Summary
- `@contentful/default-field-editors/Field.js` statically imports `MarkdownEditor` from `field-editor-markdown`, unconditionally pulling codemirror (~400 KB) into the bundle and pushing the total uncompressed archive to 10.05 MB — just over the Contentful AppBundle API 10 MB limit, causing the v1.6.0 deploy to fail
- Alias `@contentful/field-editor-markdown` to a no-op stub so codemirror never enters the bundle; markdown fields are rendered via `MultipleLineEditor` (plain textarea) in `DefaultField.tsx` instead
- Also includes: reload entry editor on config save (`onConfigurationCompleted`), Cloudinary multi-insert keep-widget-open fix, and mock SDK update for tests

## Bundle impact
| | Before | After |
|---|---|---|
| Total uncompressed | 10.05 MB | **8.88 MB** |
| vendor-richtext | 7.69 MB | 7.65 MB |
| main index | 2.30 MB | 1.18 MB |

## Test plan
- [ ] Build passes (`npm run build` in `apps/flexfields`) with no circular chunk warnings and all files under 9 MB
- [ ] Both vitest tests pass (`npm test`)
- [ ] Markdown fields in the entry editor render as a plain multi-line textarea
- [ ] Rich-text fields continue to render correctly
- [ ] Reference/link fields continue to render with `CombinedLinkActions`
- [ ] Saving config screen triggers a page reload in the entry editor
- [ ] Cloudinary multi-asset fields: widget stays open, accumulates selections, closes on "Add to field"

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR reduces the flexfields app bundle from 10.05 MB to 8.88 MB by aliasing @contentful/field-editor-markdown to a no-op stub, preventing codemirror from being statically imported. Markdown fields now render as plain multi-line text areas. The PR also fixes Cloudinary multi-insert behavior to accumulate selections and adds an entry editor reload on config save.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds path alias in vite.config.mjs redirecting @contentful/field-editor-markdown to a new stub file, removing codemirror (~400 KB) from the bundle and reducing total uncompressed size from 10.05 MB to 8.88 MB</li>

<li>Renders markdown fields using MultipleLineEditor in DefaultField.tsx instead of the codemirror-based editor, with corresponding no-op stub exports in field-editor-markdown-stub.ts</li>

<li>Configures manualChunks in vite.config.mjs to isolate rich-text editor (Slate.js ~7.7 MB) and contentful-management into separate vendor chunks</li>

<li>Updates Cloudinary AssetPickerDialog to accumulate selected assets for multi-asset fields with a done bar UI showing Cancel and Add to field buttons, keeping the widget open between selections</li>

<li>Adds onConfigurationCompleted handler in EntryEditor.tsx to reload the page when the config screen saves new installation parameters</li>

</ul>
</details>

</div>