### PR TITLE
fix: bump jspdf to 4.2.1 in sfmc-studio to clear CVE-2025-68428 [EXT-7499]

### DIFF
--- a/apps/sfmc-studio/package-lock.json
+++ b/apps/sfmc-studio/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-prettier": "^5.5.4",
         "html-react-parser": "^5.2.11",
         "html-to-image": "^1.11.13",
-        "jspdf": "^3.0.4",
+        "jspdf": "^4.2.1",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.23",
         "next": "^15.5.18",
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -13647,19 +13647,19 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
+        "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
         "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
     },

--- a/apps/sfmc-studio/package.json
+++ b/apps/sfmc-studio/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "html-react-parser": "^5.2.11",
     "html-to-image": "^1.11.13",
-    "jspdf": "^3.0.4",
+    "jspdf": "^4.2.1",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.23",
     "next": "^15.5.18",


### PR DESCRIPTION
[EXT-7499](https://contentful.atlassian.net/browse/EXT-7499) · tracked by [AIS-51](https://contentful.atlassian.net/browse/AIS-51)

## Summary
- Bumps `jspdf` in `apps/sfmc-studio` from `3.0.4` to `4.2.1` (**major bump**), clearing **CVE-2025-68428**.
- **Compatibility reviewed** (this was the AC for this story): the only jspdf usage in the app is `RightLayout.tsx` → `downloadPdf`, which uses the constructor (`new jsPDF('p','mm','a4',true)`), `pdf.internal.pageSize.getWidth()/getHeight()`, `pdf.addImage(...)`, and `pdf.save(...)`. These are stable public APIs, unchanged across the 3.x → 4.x boundary.
- Minimal lockfile diff — only `jspdf` and `@babel/runtime` change (jspdf 4.x dropped most of its transitive deps).

## Test plan
- [x] `npm ci` installs cleanly
- [x] `npm test` (jest) — 85 tests / 22 suites pass, including `RightLayout.spec.tsx` (PDF export path)
- [x] `npm run build-app` (`next build`) compiles + static-exports cleanly against jspdf 4.x type definitions
- [x] `npm audit` confirms jspdf advisory cleared
- [ ] Manual QA: trigger a PDF export in-app and confirm output renders correctly (recommended given the major bump)
- [x] CI green

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7499]: https://contentful.atlassian.net/browse/EXT-7499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-51]: https://contentful.atlassian.net/browse/AIS-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ