### PR TITLE
fix(vwo-fme): handle missing control variation when linking default entry []

### DIFF
--- a/apps/vwo-fme/src/components/CreateContent.js
+++ b/apps/vwo-fme/src/components/CreateContent.js
@@ -60,7 +60,7 @@ function CreateContent(props) {
 
   const removeContent = useCallback(
     (vwoVariation) => {
-      if (vwoVariation.id === 1) {
+      if (vwoVariation?.id === CONTROL_VARIATION_ID) {
         props.sdk.notifier.error('Default variation content cannot be removed');
         return;
       }

--- a/apps/vwo-fme/src/components/CreateContent.js
+++ b/apps/vwo-fme/src/components/CreateContent.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { EntryCard, TextInput, Modal, List, MenuItem, ButtonGroup, Button, Flex } from '@contentful/f36-components';
 import { SearchIcon } from '@contentful/f36-icons';
 import { css } from 'emotion';
+import { CONTROL_VARIATION_ID, getVariationContentEntryId } from '../utils';
 
 const styles = {
   menuList: css({
@@ -40,7 +41,13 @@ function CreateContent(props) {
 
   const editContent = (vwoVariation) => {
     setSelectContentType(false);
-    props.sdk.navigator.openEntry(vwoVariation.variables[0].value, { slideIn: { waitForClose: true } }).then((updatedEntry) => {
+    const entryId = getVariationContentEntryId(vwoVariation, props.featureVariables);
+
+    if (!entryId) {
+      return;
+    }
+
+    props.sdk.navigator.openEntry(entryId, { slideIn: { waitForClose: true } }).then((updatedEntry) => {
       if (updatedEntry && props.onRefreshVariationEntries) {
         props.onRefreshVariationEntries();
       }
@@ -73,7 +80,7 @@ function CreateContent(props) {
         return;
       }
       setProcessing(true);
-      await props.onCreateVariationEntry(props.variation.vwoVariation, contentType);
+      await props.onCreateVariationEntry(props.variation?.vwoVariation, contentType);
       setProcessing(false);
       setSelectContentType(false);
     },
@@ -121,7 +128,7 @@ function CreateContent(props) {
           <Button variant="secondary" size="small" onClick={() => setSelectContentType(true)}>
             Create entry and link
           </Button>
-          <Button variant="secondary" size="small" onClick={() => props.linkExistingEntry(props.variation.vwoVariation)}>
+          <Button variant="secondary" size="small" onClick={() => props.linkExistingEntry(props.variation?.vwoVariation)}>
             Link an existing entry
           </Button>
         </ButtonGroup>
@@ -132,12 +139,15 @@ function CreateContent(props) {
           contentType={props.variation.variationContent.contentType}
           title={props.variation.variationContent.title}
           description={props.variation.variationContent.description}
-          onClick={() => editContent(props.variation.vwoVariation)}
+          onClick={() => editContent(props.variation?.vwoVariation)}
           actions={[
-            <MenuItem key="edit" onClick={() => editContent(props.variation.vwoVariation)}>
+            <MenuItem key="edit" onClick={() => editContent(props.variation?.vwoVariation)}>
               Edit
             </MenuItem>,
-            <MenuItem key="remove" onClick={() => removeContent(props.variation.vwoVariation)} isDisabled={props.variation.vwoVariation.id === 1}>
+            <MenuItem
+              key="remove"
+              onClick={() => removeContent(props.variation?.vwoVariation)}
+              isDisabled={props.variation?.vwoVariation?.id === CONTROL_VARIATION_ID}>
               Remove
             </MenuItem>,
           ]}

--- a/apps/vwo-fme/src/components/Variations.js
+++ b/apps/vwo-fme/src/components/Variations.js
@@ -1,6 +1,6 @@
 import { Button, Heading, List, Paragraph, Skeleton } from '@contentful/f36-components';
 import { css } from 'emotion';
-import { mapVwoVariationsAndContent } from '../utils';
+import { CONTROL_VARIATION_ID, getControlVariation, mapVwoVariationsAndContent } from '../utils';
 import React, { useCallback, useEffect, useState } from 'react';
 import VariationItem from './VariationItem';
 import tokens from '@contentful/f36-tokens';
@@ -42,9 +42,17 @@ function Variations(props) {
   const fetchMappedVariations = useCallback(async () => {
     try {
       setIsVariationsLoading(true);
-      const mappedVariations = await mapVwoVariationsAndContent(vwoVariations, props.contentTypes, props.sdk.locales.default, props.sdk.space.getEntries);
+      const mappedVariations = await mapVwoVariationsAndContent(
+        vwoVariations,
+        props.contentTypes,
+        props.sdk.locales.default,
+        props.sdk.space.getEntries,
+        props.featureFlag.variables
+      );
       setMappedVariations(mappedVariations);
-      const defaultVariation = mappedVariations.filter((variation) => variation.vwoVariation.id === 1)[0] || {};
+      const defaultVariation = mappedVariations.find((variation) => variation.vwoVariation?.id === CONTROL_VARIATION_ID) || {
+        vwoVariation: getControlVariation(vwoVariations),
+      };
       setDefaultVariation(defaultVariation);
       setIsDefaultVariationContentAdded(defaultVariation?.variationContent);
     } catch (error) {
@@ -52,7 +60,7 @@ function Variations(props) {
     } finally {
       setIsVariationsLoading(false);
     }
-  }, [vwoVariations, props.contentTypes, props.sdk.locales.default, props.sdk.space.getEntries]);
+  }, [vwoVariations, props.featureFlag.variables, props.contentTypes, props.sdk.locales.default, props.sdk.space.getEntries]);
 
   useEffect(() => {
     fetchMappedVariations();
@@ -77,6 +85,7 @@ function Variations(props) {
         <CreateContent
           sdk={props.sdk}
           variation={defaultVariation}
+          featureVariables={props.featureFlag.variables}
           contentTypes={props.contentTypes}
           onRefreshVariationEntries={fetchMappedVariations}
           linkExistingEntry={props.linkExistingEntry}
@@ -107,10 +116,10 @@ function Variations(props) {
           {!isVariationsLoading ? (
             <List style={{ width: '100%', listStyle: 'none', padding: '0px' }}>
               {mappedVariations
-                .filter((variation) => variation.vwoVariation.id !== 1)
+                .filter((variation) => variation.vwoVariation?.id !== CONTROL_VARIATION_ID)
                 .map((variation, index) => {
                   return (
-                    <List.Item key={variation.vwoVariation.id}>
+                    <List.Item key={variation.vwoVariation?.id ?? index}>
                       <VariationItem
                         index={mappedVariations.length - index - 1}
                         sdk={props.sdk}

--- a/apps/vwo-fme/src/locations/EntryEditor.jsx
+++ b/apps/vwo-fme/src/locations/EntryEditor.jsx
@@ -25,7 +25,7 @@ const initialState = (sdk) => ({
   currentStep: 1,
   contentTypes: [],
   meta: sdk.entry.fields.meta?.getValue() || {},
-  featureFlag: sdk.entry.fields.featureFlag.getValue() || {},
+  featureFlag: sdk.entry.fields.featureFlag?.getValue() || {},
 });
 
 const actionTypes = {

--- a/apps/vwo-fme/src/locations/EntryEditor.jsx
+++ b/apps/vwo-fme/src/locations/EntryEditor.jsx
@@ -224,6 +224,11 @@ const EntryEditor = (props) => {
   };
 
   const linkExistingEntry = async (vwoVariation) => {
+    if (!vwoVariation?.id) {
+      props.sdk.notifier.error('Default variation is not available. Please refresh and try again.');
+      return;
+    }
+
     const data = await props.sdk.dialogs.selectSingleEntry({
       locale: props.sdk.locales.default,
       contentTypes: state.contentTypes.map(contentType => contentType.sys.id).filter(contentType => contentType !== props.sdk.contentType.sys.id)
@@ -243,6 +248,11 @@ const EntryEditor = (props) => {
   }
 
   const onCreateVariationEntry = async(vwoVariation, contentType) => {
+    if (!vwoVariation?.id) {
+      props.sdk.notifier.error('Default variation is not available. Please refresh and try again.');
+      return;
+    }
+
     const data = await props.sdk.navigator.openNewEntry(contentType.sys.id,{
       slideIn: { waitForClose: true }
     }).then(async (updatedEntry) => {

--- a/apps/vwo-fme/src/utils.js
+++ b/apps/vwo-fme/src/utils.js
@@ -63,9 +63,54 @@ export const getRequiredEntryInformation = (entry, contentTypes, defaultLocale) 
   };
 };
 
-export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, defaultLocale, getEntries) => {
-  const _vwoVariations = Array.isArray(vwoVariations) ? vwoVariations : [vwoVariations];
-  const entryIds = [...new Set(_vwoVariations.map((vwoVariation) => vwoVariation?.variables[0]?.value).filter(Boolean))];
+export const CONTROL_VARIATION_ID = 1;
+
+export const getControlVariation = (vwoVariations = []) => {
+  const variations = Array.isArray(vwoVariations) ? vwoVariations : [vwoVariations];
+  const controlVariation = variations.find((variation) => variation?.id === CONTROL_VARIATION_ID);
+
+  if (controlVariation) {
+    return controlVariation;
+  }
+
+  return {
+    id: CONTROL_VARIATION_ID,
+    name: 'Control',
+    key: '1',
+    variables: [],
+  };
+};
+
+export const getDefaultVariationContentId = (variables) => {
+  if (!variables) {
+    return '';
+  }
+
+  if (Array.isArray(variables)) {
+    return variables[0]?.defaultValue || '';
+  }
+
+  return variables.defaultValue || '';
+};
+
+export const getVariationContentEntryId = (vwoVariation, featureVariables) => {
+  if (!vwoVariation) {
+    return '';
+  }
+
+  if (vwoVariation.id === CONTROL_VARIATION_ID) {
+    return vwoVariation?.variables?.[0]?.value || getDefaultVariationContentId(featureVariables);
+  }
+
+  return vwoVariation?.variables?.[0]?.value || '';
+};
+
+export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, defaultLocale, getEntries, featureVariables) => {
+  const variations = Array.isArray(vwoVariations) ? vwoVariations : [vwoVariations];
+  const controlVariation = getControlVariation(variations);
+  const nonControlVariations = variations.filter((variation) => variation?.id !== CONTROL_VARIATION_ID);
+  const allVariations = [controlVariation, ...nonControlVariations];
+  const entryIds = [...new Set(allVariations.map((vwoVariation) => getVariationContentEntryId(vwoVariation, featureVariables)).filter(Boolean))];
 
   let entryItems = [];
   if (entryIds.length > 0) {
@@ -74,20 +119,24 @@ export const mapVwoVariationsAndContent = async (vwoVariations, contentTypes, de
     });
     entryItems = entries.items;
   }
-  return _vwoVariations.map((vwoVariation) => {
-    if (vwoVariation.variables.length && vwoVariation.variables[0].value) {
-      let contentId = vwoVariation.variables[0].value;
-      let entry = entryItems.find((entry) => entry?.sys?.id === contentId || entry.id === contentId);
-      if (!entry) {
-        return { vwoVariation };
-      }
-      let entryInformation = getRequiredEntryInformation(entry, contentTypes, defaultLocale);
-      return {
-        vwoVariation,
-        variationContent: entryInformation,
-      };
+
+  return allVariations.map((vwoVariation) => {
+    const contentId = getVariationContentEntryId(vwoVariation, featureVariables);
+
+    if (!contentId) {
+      return { vwoVariation };
     }
-    return { vwoVariation };
+
+    const entry = entryItems.find((entry) => entry?.sys?.id === contentId || entry.id === contentId);
+    if (!entry) {
+      return { vwoVariation };
+    }
+
+    const entryInformation = getRequiredEntryInformation(entry, contentTypes, defaultLocale);
+    return {
+      vwoVariation,
+      variationContent: entryInformation,
+    };
   });
 };
 


### PR DESCRIPTION
## Purpose

When creating a feature flag in the Contentful `vwo-fme` entry editor, linking an existing Contentful entry as the **default (control) variation** crashes with:

`Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'id')`

The selected entry is not saved and the editor workflow is blocked at the first step (linking default content before other variations can be added).

## Approach

VWO treats the control variation differently from other variations:

- **Default variation content** is stored in `featureFlag.variables[0].defaultValue` (updated via `updateFeatureFlag`)
- **Other variations** use `variation.variables[0].value` (updated via `updateVariations`)
- The control variation (`id: 1`) is often **omitted** from `featureFlag.variations` in API responses

The write path already used `variables[0].defaultValue` for `id === 1`. The bug was in the **read/UI layer**: the app only looked for `id === 1` in `featureFlag.variations`, so `defaultVariation` became `{}` and `linkExistingEntry(undefined)` crashed after the entry picker returned.

Changes:

- **`utils.js`**: Add helpers to synthesize the control variation when missing, read default content from `variables`, and resolve entry IDs consistently
- **`Variations.js`**: Always provide a control variation object; pass `featureFlag.variables` into mapping
- **`CreateContent.js`**: Use shared helper for entry IDs; optional chaining on variation access
- **`EntryEditor.jsx`**: Guard `linkExistingEntry` / `onCreateVariationEntry` with a user-facing error if variation is still missing

## Testing steps

1. Open a VWO FME wrapper entry in the Contentful entry editor
2. Create a new feature flag (name + description)
3. On the **Default (control) variation** tile, click **Link an existing entry**
4. Select an existing Contentful entry and confirm
5. Verify: no console error; linked entry card appears on the default variation tile
6. Repeat with **Create entry and link** for the default variation
7. After default is linked, add another variation and link content — should still work
8. Reload the entry editor and confirm the default linked entry still displays
9. Run `npm run build` in `apps/vwo-fme` — passes locally

## Breaking Changes

None. Backwards-compatible UI/read-layer fix; no API contract or Contentful content model changes.

## Dependencies and/or References

- Affected app: `apps/vwo-fme`
- VWO API (via Contentful app action): `GET/PATCH https://app.vwo.com/api/v2/accounts/{accountId}/features/{featureId}`

## Deployment

Standard `vwo-fme` app deployment after merge and `release-please` release. No new env vars or manifest changes.