### PR TITLE
docs: add architecture decision record for release-please deploy gating [INTEG-4701]

### DIFF
--- a/docs/ADRs/2023-12-19-gate-production-deploy-on-release-please.md
+++ b/docs/ADRs/2023-12-19-gate-production-deploy-on-release-please.md
@@ -1,0 +1,36 @@
+# Gate production deploys on release-please instead of a manual production branch
+
+## Status
+
+Accepted
+
+## Context
+
+Before December 2023, deploying an app to production required merging into a dedicated `production` branch from `main` on an ad hoc basis. This was prone to merge conflicts, and ran independently of `release-please` — adopted a month earlier as the source of truth for per-app versioning and changelogs — so versioning and deployment were two disconnected processes that had to be kept in sync by hand. Several now-stale branches on the remote (`production-merge-with-cloudinary`, `production-merge-bynder-fix`, `ceros-production-deploy`, `production-match-main`) are leftover evidence of that manual merge workflow.
+
+## Decision
+
+Retire the manual `production` branch and couple production deploys directly to `release-please`'s output. The `release-and-deploy.yml` GitHub Actions workflow:
+
+- Runs `release-please` in manifest mode on every push to `main`.
+- Deploys every changed app to **staging** on every push to `main`, regardless of release status.
+- Deploys to **production** only when `release-please` reports `releases_created: true` — i.e. only immediately after a release-please PR is merged.
+
+CircleCI's `apps-checks` job (build/lint/test on pull requests) was kept as-is; only the deploy step moved off CircleCI and off the branch-merge model.
+
+## Consequences
+
+### Positive
+
+- A single release-please merge event now drives both changelog/version publication and production deployment — no separate manual step to keep the two in sync.
+- Removes the merge-conflict-prone `production` branch workflow entirely.
+- Staging deploys run continuously on every `main` push, giving faster feedback than the old branch-gated flow.
+
+### Negative
+
+- CI is now split across two providers: GitHub Actions owns release/deploy, CircleCI still owns pull-request checks. The repo is not fully off CircleCI, despite `ARCHITECTURE.md` describing GitHub Actions as "the" CI system.
+- Several `production`-prefixed branches from the old workflow remain on the remote with no further purpose; cleanup was out of scope for this change.
+
+### Neutral
+
+- Every push to `main` now triggers a staging deploy of all changed apps, whether or not a release was created — a shift in deploy frequency, not scope.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| Date | Status | Title |
+|---|---|---|
+| [2023-12-19](./2023-12-19-gate-production-deploy-on-release-please.md) | Accepted | Gate production deploys on release-please instead of a manual production branch |


### PR DESCRIPTION
## Purpose

Add an ADR documenting why production deploys are gated on `release-please` output rather than manual merges to a dedicated `production` branch. This captures a CI/CD decision from December 2023 that was never recorded as a formal decision record.

## Approach

Adds `docs/ADRs/2023-12-19-gate-production-deploy-on-release-please.md` and updates the existing `docs/ADRs/README.md` index. The ADR records the problems with the old branch-merge workflow, the `release-and-deploy.yml` design (staging on every `main` push, production only when `releases_created: true`), and trade-offs (split CI across GitHub Actions and CircleCI).

## Testing steps

Documentation only — no runtime changes. Verify the ADR links and index table render correctly on GitHub.

## Breaking Changes

None.

## Dependencies and/or References

* [INTEG-4701](https://contentful.atlassian.net/browse/INTEG-4701) — governance rollout remediation for decision records
* Originating change: December 2023 — `release-and-deploy.yml` workflow adoption

## Deployment

No deployment impact.

> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit](https://github.com/contentful/agents-kit). To follow or use this workflow, see the [Agents Kit CLI skill docs](https://github.com/contentful/agents-kit/blob/main/apps/cli/README.md#consuming-skills).


[INTEG-4701]: https://contentful.atlassian.net/browse/INTEG-4701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ