### PR TITLE
fix(markup-ai, imageHotspotCreator): use sdk.cma instead of manual createClient [AIS-59]

### DIFF
--- a/apps/imageHotspotCreator/src/components/ImageSelector/selectImage.tsx
+++ b/apps/imageHotspotCreator/src/components/ImageSelector/selectImage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import MagicDropzone from "react-magic-dropzone";
 import { Button, TextInput } from "@contentful/f36-components";
 import cloneDeep from "clone-deep";
-import { AssetProps, createClient } from "contentful-management";
+import { AssetProps } from "contentful-management";
 import fieldMissing from "../../Assets/MissingField.svg";
 import ValidationPage from "../Validation";
 import { EditorAppSDK } from "@contentful/app-sdk";
@@ -140,22 +140,14 @@ const SelectImage = ({
    * @param {Blob} file - The blob file of the Image
    */
   const uploadImage = async (bufferData: any, file: any) => {
-    const cma = createClient({ apiAdapter: sdk.cmaAdapter });
-
-    const space = await cma.getSpace(sdk.ids.space);
-
     setImageAssets("");
-    await space
-      .getEnvironment(sdk.ids.environment)
-      .then((environment: any) =>
-        environment.createAssetFromFiles({
+    try {
+      const asset = await sdk.cma.asset.createFromFiles(
+        {},
+        {
           fields: {
-            title: {
-              [defaultLocale]: file?.name,
-            },
-            description: {
-              [defaultLocale]: file?.type,
-            },
+            title: { [defaultLocale]: file?.name },
+            description: { [defaultLocale]: file?.type },
             file: {
               [defaultLocale]: {
                 contentType: file?.type,
@@ -164,15 +156,14 @@ const SelectImage = ({
               },
             },
           },
-        })
-      )
-      .then((asset: any) => asset.processForAllLocales())
-      .then((asset: any) => {
-        getImageUrl(asset?.sys?.id, false);
-
-        asset.publish();
-      })
-      .catch(console.error);
+        }
+      );
+      const processed = await sdk.cma.asset.processForAllLocales({}, asset);
+      getImageUrl(processed?.sys?.id, false);
+      await sdk.cma.asset.publish({ assetId: processed.sys.id }, processed);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const isValidUrl = (url: string) => {

--- a/apps/markup-ai/src/locations/ConfigScreen/ConfigScreen.tsx
+++ b/apps/markup-ai/src/locations/ConfigScreen/ConfigScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from "react";
 import { ConfigAppSDK } from "@contentful/app-sdk";
 import { useSDK } from "@contentful/react-apps-toolkit";
 import { Box, Checkbox, Heading, Paragraph, Spinner, Subheading } from "@contentful/f36-components";
-import { createClient } from "contentful-management";
 import styled from "@emotion/styled";
 import tokens from "@contentful/f36-tokens";
 import {
@@ -113,21 +112,12 @@ export const ConfigScreen = () => {
 
   useEffect(() => {
     void (async () => {
-      const { app, cmaAdapter, ids } = sdk;
+      const { app } = sdk;
 
       const richTextFields: TextFieldsState = {};
       const activeFields: Record<string, boolean> = {};
 
-      const cma = createClient(
-        { apiAdapter: cmaAdapter },
-        {
-          type: "plain",
-          defaults: {
-            environmentId: ids.environmentAlias ?? ids.environment,
-            spaceId: ids.space,
-          },
-        },
-      );
+      const cma = sdk.cma;
 
       const content = await cma.contentType.getMany({ query: { limit: 1000 } });
       const currentState = await app.getCurrentState();

--- a/apps/vwo-fme/src/services/vwoAppActionService.js
+++ b/apps/vwo-fme/src/services/vwoAppActionService.js
@@ -1,19 +1,9 @@
-import { createClient } from 'contentful-management';
 import { globalConstants } from '../utils';
 
 class VwoAppActionService {
   constructor(sdk) {
     this.sdk = sdk;
-    this.cma = createClient(
-      { apiAdapter: sdk.cmaAdapter },
-      {
-        type: 'plain',
-        defaults: {
-          environmentId: sdk.ids.environment,
-          spaceId: sdk.ids.space,
-        },
-      }
-    );
+    this.cma = sdk.cma;
     this.actionId = null;
   }
 


### PR DESCRIPTION
## Summary
- `app-sdk` >=4.58.0 introduces a nested `contentful-management@12` dependency that conflicts with apps' own v11 direct dep when bundled, causing `createClient is not a function` at runtime (same root cause as #8449 for vwo-fme)
- `markup-ai`: replace `createClient({ apiAdapter }, { type: 'plain', ... })` with `sdk.cma`
- `imageHotspotCreator`: rewrite asset upload chain using `sdk.cma.asset.createFromFiles` / `processForAllLocales` / `publish` — the plain client equivalents of the previous `getSpace().getEnvironment().createAssetFromFiles()` chain

## Test plan
- [ ] markup-ai: install the app and verify the config screen loads content types without error
- [ ] imageHotspotCreator: upload an image and confirm it is created, processed, and published successfully
- [ ] No `createClient is not a function` console errors in either app

Generated with [Claude Code](https://claude.com/claude-code)