### PR TITLE
fix(abtasty): verify postMessage origin before accepting OAuth token[AIS-302]

### DIFF
--- a/apps/abtasty/src/constants/index.ts
+++ b/apps/abtasty/src/constants/index.ts
@@ -1,2 +1,6 @@
 export const INTEGRATION_API_URL = 'https://integration-api.abtasty.com';
 export const CONTENT_TYPE_ID = 'abTastyContainer';
+
+export const OAUTH_URL = 'https://integrations-oauth.abtasty.com/contentful/oauth';
+/** Only `postMessage` events from this origin may deliver an access token. */
+export const OAUTH_ORIGIN = 'https://integrations-oauth.abtasty.com';

--- a/apps/abtasty/src/hooks/useAbTastyOAuth.spec.ts
+++ b/apps/abtasty/src/hooks/useAbTastyOAuth.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAbTastyOAuth } from './useAbTastyOAuth';
+import { OAUTH_ORIGIN } from '@/constants';
+
+const postMessageToWindow = (data: unknown, origin: string) => {
+  window.dispatchEvent(new MessageEvent('message', { data, origin }));
+};
+
+const successMessage = { type: 'ABTASTY_OAUTH_SUCCESS', access_token: 'token-123' };
+
+describe('useAbTastyOAuth', () => {
+  let onToken: Mock<(token: string) => void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onToken = vi.fn<(token: string) => void>();
+  });
+
+  it('accepts a token posted from the AB Tasty OAuth origin', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessageToWindow(successMessage, OAUTH_ORIGIN);
+
+    expect(onToken).toHaveBeenCalledWith('token-123');
+  });
+
+  it('ignores a token posted from any other origin', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessageToWindow({ ...successMessage, access_token: 'attacker-token' }, 'https://evil.example.com');
+    postMessageToWindow({ ...successMessage, access_token: 'attacker-token' }, 'null');
+    postMessageToWindow({ ...successMessage, access_token: 'attacker-token' }, 'https://abtasty.com');
+    postMessageToWindow({ ...successMessage, access_token: 'attacker-token' }, `${OAUTH_ORIGIN}.evil.com`);
+
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages from the OAuth origin that do not carry a token', () => {
+    renderHook(() => useAbTastyOAuth(onToken));
+
+    postMessageToWindow({ type: 'ABTASTY_OAUTH_SUCCESS' }, OAUTH_ORIGIN);
+    postMessageToWindow({ type: 'ABTASTY_OAUTH_SUCCESS', access_token: '' }, OAUTH_ORIGIN);
+    postMessageToWindow({ type: 'ABTASTY_OAUTH_ERROR', access_token: 'token-123' }, OAUTH_ORIGIN);
+    postMessageToWindow('ABTASTY_OAUTH_SUCCESS', OAUTH_ORIGIN);
+    postMessageToWindow(null, OAUTH_ORIGIN);
+
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once unmounted', () => {
+    const { unmount } = renderHook(() => useAbTastyOAuth(onToken));
+
+    unmount();
+    postMessageToWindow(successMessage, OAUTH_ORIGIN);
+
+    expect(onToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/abtasty/src/hooks/useAbTastyOAuth.ts
+++ b/apps/abtasty/src/hooks/useAbTastyOAuth.ts
@@ -1,11 +1,30 @@
 import { useEffect } from 'react';
+import { OAUTH_ORIGIN, OAUTH_URL } from '@/constants';
+
+interface OAuthSuccessMessage {
+  type: 'ABTASTY_OAUTH_SUCCESS';
+  access_token: string;
+}
+
+function isOAuthSuccessMessage(data: unknown): data is OAuthSuccessMessage {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const { type, access_token } = data as Record<string, unknown>;
+  return type === 'ABTASTY_OAUTH_SUCCESS' && typeof access_token === 'string' && access_token.length > 0;
+}
 
 export function useAbTastyOAuth(onToken: (token: string) => void) {
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      const data = (event as MessageEvent<any>).data;
-      if (data?.type === 'ABTASTY_OAUTH_SUCCESS' && data.access_token) {
-        onToken(data.access_token);
+      // Only trust token when it comes from the AB Tasty OAuth origin.
+      if (event.origin !== OAUTH_ORIGIN) {
+        return;
+      }
+
+      if (isOAuthSuccessMessage(event.data)) {
+        onToken(event.data.access_token);
       }
     };
 
@@ -17,11 +36,10 @@ export function useAbTastyOAuth(onToken: (token: string) => void) {
     const width = 600;
     const height = 700;
     const name = 'abtasty_oauth';
-    const url = 'https://integrations-oauth.abtasty.com/contentful/oauth';
     const left = window.screenX + (window.outerWidth - width) / 2;
     const top = window.screenY + (window.outerHeight - height) / 2;
     const popup = window.open(
-      url,
+      OAUTH_URL,
       name,
       `width=${width},height=${height},top=${top},left=${left},resizable,scrollbars=yes`
     );


### PR DESCRIPTION
## Purpose

  Fixes AIS-302 (SAST p1, broken access control).

  -`useAbTastyOAuth` receives the AB Tasty access token over `window.postMessage` but never validated the sender, so a token could be supplied by something other than the OAuth popup. The token is persisted to `localStorage` and used for all subsequent AB Tasty API calls, so an unvalidated one puts the config screen on the wrong account.

  ## Approach

  - Ignore `message` events whose `event.origin` is not the AB Tasty OAuth origin, checked before the payload is read. Exact equality, so lookalike hosts don't pass.
  - Replaced the `as MessageEvent<any>` cast with a type guard requiring `access_token` to be a non-empty string.
  - Moved the popup URL and trusted origin into `constants/` as `OAUTH_URL` /`OAUTH_ORIGIN` so the origin we trust can't drift from the one we navigate to. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes AIS-302 (SAST P1, broken access control) by validating the origin of incoming postMessage events before accepting the AB Tasty OAuth access token. Previously, any page could inject a token via postMessage, allowing an attacker to hijack the OAuth flow and gain access to the victim's AB Tasty account configuration.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds strict origin validation to useAbTastyOAuth hook: returns early if event.origin !== OAUTH_ORIGIN ('https://integrations-oauth.abtasty.com'), preventing token injection from any other origin including lookalike domains.</li>

<li>Replaces unsafe `as MessageEvent<any>` cast with `isOAuthSuccessMessage()` type guard that validates data.shape.type === 'ABTASTY_OAUTH_SUCCESS' and access_token is a non-empty string.</li>

<li>Extracts OAuth URL and trusted origin into constants (OAUTH_URL / OAUTH_ORIGIN) in constants/index.ts to keep the trusted origin synchronized with the popup navigation target.</li>

<li>Adds comprehensive test coverage (useAbTastyOAuth.spec.ts) validating correct origin acceptance, lookalike domain rejection, malformed message handling, and cleanup on unmount.</li>

</ul>
</details>

</div>