### PR TITLE
fix: update CODEOWNERS to use group-applied-ai-solutions [AIS-66]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contentful/team-extensibility @contentful/team-marketplace
+* @contentful/group-applied-ai-solutions


### PR DESCRIPTION
[AIS-66](https://contentful.atlassian.net/browse/AIS-66) / [AIS-60](https://contentful.atlassian.net/browse/AIS-60)

## What's happening here

We're migrating GitHub ownership away from the old Ecosystem-era teams over to the new `group-applied-ai-solutions` group. This PR is the CODEOWNERS piece of that for `marketplace-partner-apps` — it swaps out `@contentful/team-marketplace` and `@contentful/team-extensibility` wherever they show up and points those paths at `@contentful/group-applied-ai-solutions` instead.

This affects the repo's default ownership rule (the `*` line) — everything else in the file is untouched.

## Before this can merge, someone needs to update repo access

Here's the thing: `group-applied-ai-solutions` doesn't have confirmed Write access to this repo yet (that's tracked separately in [AIS-61](https://contentful.atlassian.net/browse/AIS-61)). If we merge this CODEOWNERS change before that's sorted, GitHub won't be able to resolve the new group as a valid owner, and review routing will just break.

So, before merging:

1. Head over to the repo's access settings: [github.com/contentful/marketplace-partner-apps/settings/access](https://github.com/contentful/marketplace-partner-apps/settings/access)
2. Click **Add teams** and search for `group-applied-ai-solutions`
3. Give it **Write** access — matching the access `@contentful/team-marketplace` and `@contentful/team-extensibility` already has
4. Before removing `@contentful/team-marketplace` and `@contentful/team-extensibility`'s access from this repo, confirm their members are a full subset of `group-applied-ai-solutions`'s members (same overlap check we ran for `agents-api` in [#872](https://github.com/contentful/agents-api/pull/872)) — don't assume it's clean without checking, and fall back to the two-phase grant-then-remove approach from AIS-61 if it isn't

## Test plan
- [ ] Confirm `group-applied-ai-solutions` has Write access on this repo before merging
- [ ] Confirm member overlap before removing old team access (or use the two-phase approach if it isn't clean)
- [ ] After merging, make sure GitHub isn't flagging anything as unowned in CODEOWNERS validation
- [ ] Confirm review requests go to `group-applied-ai-solutions` for the affected paths

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-66]: https://contentful.atlassian.net/browse/AIS-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-60]: https://contentful.atlassian.net/browse/AIS-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-61]: https://contentful.atlassian.net/browse/AIS-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the repository's CODEOWNERS file to migrate default ownership from two legacy teams (`@contentful/team-extensibility` and `@contentful/team-marketplace`) to the newly established `@contentful/group-applied-ai-solutions` group. The change is part of a broader team consolidation effort across Contentful's GitHub organization.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates the default ownership rule (`*`) in CODEOWNERS to reference @contentful/group-applied-ai-solutions instead of the legacy @contentful/team-extensibility and @contentful/team-marketplace teams</li>

</ul>
</details>

</div>