### PR TITLE
feat(cloudinary): add sidebar multi-field picker for batch asset assignment [ES-380]

### DIFF
--- a/apps/cloudinary2/src/App.tsx
+++ b/apps/cloudinary2/src/App.tsx
@@ -4,11 +4,13 @@ import { useMemo } from 'react';
 import ConfigScreen from './locations/ConfigScreen';
 import Dialog from './locations/Dialog';
 import Field from './locations/Field';
+import Sidebar from './locations/Sidebar';
 
 const ComponentLocationSettings = {
   [locations.LOCATION_APP_CONFIG]: ConfigScreen,
   [locations.LOCATION_ENTRY_FIELD]: Field,
   [locations.LOCATION_DIALOG]: Dialog,
+  [locations.LOCATION_ENTRY_SIDEBAR]: Sidebar,
 };
 
 

--- a/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
+++ b/apps/cloudinary2/src/locations/AssetPickerDialog.tsx
@@ -1,76 +1,104 @@
 import { DialogAppSDK } from '@contentful/app-sdk';
+import { Button, Menu } from '@contentful/f36-components';
+import { ArrowDownIcon } from '@contentful/f36-icons';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { injectGlobal } from '@emotion/css';
 import { css } from '@emotion/react';
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { APP_ENV, APP_VERSION } from '../constants';
-import { AppInstallationParameters } from '../types';
+import { AppInstallationParameters, MediaLibraryResult, MediaLibraryResultAsset } from '../types';
 import { loadScript } from '../utils';
+import { PickerSlot } from './Sidebar';
 import { ShowOptions } from './types';
 
 const styles = {
   container: css({
     height: '100%',
   }),
+  toolbar: css({
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '10px 16px',
+    background: 'white',
+    borderTop: '1px solid #e5ebed',
+    zIndex: 10,
+  }),
+  toolbarLabel: css({
+    fontSize: '14px',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+    color: '#536171',
+    flexShrink: 0,
+  }),
+  dot: css({
+    display: 'inline-block',
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    background: '#0059C8',
+    flexShrink: 0,
+  }),
+  dotPlaceholder: css({
+    display: 'inline-block',
+    width: '8px',
+    flexShrink: 0,
+  }),
+  menuItemInner: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  }),
+  actions: css({
+    display: 'flex',
+    gap: '8px',
+    marginLeft: 'auto',
+    flexShrink: 0,
+  }),
 };
 
-const AssetPickerDialog = () => {
-  const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
-  const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
-  const expression = invocationParams.expression as string;
+// ─── Single-field mode (original behaviour) ───────────────────────────────────
 
-  /**
-   * Initialization is triggered using the div's ref to ensure the container exists in the DOM
-   */
+interface SingleFieldProps {
+  sdk: DialogAppSDK<AppInstallationParameters>;
+  invocationParams: Record<string, unknown>;
+}
+
+const SingleFieldDialog = ({ sdk, invocationParams }: SingleFieldProps) => {
+  const expression = invocationParams.expression as string | undefined;
+
   const init = useCallback(
     (container: HTMLDivElement) => {
+      if (!container) return;
       (async () => {
         await loadScript('https://media-library.cloudinary.com/global/all.js');
-        // clear container
         container.innerHTML = '';
-        // style `body`
         injectGlobal({
-          'html, body, #root': {
-            padding: 0,
-            margin: 0,
-            border: 0,
-            height: '100%',
-            overflow: 'hidden',
-          },
+          'html, body, #root': { padding: 0, margin: 0, border: 0, height: '100%', overflow: 'hidden' },
         });
 
         const configurationParams = sdk.parameters.installation;
-        // allow local instances of the dialog to override the configuration maxFiles parameter
-        const maxFiles = 'maxFiles' in invocationParams ? Number(invocationParams.maxFiles) : configurationParams.maxFiles;
+        const maxFiles =
+          'maxFiles' in invocationParams ? Number(invocationParams.maxFiles) : configurationParams.maxFiles;
         const transformations = [];
+        if (configurationParams.format !== 'none') transformations.push({ fetch_format: configurationParams.format });
+        if (configurationParams.quality !== 'none') transformations.push({ quality: configurationParams.quality });
 
-        // Handle format
-        if (configurationParams.format !== 'none') {
-          transformations.push({ fetch_format: configurationParams.format });
-        }
-
-        // Handle quality
-        if (configurationParams.quality !== 'none') {
-          transformations.push({ quality: configurationParams.quality });
-        }
         sdk.window.updateHeight(window.outerHeight);
+
         const options = {
           cloud_name: configurationParams.cloudName,
           api_key: configurationParams.apiKey,
           max_files: maxFiles,
           multiple: maxFiles > 1,
-          // if we pass `container` instead of the id, the media library would render without iframe
           inline_container: `#${container.id}`,
           remove_header: true,
           default_transformations: [transformations],
           search: { expression },
-
-          integration: {
-            platform: 'contentful',
-            type: 'contentful',
-            version: APP_VERSION,
-            environment: APP_ENV,
-          },
+          integration: { platform: 'contentful', type: 'contentful', version: APP_VERSION, environment: APP_ENV },
         };
 
         const instance = window.cloudinary.createMediaLibrary(options, {
@@ -86,10 +114,166 @@ const AssetPickerDialog = () => {
         instance.show(showOptions);
       })();
     },
-    [sdk],
+    [sdk, invocationParams, expression],
   );
 
   return <div ref={init} id="container" css={styles.container} />;
+};
+
+// ─── Multi-field mode (sidebar workflow) ─────────────────────────────────────
+
+interface MultiFieldProps {
+  sdk: DialogAppSDK<AppInstallationParameters>;
+  slots: PickerSlot[];
+}
+
+const MultiFieldDialog = ({ sdk, slots }: MultiFieldProps) => {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [assignments, setAssignments] = useState<Record<string, MediaLibraryResultAsset[]>>(() =>
+    Object.fromEntries(slots.map((s) => [s.slotKey, []])),
+  );
+  const activeIdxRef = useRef(0);
+  const assignmentsRef = useRef(assignments);
+
+  const updateActive = (idx: number) => {
+    setActiveIdx(idx);
+    activeIdxRef.current = idx;
+  };
+
+  const handleDone = useCallback(() => {
+    sdk.close({ mode: 'multi-field', assignments: assignmentsRef.current });
+  }, [sdk]);
+
+  const totalSelected = Object.values(assignments).reduce((n, a) => n + a.length, 0);
+
+  const init = useCallback(
+    (container: HTMLDivElement) => {
+      if (!container) return;
+      (async () => {
+        await loadScript('https://media-library.cloudinary.com/global/all.js');
+        container.innerHTML = '';
+        injectGlobal({
+          'html, body, #root': { padding: 0, margin: 0, border: 0, height: '100%', overflow: 'hidden' },
+        });
+
+        const configurationParams = sdk.parameters.installation;
+        const maxFiles = configurationParams.maxFiles ?? 10;
+        const transformations = [];
+        if (configurationParams.format !== 'none') transformations.push({ fetch_format: configurationParams.format });
+        if (configurationParams.quality !== 'none') transformations.push({ quality: configurationParams.quality });
+
+        container.style.paddingBottom = '56px';
+        sdk.window.updateHeight(window.outerHeight);
+
+        const options = {
+          cloud_name: configurationParams.cloudName,
+          api_key: configurationParams.apiKey,
+          max_files: maxFiles,
+          multiple: maxFiles > 1,
+          inline_container: `#${container.id}`,
+          remove_header: true,
+          default_transformations: [transformations],
+          integration: { platform: 'contentful', type: 'contentful', version: APP_VERSION, environment: APP_ENV },
+        };
+
+        const instance = window.cloudinary.createMediaLibrary(options, {
+          insertHandler: (data: MediaLibraryResult) => {
+            const idx = activeIdxRef.current;
+            const slot = slots[idx];
+            if (!slot) return;
+
+            const current = assignmentsRef.current[slot.slotKey] ?? [];
+            const remaining = slot.maxFiles - current.length;
+            if (remaining <= 0) return;
+            const next = [...current, ...data.assets.slice(0, remaining)];
+
+            const updated = { ...assignmentsRef.current, [slot.slotKey]: next };
+            assignmentsRef.current = updated;
+            setAssignments({ ...updated });
+
+            // Auto-advance to next slot that still has capacity
+            const nextIdx = slots.findIndex(
+              (s, i) => i > idx && (updated[s.slotKey]?.length ?? 0) < s.maxFiles,
+            );
+            if (nextIdx !== -1) updateActive(nextIdx);
+          },
+        });
+
+        const showOptions: ShowOptions = {
+          remove_upload_operation: configurationParams.showUploadButton === 'false',
+        };
+        if (typeof configurationParams.startFolder === 'string' && configurationParams.startFolder.length) {
+          showOptions.folder = { path: configurationParams.startFolder };
+        }
+        instance.show(showOptions);
+      })();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sdk],
+  );
+
+  return (
+    <>
+      <div ref={init} id="container" css={styles.container} />
+      <div css={styles.toolbar}>
+        <span css={styles.toolbarLabel}>Add to field:</span>
+        <Menu>
+          <Menu.Trigger>
+            <Button variant="secondary" size="small" endIcon={<ArrowDownIcon />} style={{ minWidth: '260px', justifyContent: 'space-between' }}>
+              {slots[activeIdx]
+                ? `${slots[activeIdx].fieldName} — ${slots[activeIdx].localeName}`
+                : 'Select slot'}
+            </Button>
+          </Menu.Trigger>
+          <Menu.List>
+            {slots.map((slot, idx) => {
+              const count = assignments[slot.slotKey]?.length ?? 0;
+              const isActive = idx === activeIdx;
+              return (
+                <Menu.Item key={slot.slotKey} onClick={() => updateActive(idx)}>
+                  <span css={styles.menuItemInner}>
+                    {count > 0
+                      ? <span css={styles.dot} title={`${count} selected`} />
+                      : <span css={styles.dotPlaceholder} />}
+                    <span style={{ fontWeight: isActive ? 700 : 400 }}>
+                      {slot.fieldName} — {slot.localeName}
+                      {count > 0 ? ` (${count})` : ''}
+                    </span>
+                  </span>
+                </Menu.Item>
+              );
+            })}
+          </Menu.List>
+        </Menu>
+        <div css={styles.actions}>
+          <Button variant="secondary" size="small" onClick={() => sdk.close(undefined)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            isDisabled={totalSelected === 0}
+            onClick={handleDone}>
+            {totalSelected > 0 ? `Add to entry (${totalSelected})` : 'Add to entry'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// ─── Router ───────────────────────────────────────────────────────────────────
+
+const AssetPickerDialog = () => {
+  const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
+  const invocationParams = sdk.parameters.invocation as Record<string, unknown>;
+
+  if (invocationParams.mode === 'multi-field') {
+    const slots = invocationParams.slots as PickerSlot[];
+    return <MultiFieldDialog sdk={sdk} slots={slots} />;
+  }
+
+  return <SingleFieldDialog sdk={sdk} invocationParams={invocationParams} />;
 };
 
 export default AssetPickerDialog;

--- a/apps/cloudinary2/src/locations/Sidebar.tsx
+++ b/apps/cloudinary2/src/locations/Sidebar.tsx
@@ -1,0 +1,186 @@
+import { SidebarAppSDK, SerializedJSONValue } from '@contentful/app-sdk';
+import { Button, Note, Spinner, Stack, Text } from '@contentful/f36-components';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
+import { css } from '@emotion/react';
+import { useCallback, useEffect, useState } from 'react';
+import logo from '../assets/logo.svg';
+import { AppInstallationParameters, CloudinaryAsset, MediaLibraryResultAsset } from '../types';
+import { extractAsset } from '../utils';
+
+const styles = {
+  logo: css({
+    display: 'block',
+    width: '16px',
+    height: '16px',
+    filter: 'brightness(0) invert(1)',
+  }),
+  wrapper: css({
+    marginTop: '-8px',
+  }),
+};
+
+/** One picker slot = one (field, locale) pair */
+export interface PickerSlot {
+  slotKey: string; // `${fieldId}::${locale}`
+  fieldId: string;
+  fieldName: string;
+  locale: string;
+  localeName: string;
+  maxFiles: number;
+}
+
+/** Result the dialog returns */
+interface MultiFieldResult {
+  mode: 'multi-field';
+  assignments: Record<string, MediaLibraryResultAsset[]>; // keyed by slotKey
+}
+
+const Sidebar = () => {
+  const sdk = useSDK<SidebarAppSDK<AppInstallationParameters>>();
+  useAutoResizer({ absoluteElements: true });
+
+  const [slots, setSlots] = useState<PickerSlot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [picking, setPicking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const contentTypeId = sdk.entry.getSys().contentType.sys.id;
+        const [ei, ct] = await Promise.all([
+          sdk.cma.editorInterface.get({ contentTypeId }),
+          sdk.cma.contentType.get({ contentTypeId }),
+        ]);
+
+        const appFieldIds = new Set(
+          (ei.controls ?? [])
+            .filter((c) => c.widgetNamespace === 'app' && c.widgetId === sdk.ids.app)
+            .map((c) => c.fieldId)
+            .filter((id): id is string => typeof id === 'string'),
+        );
+
+        const installMaxFiles = sdk.parameters.installation.maxFiles ?? 10;
+        const localeNames: Record<string, string> = sdk.locales.names;
+        const defaultLocale = sdk.locales.default;
+
+        // Use only the locales the editor has active, not all space locales.
+        const { active } = sdk.editor.getLocaleSettings();
+        const activeLocales = active && active.length > 0 ? active : [defaultLocale];
+
+        const built: PickerSlot[] = [];
+        for (const f of ct.fields) {
+          if (!appFieldIds.has(f.id)) continue;
+          const locales = f.localized ? activeLocales : [defaultLocale];
+          for (const locale of locales) {
+            built.push({
+              slotKey: `${f.id}::${locale}`,
+              fieldId: f.id,
+              fieldName: f.name,
+              locale,
+              localeName: localeNames[locale] ?? locale,
+              maxFiles: installMaxFiles,
+            });
+          }
+        }
+
+        setSlots(built);
+      } catch (e) {
+        setError('Could not load Cloudinary fields.');
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [sdk]);
+
+  const openMultiPicker = useCallback(async () => {
+    setPicking(true);
+    setError(null);
+
+    try {
+      const parameters: SerializedJSONValue = {
+        mode: 'multi-field',
+        slots: slots.map((s) => ({
+          slotKey: s.slotKey,
+          fieldId: s.fieldId,
+          fieldName: s.fieldName,
+          locale: s.locale,
+          localeName: s.localeName,
+          maxFiles: s.maxFiles,
+        })),
+      };
+
+      const result: MultiFieldResult | undefined = await sdk.dialogs.openCurrentApp({
+        position: 'center',
+        title: 'Select Cloudinary assets',
+        shouldCloseOnOverlayClick: true,
+        shouldCloseOnEscapePress: true,
+        width: 1400,
+        parameters,
+      });
+
+      if (!result) return;
+
+      for (const slot of slots) {
+        const rawAssets = result.assignments[slot.slotKey];
+        if (!rawAssets || rawAssets.length === 0) continue;
+
+        const newAssets: CloudinaryAsset[] = rawAssets.map(extractAsset);
+        const entryField = sdk.entry.fields[slot.fieldId];
+        if (!entryField) continue;
+
+        const existing: CloudinaryAsset[] = entryField.getValue(slot.locale) ?? [];
+        const merged = [...existing, ...newAssets].slice(0, slot.maxFiles);
+        await entryField.setValue(merged, slot.locale);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to pick assets.';
+      setError(msg);
+      sdk.notifier.error(msg);
+    } finally {
+      setPicking(false);
+    }
+  }, [sdk, slots]);
+
+  if (loading) {
+    return (
+      <Stack alignItems="center" justifyContent="center" spacing="spacingS">
+        <Spinner size="small" />
+        <Text fontSize="fontSizeS">Loading fields…</Text>
+      </Stack>
+    );
+  }
+
+  if (error) {
+    return <Note variant="negative">{error}</Note>;
+  }
+
+  if (slots.length === 0) {
+    return <Note variant="neutral">No Cloudinary fields found in this content type.</Note>;
+  }
+
+  const fieldCount = new Set(slots.map((s) => s.fieldId)).size;
+  const localeCount = new Set(slots.map((s) => s.locale)).size;
+
+  return (
+    <div css={styles.wrapper}>
+      <Stack flexDirection="column" spacing="spacingS">
+        <Text fontSize="fontSizeS" fontColor="gray600">
+          Open Cloudinary once and assign assets to {fieldCount} field{fieldCount !== 1 ? 's' : ''}, {localeCount} locale{localeCount !== 1 ? 's' : ''}.
+        </Text>
+        <Button
+          startIcon={picking ? <Spinner size="small" /> : <img src={logo} alt="Cloudinary" css={styles.logo} />}
+          variant="primary"
+          size="small"
+          isFullWidth
+          isDisabled={picking}
+          onClick={openMultiPicker}>
+          {picking ? 'Opening…' : 'Open Cloudinary'}
+        </Button>
+      </Stack>
+    </div>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
[ES-380](https://contentful.atlassian.net/browse/ES-380)

## Summary
- Adds a new `LOCATION_ENTRY_SIDEBAR` location to the Cloudinary app that opens the widget once and lets editors assign assets to multiple fields and active locales in a single session
- The dialog shows a dropdown (with blue dot indicators for filled slots) to select the target field + locale; auto-advances to the next empty slot after each insert
- Original per-field picker behaviour is fully preserved — the sidebar is additive and the existing `AssetPickerDialog` single-field path is unchanged

<img width="1197" height="912" alt="Screenshot 2026-06-25 at 12 47 26 PM" src="https://github.com/user-attachments/assets/d10af355-5a82-444a-83ff-af76ee3d6806" />

<img width="1199" height="908" alt="Screenshot 2026-06-25 at 12 47 53 PM" src="https://github.com/user-attachments/assets/1ae08d71-f079-49a2-9164-7e39e7d1874d" />

<img width="1200" height="910" alt="Screenshot 2026-06-25 at 12 48 19 PM" src="https://github.com/user-attachments/assets/588e0576-cef8-40e8-8375-fd7719c9fb9d" />

## Test plan
- [ ] Open an entry that has multiple Cloudinary fields — sidebar should show "Open Cloudinary" button with field/locale count
- [ ] Click "Open Cloudinary" — widget loads once, picker appears with field+locale dropdown in toolbar
- [ ] Select an asset and hit Insert — blue dot appears on that slot in the dropdown, auto-advances to next slot
- [ ] Switch slots manually via dropdown and insert assets for each
- [ ] Click "Add to entry" — all assigned assets written to the correct fields and locales
- [ ] Cancel mid-session — no fields written, entry unchanged
- [ ] Non-localized fields appear once (default locale only); localized fields appear once per active locale
- [ ] Per-field picker buttons still work as before (single-field mode unaffected)
- [ ] App manifest must have `sidebar` location registered in the Contentful developer portal for the sidebar to render

Generated with [Claude Code](https://claude.com/claude-code)

[ES-380]: https://contentful.atlassian.net/browse/ES-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Adds a new sidebar location to the Cloudinary2 app that enables editors to open the Cloudinary media library once and assign assets to multiple fields and locales in a single workflow. The existing per-field picker remains fully intact — the sidebar is entirely additive and the original AssetPickerDialog single-field path is unchanged.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a new LOCATION_ENTRY_SIDEBAR entry point in App.tsx, rendering a Sidebar component that discovers all Cloudinary-bound fields in the current content type and builds picker slots for each (field, locale) pair.</li>

<li>AssetPickerDialog.tsx is refactored into two modes: SingleFieldDialog keeps the original single-field behaviour untouched, while MultiFieldDialog adds a bottom toolbar with a field+locale dropdown, blue-dot indicators for filled slots, auto-advancement after each insert, and a bulk 'Add to entry' commit button.</li>

<li>The Sidebar queries the EditorInterface and ContentType CMA APIs on mount to enumerate app-bound fields, respects the editor's active locale settings (not all space locales), and on dialog confirmation merges each slot's assigned assets with existing field values before calling entryField.setValue.</li>

<li>No unit tests were added in this diff.</li>

</ul>
</details>

</div>