### PR TITLE
fix(vwo-fme): use sdk.cma instead of manual createClient [AIS-59]

### DIFF
--- a/apps/vwo-fme/src/services/vwoAppActionService.js
+++ b/apps/vwo-fme/src/services/vwoAppActionService.js
@@ -1,19 +1,9 @@
-import { createClient } from 'contentful-management';
 import { globalConstants } from '../utils';
 
 class VwoAppActionService {
   constructor(sdk) {
     this.sdk = sdk;
-    this.cma = createClient(
-      { apiAdapter: sdk.cmaAdapter },
-      {
-        type: 'plain',
-        defaults: {
-          environmentId: sdk.ids.environment,
-          spaceId: sdk.ids.space,
-        },
-      }
-    );
+    this.cma = sdk.cma;
     this.actionId = null;
   }
 


### PR DESCRIPTION
## Summary
- `app-sdk` 4.58.0 (shipped in v1.0.13) declares `contentful-management ^12.3.1` as its own dependency, which npm resolves as a nested copy alongside the app's root `contentful-management@11.69.2`
- `react-scripts` bundles both copies; the named `{ createClient }` import from the nested v12 ESM-only build is unavailable at runtime → `t.createClient is not a function` → app iframe fails to load
- Fix: drop the manual `createClient(...)` call and use `sdk.cma`, the pre-configured plain CMA client the SDK already constructs — functionally identical, zero additional dependencies

## Test plan
- [ ] Install and open the VWO FME app on production definition `71oYmQJFCIWn9pxizjN8dZ` — app iframe should load without the `createClient is not a function` error
- [ ] Verify the config screen loads and the entry editor field app renders correctly
- [ ] Confirm no console errors related to `createClient` or `contentful-management`

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a critical runtime error in the VWO Feature Manager Experiments (FME) app where the app iframe failed to load with a 'createClient is not a function' error. The fix replaces manual CMA client instantiation using createClient from contentful-management with the pre-configured sdk.cma property provided by the App SDK, eliminating a nested dependency conflict.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes manual createClient import and instantiation in vwoAppActionService.js, switching to sdk.cma to resolve runtime error caused by ESM import resolution failure</li>

<li>Eliminates nested contentful-management dependency conflict between app-sdk's v12.3.1 and root package's v11.69.2 that prevented the CMA client from working</li>

<li>Simplifies CMA client initialization by using the SDK-provided pre-configured client instead of recreating identical configuration with environmentId and spaceId</li>

</ul>
</details>

</div>