### PR TITLE
[] fix(security): validate postMessage origin in useAbTastyOAuth

### DIFF
--- a/apps/abtasty/src/hooks/useAbTastyOAuth.ts
+++ b/apps/abtasty/src/hooks/useAbTastyOAuth.ts
@@ -3,6 +3,9 @@ import { useEffect } from 'react';
 export function useAbTastyOAuth(onToken: (token: string) => void) {
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== 'https://integrations-oauth.abtasty.com') {
+        return;
+      }
       const data = (event as MessageEvent<any>).data;
       if (data?.type === 'ABTASTY_OAUTH_SUCCESS' && data.access_token) {
         onToken(data.access_token);


### PR DESCRIPTION
## Summary
- \`apps/abtasty/src/hooks/useAbTastyOAuth.ts\`: handler was accepting \`postMessage\` from any origin, allowing injection of a fake \`ABTASTY_OAUTH_SUCCESS\` message with an attacker-controlled token. Now validates \`event.origin\` against \`https://integrations-oauth.abtasty.com\`.

## Test plan
- [ ] Complete a real AB Tasty OAuth flow — token received, integration connects
- [ ] \`postMessage\` from a different origin is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)