### PR TITLE
fix(security): sanitize error disclosure in translationstudio and ceros [ACT-3449]

### DIFF
--- a/apps/ceros/src/oembed.test.ts
+++ b/apps/ceros/src/oembed.test.ts
@@ -196,7 +196,7 @@ describe('getExperienceMetadata', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockExtract.mockRejectedValue(new Error('Network error'));
       await getExperienceMetadata('https://view.ceros.com/account/experience');
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch oembed metadata:', 'Network error');
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch oembed metadata.');
       expect(consoleSpy).not.toHaveBeenCalledWith(expect.any(Error));
       consoleSpy.mockRestore();
     });

--- a/apps/ceros/src/oembed.test.ts
+++ b/apps/ceros/src/oembed.test.ts
@@ -196,7 +196,7 @@ describe('getExperienceMetadata', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockExtract.mockRejectedValue(new Error('Network error'));
       await getExperienceMetadata('https://view.ceros.com/account/experience');
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch oembed metadata.');
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch oembed metadata:', 'Network error');
       expect(consoleSpy).not.toHaveBeenCalledWith(expect.any(Error));
       consoleSpy.mockRestore();
     });

--- a/apps/ceros/src/oembed.test.ts
+++ b/apps/ceros/src/oembed.test.ts
@@ -192,6 +192,15 @@ describe('getExperienceMetadata', () => {
       expect(result).toBeNull();
     });
 
+    it('logs a sanitized message (not the raw error) when extract throws', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockExtract.mockRejectedValue(new Error('Network error'));
+      await getExperienceMetadata('https://view.ceros.com/account/experience');
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch oembed metadata.');
+      expect(consoleSpy).not.toHaveBeenCalledWith(expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+
     it('fills url from canonical URL when metadata has no url', async () => {
       const { url: _url, ...metadataWithoutUrl } = baseMetadata;
       mockExtract.mockResolvedValue(metadataWithoutUrl);

--- a/apps/ceros/src/oembed.ts
+++ b/apps/ceros/src/oembed.ts
@@ -72,7 +72,7 @@ export async function getExperienceMetadata(experienceUrl: string): Promise<Oemb
     }
     return metadata;
   } catch (err) {
-    console.trace(err);
+    console.error('Failed to fetch oembed metadata.');
     return null;
   }
 }

--- a/apps/ceros/src/oembed.ts
+++ b/apps/ceros/src/oembed.ts
@@ -72,7 +72,7 @@ export async function getExperienceMetadata(experienceUrl: string): Promise<Oemb
     }
     return metadata;
   } catch (err) {
-    console.error('Failed to fetch oembed metadata.');
+    console.error('Failed to fetch oembed metadata:', err instanceof Error ? err.message : String(err));
     return null;
   }
 }

--- a/apps/ceros/src/oembed.ts
+++ b/apps/ceros/src/oembed.ts
@@ -72,7 +72,7 @@ export async function getExperienceMetadata(experienceUrl: string): Promise<Oemb
     }
     return metadata;
   } catch (err) {
-    console.error('Failed to fetch oembed metadata:', err instanceof Error ? err.message : String(err));
+    console.error('Failed to fetch oembed metadata.');
     return null;
   }
 }

--- a/apps/translationstudio/components/Translations.tsx
+++ b/apps/translationstudio/components/Translations.tsx
@@ -234,7 +234,7 @@ async function fetchAllEntries(sdk: PageAppSDK, space: string, id: string, displ
         return data;
     }
     catch (err) {
-        console.error('Failed to fetch entries.');
+        console.error('Failed to fetch entries:', err instanceof Error ? err.message : String(err));
     }
 
     return null;

--- a/apps/translationstudio/components/Translations.tsx
+++ b/apps/translationstudio/components/Translations.tsx
@@ -234,7 +234,7 @@ async function fetchAllEntries(sdk: PageAppSDK, space: string, id: string, displ
         return data;
     }
     catch (err) {
-        console.error('Failed to fetch entries:', err instanceof Error ? err.message : String(err));
+        console.error('Failed to fetch entries.');
     }
 
     return null;

--- a/apps/translationstudio/components/Translations.tsx
+++ b/apps/translationstudio/components/Translations.tsx
@@ -234,7 +234,7 @@ async function fetchAllEntries(sdk: PageAppSDK, space: string, id: string, displ
         return data;
     }
     catch (err) {
-        console.error(err);
+        console.error('Failed to fetch entries.');
     }
 
     return null;


### PR DESCRIPTION
## Summary

Fixes WS-I002-JAVASCRIPT-00027 (CWE-209 — Disclosure of Error Details and Stack Traces) in two apps by replacing raw error logging with sanitized, context-specific messages.

| File | Before | After | Ticket |
|------|--------|-------|--------|
| `apps/translationstudio/components/Translations.tsx` | `console.error(err)` | `console.error('Failed to fetch entries.')` | [ACT-3450](https://contentful.atlassian.net/browse/ACT-3450) |
| `apps/ceros/src/oembed.ts` | `console.trace(err)` | `console.error('Failed to fetch oembed metadata.')` | [ACT-3449](https://contentful.atlassian.net/browse/ACT-3449) |
| `apps/ceros/src/oembed.test.ts` | — | Added assertion that sanitized message is logged, not raw `Error` | ACT-3449 |

## Wiz details

- Rule: `WS-I002-JAVASCRIPT-00027`
- Severity: CRITICAL
- CWE: [CWE-209](https://cwe.mitre.org/data/definitions/209.html) — Generation of Error Message Containing Sensitive Information
- Wiz issues: [fbab93ac](https://app.wiz.io/p/production/issues#~(issue~'fbab93ac-edb8-4cf8-a1cf-f71eac928c08')) · [52672b8c](https://app.wiz.io/p/production/issues#~(issue~'52672b8c-ee5d-40f6-bbce-a460edf39020'))

## Replaces

Consolidates the following individual PRs (being closed):
- #8652 (ACT-3450)
- #8650 (ACT-3449)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACT-3450]: https://contentful.atlassian.net/browse/ACT-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACT-3449]: https://contentful.atlassian.net/browse/ACT-3449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a critical security vulnerability (CWE-209) by sanitizing error messages that were previously disclosing raw error details and stack trace information through console logging. Two error handlers in the Ceros oembed module and TranslationStudio component are modified to log only generic, sanitized messages instead of exposing potentially sensitive error information.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Sanitizes error logging in oembed.ts by removing err.message details from the catch block in getExperienceMetadata, preventing raw error disclosure (CWE-209 / WS-I002-JAVASCRIPT-00027)</li>

<li>Sanitizes error logging in Translations.tsx by removing err instanceof Error check and message extraction from the catch block in fetchAllEntries</li>

<li>Updates oembed.test.ts test assertion to expect the static sanitized message 'Failed to fetch oembed metadata.' instead of the previous format that included error details</li>

</ul>
</details>

</div>