### PR TITLE
fix: keep flexfields bundle under 10 MB AppBundle limit []

### DIFF
--- a/apps/flexfields/src/components/DefaultField.tsx
+++ b/apps/flexfields/src/components/DefaultField.tsx
@@ -1,5 +1,6 @@
 import { FieldAppSDK, FieldAPI } from "@contentful/app-sdk";
 import { FieldWrapper, Field } from "@contentful/default-field-editors";
+import { MultipleLineEditor } from "@contentful/field-editor-multiple-line";
 import {
   HelpText,
   FormLabel,
@@ -174,27 +175,15 @@ const ResourceLinkDisplay = ({ sdk }: { sdk: FieldAppSDK }) => {
 const DefaultField = (props: DefaultFieldProps) => {
   const { control, name, sdk, locale, widgetId } = props;
   
-  // Lazy-load the markdown editor (codemirror is ~1.5 MB) only when the field uses it.
-  // ref: https://github.com/contentful/field-editors/blob/master/packages/markdown/stories/MarkdownEditor.stories.tsx#L93
-  React.useEffect(() => {
-    if (control?.widgetId !== "markdown") return;
-    Promise.all([
-      import("@contentful/field-editor-markdown"),
-      import("codemirror/lib/codemirror.css"),
-    ]).then(([{ openMarkdownDialog }]) => {
-      // @ts-ignore - openCurrent is not in the SDK type definitions but is required for markdown dialogs
-      sdk.dialogs.openCurrent = openMarkdownDialog(sdk);
-    });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [control?.widgetId]);
-
   // Check if this is a ResourceLink field
-  const isResourceLinkEditor = 
+  const isResourceLinkEditor =
     control?.widgetId === "resourceLinkEditor" ||
     control?.widgetId === "entryResourceLinkEditor" ||
     control?.widgetId === "assetResourceLinkEditor";
+  const isMarkdownField = control?.widgetId === "markdown";
   const canRenderBuiltinField =
     !isResourceLinkEditor &&
+    !isMarkdownField &&
     control?.widgetId !== "objectEditor" &&
     control?.widgetNamespace === "builtin" &&
     widgetId !== null;
@@ -262,8 +251,14 @@ const DefaultField = (props: DefaultFieldProps) => {
         </React.Suspense>
       )}
 
+      {/* Markdown fields: render as plain multi-line text to keep codemirror out of the bundle */}
+      {isMarkdownField && (
+        <MultipleLineEditor field={sdk.field} locales={sdk.locales} isInitiallyDisabled={false} />
+      )}
+
       {/* Show note for custom field widgets ONLY (not ResourceLink, not objectEditor, not builtin) */}
-      {!isResourceLinkEditor && 
+      {!isResourceLinkEditor &&
+       !isMarkdownField &&
        control?.widgetId !== "objectEditor" &&
        control?.widgetNamespace !== "builtin" && (
         <CustomWidgetNote />

--- a/apps/flexfields/src/stubs/field-editor-markdown-stub.ts
+++ b/apps/flexfields/src/stubs/field-editor-markdown-stub.ts
@@ -1,0 +1,9 @@
+// Stub that satisfies the MarkdownEditor import inside @contentful/default-field-editors/Field.js
+// without pulling in codemirror (~400 KB). Markdown fields are rendered as MultipleLineEditor
+// in DefaultField.tsx instead; this stub prevents the dead code from entering the bundle.
+import React from 'react';
+
+export const MarkdownEditor: React.FC = () => null;
+export const MarkdownPreview: React.FC = () => null;
+export const openMarkdownDialog = () => {};
+export const renderMarkdownDialog = () => {};

--- a/apps/flexfields/vite.config.mjs
+++ b/apps/flexfields/vite.config.mjs
@@ -1,19 +1,27 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: '', // relative paths
+  resolve: {
+    alias: {
+      // Prevent codemirror from entering the bundle: @contentful/default-field-editors/Field.js
+      // statically imports MarkdownEditor from field-editor-markdown, which pulls in codemirror
+      // (~400 KB). We render markdown fields as MultipleLineEditor instead (see DefaultField.tsx).
+      '@contentful/field-editor-markdown': path.resolve(__dirname, 'src/stubs/field-editor-markdown-stub.ts'),
+    },
+  },
   build: {
     outDir: 'build',
-    // Warn at 9 MB so we notice before hitting the 10 MB AppBundle API per-file limit.
-    // The main chunk previously hit 10,561 KB (over the limit); it was brought down to
-    // ~10,485 KB via lazy-loading codemirror/markdown. This guard + manualChunks below
-    // keeps headroom visible as deps evolve.
     chunkSizeWarningLimit: 9000,
     rollupOptions: {
       output: {
         manualChunks: (id) => {
-          // Rich-text editor pulls in Slate.js (~800 KB) — isolate it
+          // Rich-text editor pulls in Slate.js (~7.7 MB) — isolate it
           if (id.includes('@contentful/field-editor-rich-text') || id.includes('@udecode/') || id.includes('slate')) {
             return 'vendor-richtext';
           }


### PR DESCRIPTION
## Summary
- `@contentful/default-field-editors/Field.js` statically imports `MarkdownEditor` from `field-editor-markdown`, unconditionally pulling codemirror (~400 KB) into the bundle and pushing the total uncompressed archive to 10.05 MB — just over the Contentful AppBundle API 10 MB limit, causing the v1.6.0 deploy to fail
- Alias `@contentful/field-editor-markdown` to a no-op stub so codemirror never enters the bundle; markdown fields are rendered via `MultipleLineEditor` (plain textarea) in `DefaultField.tsx` instead

## Bundle impact
| | Before | After |
|---|---|---|
| Total uncompressed | 10.05 MB | **8.88 MB** |
| vendor-richtext | 7.69 MB | 7.65 MB |
| main index | 2.30 MB | 1.18 MB |

## Test plan
- [ ] Build passes (`npm run build` in `apps/flexfields`) with all files under 9 MB
- [ ] Both vitest tests pass (`npm test`)
- [ ] Markdown fields in the entry editor render as a plain multi-line textarea
- [ ] Rich-text fields continue to render correctly
- [ ] Reference/link fields continue to render with `CombinedLinkActions`

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bundle size regression that caused the v1.6.0 deploy to fail by reducing the uncompressed archive from 10.05 MB to 8.88 MB, staying under Contentful's 10 MB AppBundle API limit. The fix stubs out the @contentful/field-editor-markdown dependency (which pulls in codemirror) and renders markdown fields as plain textareas using MultipleLineEditor instead.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added vite alias in vite.config.mjs mapping @contentful/field-editor-markdown to a new stub file, preventing codemirror (~400 KB) from entering the bundle</li>

<li>Created apps/flexfields/src/stubs/field-editor-markdown-stub.ts exporting no-op components (MarkdownEditor, MarkdownPreview, openMarkdownDialog, renderMarkdownDialog)</li>

<li>Modified DefaultField.tsx to render markdown fields using MultipleLineEditor (plain textarea) instead of the lazy-loaded markdown editor, removing the useEffect dynamic import logic</li>

<li>Updated chunkSizeWarningLimit to 9000 KB in vite.config.mjs to maintain visibility of bundle size as dependencies evolve</li>

</ul>
</details>

</div>