### PR TITLE
fix(ceros): resolve App Action via space/environment, not install org [AIS-501]

### DIFF
--- a/apps/ceros/src/ceros-action.ts
+++ b/apps/ceros/src/ceros-action.ts
@@ -23,13 +23,19 @@ export const CEROS_ACTION_ID = 'cerosApi'
 
 // Looks up the CerosApi App Action's id. Prefers the pinned id, falling back to a
 // name match so installs created before the id was pinned keep resolving.
+//
+// Scoped by space/environment rather than organizationId: the app definition can be
+// managed in a different org than the one the app is installed into, so
+// sdk.ids.organization (the install org) can't be used to look up its App Actions.
 export async function findCerosActionId(sdk: EditorAppSDK): Promise<string> {
-    const actions = await sdk.cma.appAction.getMany({
-        organizationId: sdk.ids.organization,
-        appDefinitionId: sdk.ids.app || '',
+    const appId = sdk.ids.app || ''
+    const actions = await sdk.cma.appAction.getManyForEnvironment({
+        spaceId: sdk.ids.space,
+        environmentId: sdk.ids.environment,
     })
-    const found =
-        actions.items.find((a) => a.sys.id === CEROS_ACTION_ID) ?? actions.items.find((a) => a.name === 'CerosApi')
+    const found = actions.items.find(
+        (a) => a.sys.appDefinition?.sys.id === appId && (a.sys.id === CEROS_ACTION_ID || a.name === 'CerosApi')
+    )
     if (!found) throw new Error(CEROS_ACTION_MISSING_ERROR)
     return found.sys.id
 }


### PR DESCRIPTION
## Purpose

`findCerosActionId` looked up the CerosApi App Action by the install org, which 404s whenever the app is installed into an org other than the one that manages its App Definition.

## Approach

- Switched `appAction.getMany({ organizationId, appDefinitionId })` to `appAction.getManyForEnvironment({ spaceId, environmentId })`, which resolves via space/environment instead of the app definition's owning org.
- Filter the returned collection by `sys.appDefinition.sys.id` to disambiguate from other apps' actions installed in the same environment, then match on the pinned action id or name as before.
- Mirrors the existing pattern in `apps/bynder/src/locations/Sidebar.tsx`, which never scopes App Action lookups by org for the same reason.
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This change fixes CerosApi App Action discovery for installations where the app is installed in an organization different from the one managing its App Definition. Lookup is now scoped to the active space and environment, while retaining compatibility with both pinned action IDs and legacy action names.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changes the App Action query in ceros-action.ts from organization/app-definition scoping to getManyForEnvironment with the active space and environment, preventing lookup failures caused by cross-organization installations.</li>

<li>Adds app-definition filtering through sys.appDefinition.sys.id before matching the pinned cerosApi ID or CerosApi name, preventing similarly named actions from other apps in the same environment from being selected.</li>

<li>Preserves the existing missing-action error behavior and downstream action invocation flow, so callers in EntryEditor.tsx and ExperiencePicker.tsx continue receiving the resolved action ID through findCerosActionId.</li>

</ul>
</details>

</div>