### PR TITLE
fix: add --repo flag to gh pr merge to fix dependabot auto-merge []

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yml
@@ -121,4 +121,4 @@ jobs:
         run: |
           merge_method="$(echo "$MERGE_METHOD" | tr -d '"')"
           echo "Auto merging PR using method $merge_method"
-          gh pr merge "--$merge_method" --auto "$PR_NUMBER"
+          gh pr merge "--$merge_method" --auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary
- `gh pr merge --auto` was failing with `fatal: not a git repository` because the workflow has no `checkout` step
- Fix is a one-liner: pass `--repo "$GITHUB_REPOSITORY"` so `gh` doesn't need a local git context
- This unblocks the existing auto-merge pipeline for all patch/minor dependabot PRs (skips major bumps per existing logic)

## Test plan
- [ ] Trigger fires on a new dependabot PR and "Enable auto merge" step succeeds (no `fatal: not a git repository` error)
- [ ] PR is approved by `contentful-automation[bot]` and auto-merge is enabled

Generated with [Claude Code](https://claude.com/claude-code)