### PR TITLE
fix(vwo-fme): surface content-type-limit error on install [AIS-89]

### DIFF
--- a/apps/vwo-fme/package-lock.json
+++ b/apps/vwo-fme/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@contentful/app-scripts": "^2.5.12",
         "@craco/craco": "^7.1.0",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "cross-env": "^10.1.0"
@@ -6282,7 +6283,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6403,8 +6403,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -10066,8 +10065,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -16151,7 +16149,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/apps/vwo-fme/package.json
+++ b/apps/vwo-fme/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@contentful/app-scripts": "^2.5.12",
     "@craco/craco": "^7.1.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "cross-env": "^10.1.0"

--- a/apps/vwo-fme/src/locations/ConfigScreen.jsx
+++ b/apps/vwo-fme/src/locations/ConfigScreen.jsx
@@ -231,7 +231,19 @@ export default class ConfigScreen extends React.Component {
     );
 
     if (needsVariationContainerInSpace) {
-      await this.createVariationContainerContentType();
+      try {
+        await this.createVariationContainerContentType();
+      } catch (e) {
+        const reasons = e?.details?.reasons || [];
+        const limitReached =
+          reasons.includes("usageExceeded") || e?.sys?.id === "AccessDenied";
+        this.props.sdk.notifier.error(
+          limitReached
+            ? "The VWO FME app needs to create a content type, but this environment has reached its content type limit. Free up a content type or raise the limit, then try installing again."
+            : "The VWO FME app could not create its content type. Please try again."
+        );
+        return false;
+      }
     }
 
     const res = await this.saveEnabledContentTypes(

--- a/apps/vwo-fme/src/locations/ConfigScreen.test.js
+++ b/apps/vwo-fme/src/locations/ConfigScreen.test.js
@@ -1,0 +1,62 @@
+import ConfigScreen from './ConfigScreen';
+
+const usageExceededError = {
+  sys: { type: 'Error', id: 'AccessDenied' },
+  message: 'Forbidden',
+  details: {
+    reasons: [
+      'usageExceeded',
+      'You do not have permissions to create on ContentType, please contact your administrator for more information.',
+    ],
+  },
+};
+
+const makeSdk = (createContentType) => ({
+  locales: { default: 'en-US' },
+  notifier: { error: jest.fn() },
+  space: {
+    createContentType,
+    updateContentType: jest.fn().mockResolvedValue({}),
+    getContentTypes: jest.fn().mockResolvedValue({ items: [] }),
+  },
+  app: {
+    getCurrentState: jest.fn().mockResolvedValue({ EditorInterface: {} }),
+  },
+});
+
+// onConfigure only reads this.props / this.state, so we can drive it on a bare
+// instance without mounting the component or running componentDidMount.
+const makeInstance = (sdk) => {
+  const instance = new ConfigScreen({ accessToken: 'token', sdk });
+  instance.setState = (updater) => {
+    const next = typeof updater === 'function' ? updater(instance.state) : updater;
+    instance.state = { ...instance.state, ...next };
+  };
+  return instance;
+};
+
+describe('ConfigScreen.onConfigure', () => {
+  it('surfaces a content-type-limit error instead of failing silently when createContentType is rejected with usageExceeded', async () => {
+    const sdk = makeSdk(jest.fn().mockRejectedValue(usageExceededError));
+    const instance = makeInstance(sdk);
+
+    const result = await instance.onConfigure();
+
+    // Install must be aborted cleanly, not left to an unhandled rejection.
+    expect(result).toBe(false);
+    // The user must be told the content-type limit is the cause.
+    expect(sdk.notifier.error).toHaveBeenCalledTimes(1);
+    expect(sdk.notifier.error.mock.calls[0][0].toLowerCase()).toContain('content type');
+  });
+
+  it('returns install target state on the happy path', async () => {
+    const sdk = makeSdk(jest.fn().mockResolvedValue({ sys: { id: 'variationFmeContainer' } }));
+    const instance = makeInstance(sdk);
+
+    const result = await instance.onConfigure();
+
+    expect(result).not.toBe(false);
+    expect(result.targetState.EditorInterface).toHaveProperty('variationFmeContainer');
+    expect(sdk.notifier.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
[AIS-89](https://contentful.atlassian.net/browse/AIS-89)

## Summary
- On install, `ConfigScreen.onConfigure()` creates the "VWO FME Wrapper" content type via `sdk.space.createContentType(...)` with **no try/catch**. When that call rejects — e.g. `AccessDenied` / `usageExceeded` because the environment is at its content-type limit — the unhandled rejection makes app-sdk abort the install **silently**: nothing appears to happen, and a subsequent GET on the never-created installation returns 404 `AppInstallation does not exist`.
- Fix: wrap the create call and emit `sdk.notifier.error(...)`, with a specific message for the content-type-limit / `usageExceeded` case, and abort cleanly (`return false`) — mirroring the existing handling in the sibling `saveEnabledContentTypes`.
- Also added `@testing-library/dom` (the missing peer of `@testing-library/react`) so the CRA test harness runs, plus a regression test for `onConfigure`.

## Test plan
- [x] `craco test` passes: `onConfigure` returns `false` and fires a content-type-limit notifier error when `createContentType` rejects with `usageExceeded`; happy path still returns the install target state.
- [x] `npm ci` installs cleanly from the updated lockfile.
- [x] `eslint` clean on changed files.
- [ ] Staging validation: install the built app against an environment at its content-type limit and confirm the notifier error appears (not blocking; UX-only error path).

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-89]: https://contentful.atlassian.net/browse/AIS-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ