### PR TITLE
fix(vwo-fme): bump @contentful/app-sdk to 4.61.1 [AIS-59]

### DIFF
--- a/apps/vwo-fme/package-lock.json
+++ b/apps/vwo-fme/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vwo-fme",
       "version": "1.0.14",
       "dependencies": {
-        "@contentful/app-sdk": "^4.58.0",
+        "@contentful/app-sdk": "^4.61.1",
         "@contentful/f36-components": "4.81.1",
         "@contentful/f36-tokens": "^6.1.2",
         "@contentful/react-apps-toolkit": "1.2.19",
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.58.0.tgz",
-      "integrity": "sha512-XRL64azk47DerkIaj2bwzSmjOK4ZfStsragY3Lkoyi4IFFwmLptQK8d2OqaNVME1ADq/92rQUwziFAqaUbKInw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.61.1.tgz",
+      "integrity": "sha512-J7dVMR4doRwQBt7/nOKKcOiJ8qn5oblL8neausc3yOxe2ppp8pZJW+m428JqTFHfPGkShlSpikc/z+tulP48+w==",
       "license": "MIT",
       "dependencies": {
         "contentful-management": "^12.3.1"
@@ -6209,27 +6209,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -6302,14 +6281,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -9896,14 +9867,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -15948,17 +15911,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -21322,20 +21274,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/apps/vwo-fme/package.json
+++ b/apps/vwo-fme/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.14",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.58.0",
+    "@contentful/app-sdk": "^4.61.1",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-tokens": "^6.1.2",
     "@contentful/react-apps-toolkit": "1.2.19",


### PR DESCRIPTION
[AIS-59](https://contentful.atlassian.net/browse/AIS-59)

## Summary
- Bumps `@contentful/app-sdk` `^4.58.0` → `^4.61.1` in vwo-fme and regenerates the lockfile.
- 4.61.1 ships [ui-extensions-sdk#2614](https://github.com/contentful/ui-extensions-sdk/pull/2614), which fixes the `createClient` interop regression that threw `t.createClient is not a function` inside the SDK's own `init()` — crashing the VWO FME iframe on **every** location (install/config + editor).
- The earlier `sdk.cma` fix (v1.0.14, PR #8449) was necessary but insufficient: `sdk.cma` is constructed by the same SDK-internal `createClient` call that threw. The real fix had to land in app-sdk.

## Root cause recap
app-sdk 4.58 bumped its `contentful-management` dep `^11`→`^12.3.1`. CM v12 is ESM-first; under react-scripts/webpack interop (with the dual-copy tree — nested CM v12 under app-sdk alongside the app's v11), the SDK's named `import { createClient }` resolved to `undefined` → threw in `init()`. 4.61.1 resolves it defensively.

## Test plan
- [x] `npm install --legacy-peer-deps` resolves `@contentful/app-sdk@4.61.1` (verified in regenerated lockfile)
- [x] `react-scripts build` succeeds; new bundle `main.eca22d78.js`
- [x] Built bundle contains the SDK's defensive resolution (`createClient ?? default?.createClient`) — no bare throwing `t.createClient`
- [ ] After release-please deploys, confirm prod definition `71oYmQJFCIWn9pxizjN8dZ` loads the iframe without `createClient is not a function` (install + editor)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-59]: https://contentful.atlassian.net/browse/AIS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ