### PR TITLE
fix: validate postMessage origin in AB Tasty OAuth handler [AIS-301]

### DIFF
--- a/apps/abtasty/src/hooks/useAbTastyOAuth.spec.ts
+++ b/apps/abtasty/src/hooks/useAbTastyOAuth.spec.ts
@@ -1,0 +1,53 @@
+// useAbTastyOAuth.spec.ts
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useAbTastyOAuth } from './useAbTastyOAuth';
+
+describe('useAbTastyOAuth', () => {
+  let onToken: (token: string) => void;
+
+  beforeEach(() => {
+    onToken = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const postMessage = (origin: string, data: unknown) => {
+    window.dispatchEvent(new MessageEvent('message', { data, origin }));
+  };
+
+  it('accepts a token from the AB Tasty OAuth origin', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessage('https://integrations-oauth.abtasty.com', {
+      type: 'ABTASTY_OAUTH_SUCCESS',
+      access_token: 'valid-token',
+    });
+
+    expect(onToken).toHaveBeenCalledWith('valid-token');
+  });
+
+  it('ignores a token from an untrusted origin', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessage('https://attacker.example', {
+      type: 'ABTASTY_OAUTH_SUCCESS',
+      access_token: 'malicious-token',
+    });
+
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from an untrusted origin even with a matching message type and shape', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessage('https://evil.abtasty.com.attacker.example', {
+      type: 'ABTASTY_OAUTH_SUCCESS',
+      access_token: 'spoofed-token',
+    });
+
+    expect(onToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/abtasty/src/hooks/useAbTastyOAuth.ts
+++ b/apps/abtasty/src/hooks/useAbTastyOAuth.ts
@@ -1,8 +1,12 @@
 import { useEffect } from 'react';
 
+const OAUTH_ORIGIN = 'https://integrations-oauth.abtasty.com';
+
 export function useAbTastyOAuth(onToken: (token: string) => void) {
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== OAUTH_ORIGIN) return;
+
       const data = (event as MessageEvent<any>).data;
       if (data?.type === 'ABTASTY_OAUTH_SUCCESS' && data.access_token) {
         onToken(data.access_token);
@@ -17,7 +21,7 @@ export function useAbTastyOAuth(onToken: (token: string) => void) {
     const width = 600;
     const height = 700;
     const name = 'abtasty_oauth';
-    const url = 'https://integrations-oauth.abtasty.com/contentful/oauth';
+    const url = `${OAUTH_ORIGIN}/contentful/oauth`;
     const left = window.screenX + (window.outerWidth - width) / 2;
     const top = window.screenY + (window.outerHeight - height) / 2;
     const popup = window.open(


### PR DESCRIPTION
[AIS-301](https://contentful.atlassian.net/browse/AIS-301) / [AIS-302](https://contentful.atlassian.net/browse/AIS-302)

## What's happening here

`useAbTastyOAuth`'s `message` event listener accepted a token from **any origin** — there was no `event.origin` check before treating `data.access_token` as a valid OAuth token. Since the listener is registered on `window` for the lifetime of the config screen, any page (an ad, an iframe, a malicious tab) could `postMessage` a fake `ABTASTY_OAUTH_SUCCESS` payload and have the app treat an attacker-supplied token as the user's real AB Tasty credential.

This closes AIS-301/AIS-302 (duplicate tickets for the same finding — filed by the same Cypress SAST sweep, see [spreadsheet source](https://docs.google.com/spreadsheets/d/1-oiIP3rscjRsxmRgWT1ku98SiW7LSjVB8jWYExU-f7E)).

## Fix

- Added an `OAUTH_ORIGIN` constant (`https://integrations-oauth.abtasty.com`) — the same host the popup URL already opens, so this isn't a new dependency, just making the existing implicit trust boundary explicit.
- `handleMessage` now bails immediately if `event.origin` doesn't match, before even looking at `data`.
- No behavior change for the legitimate flow — the popup still opens the same URL and posts the same message shape back.

## Test plan

- [ ] Added `useAbTastyOAuth.spec.ts` — covers accepting a token from the trusted origin, rejecting a token from an untrusted origin, and rejecting a lookalike origin (e.g. `evil.abtasty.com.attacker.example`) that matches the message shape but not the real origin
- [ ] `npm test` passes in `apps/abtasty`
- [ ] Manually verify the AB Tasty config screen OAuth flow still connects successfully (real flow unaffected by the origin check)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-301]: https://contentful.atlassian.net/browse/AIS-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-302]: https://contentful.atlassian.net/browse/AIS-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This security fix adds postMessage origin validation to the AB Tasty OAuth handler in the marketplace-partner-apps repository. Previously, the `useAbTastyOAuth` hook's message event listener accepted tokens from any origin, allowing potential attackers to inject fake OAuth tokens via cross-origin postMessage. The fix validates that `event.origin` matches the trusted OAuth server (`https://integrations-oauth.abtasty.com`) before processing any token data.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added origin validation in `useAbTastyOAuth.ts` - the `handleMessage` function now returns early if `event.origin` doesn't match the trusted OAuth origin, preventing token spoofing attacks from any cross-origin source</li>

<li>Introduced `OAUTH_ORIGIN` constant to consolidate the trusted origin value and refactored the popup URL to use this constant instead of a hardcoded string</li>

<li>Added `useAbTastyOAuth.spec.ts` test coverage validating three scenarios: accepting tokens from the trusted origin, rejecting tokens from untrusted origins, and rejecting lookalike origins that mimic the trusted domain</li>

</ul>
</details>

</div>